### PR TITLE
feat: company-wise restriction for Item, Customer and Supplier masters (backport #57124, #57258)

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -2,6 +2,12 @@
 // License: GNU General Public License v3. See license.txt
 
 frappe.ui.form.on("Supplier", {
+	restrict_to_companies(frm) {
+		if (!frm.doc.restrict_to_companies) {
+			frm.set_value("allowed_companies", []);
+		}
+	},
+
 	setup: function (frm) {
 		frm.set_query("allowed_companies", () => ({
 			query: "erpnext.stock.doctype.company_restriction.company_restriction.company_query",

--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -3,6 +3,9 @@
 
 frappe.ui.form.on("Supplier", {
 	setup: function (frm) {
+		frm.set_query("allowed_companies", () => ({
+			query: "erpnext.stock.doctype.company_restriction.company_restriction.company_query",
+		}));
 		frm.set_query("default_price_list", { buying: 1 });
 		if (frm.doc.__islocal == 1) {
 			frm.set_value("represents_company", "");

--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -55,6 +55,7 @@
   "tax_withholding_group",
   "settings_tab",
   "company_restrictions_section",
+  "restrict_to_companies",
   "allowed_companies",
   "invoice_settings_section",
   "is_transporter",
@@ -438,16 +439,22 @@
   {
    "fieldname": "company_restrictions_section",
    "fieldtype": "Section Break",
-   "label": "Company Restrictions",
-   "description": "If set, this Supplier is only available for transactions in the listed companies. Leave empty for no restriction.",
-   "depends_on": "eval:cint(frappe.sys_defaults.enable_company_wise_masters)"
+   "label": "Company Restrictions"
+  },
+  {
+   "default": "0",
+   "fieldname": "restrict_to_companies",
+   "fieldtype": "Check",
+   "label": "Restrict to Companies",
+   "description": "If checked, this Supplier is only available for transactions in the companies listed below."
   },
   {
    "fieldname": "allowed_companies",
    "fieldtype": "Table MultiSelect",
    "label": "Allowed Companies",
    "options": "Company Restriction",
-   "depends_on": "eval:cint(frappe.sys_defaults.enable_company_wise_masters)"
+   "depends_on": "eval:doc.restrict_to_companies",
+   "mandatory_depends_on": "eval:doc.restrict_to_companies"
   },
   {
    "fieldname": "contact_and_address_tab",
@@ -578,7 +585,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-07-14 21:00:00.000000",
+ "modified": "2026-07-14 23:00:00.000000",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",

--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -54,6 +54,8 @@
   "tax_withholding_category",
   "tax_withholding_group",
   "settings_tab",
+  "company_restrictions_section",
+  "allowed_companies",
   "invoice_settings_section",
   "is_transporter",
   "allow_purchase_invoice_creation_without_purchase_order",
@@ -434,6 +436,20 @@
    "label": "Settings"
   },
   {
+   "fieldname": "company_restrictions_section",
+   "fieldtype": "Section Break",
+   "label": "Company Restrictions",
+   "description": "If set, this Supplier is only available for transactions in the listed companies. Leave empty for no restriction.",
+   "depends_on": "eval:cint(frappe.sys_defaults.enable_company_wise_masters)"
+  },
+  {
+   "fieldname": "allowed_companies",
+   "fieldtype": "Table MultiSelect",
+   "label": "Allowed Companies",
+   "options": "Company Restriction",
+   "depends_on": "eval:cint(frappe.sys_defaults.enable_company_wise_masters)"
+  },
+  {
    "fieldname": "contact_and_address_tab",
    "fieldtype": "Tab Break",
    "label": "Address & Contact"
@@ -562,7 +578,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-06-27 16:12:33.190257",
+ "modified": "2026-07-14 21:00:00.000000",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -20,7 +20,6 @@ from erpnext.controllers.website_list_for_contact import (
 	add_role_for_portal_user,
 	link_portal_users_to_contacts,
 )
-from erpnext.stock.doctype.company_restriction.company_restriction import validate_allowed_companies
 from erpnext.utilities.transaction_base import TransactionBase
 
 
@@ -154,7 +153,6 @@ class Supplier(TransactionBase):
 		self.validate_internal_supplier()
 		self.add_role_for_user()
 		self.validate_currency_for_receivable_payable_and_advance_account()
-		validate_allowed_companies(self)
 
 	@frappe.whitelist()
 	def get_supplier_group_details(self):

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -73,6 +73,7 @@ class Supplier(TransactionBase):
 		primary_address: DF.TextEditor | None
 		release_date: DF.Date | None
 		represents_company: DF.Link | None
+		restrict_to_companies: DF.Check
 		supplier_details: DF.Text | None
 		supplier_group: DF.Link | None
 		supplier_name: DF.Data

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -20,6 +20,7 @@ from erpnext.controllers.website_list_for_contact import (
 	add_role_for_portal_user,
 	link_portal_users_to_contacts,
 )
+from erpnext.stock.doctype.company_restriction.company_restriction import validate_allowed_companies
 from erpnext.utilities.transaction_base import TransactionBase
 
 
@@ -39,12 +40,14 @@ class Supplier(TransactionBase):
 		from erpnext.buying.doctype.customer_number_at_supplier.customer_number_at_supplier import (
 			CustomerNumberAtSupplier,
 		)
+		from erpnext.stock.doctype.company_restriction.company_restriction import CompanyRestriction
 		from erpnext.utilities.doctype.portal_user.portal_user import PortalUser
 
 		accounts: DF.Table[PartyAccount]
 		alias: DF.Data | None
 		allow_purchase_invoice_creation_without_purchase_order: DF.Check
 		allow_purchase_invoice_creation_without_purchase_receipt: DF.Check
+		allowed_companies: DF.TableMultiSelect[CompanyRestriction]
 		companies: DF.Table[AllowedToTransactWith]
 		country: DF.Link | None
 		customer_numbers: DF.Table[CustomerNumberAtSupplier]
@@ -150,6 +153,7 @@ class Supplier(TransactionBase):
 		self.validate_internal_supplier()
 		self.add_role_for_user()
 		self.validate_currency_for_receivable_payable_and_advance_account()
+		validate_allowed_companies(self)
 
 	@frappe.whitelist()
 	def get_supplier_group_details(self):

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -16,6 +16,7 @@ from pypika import Order
 
 import erpnext
 from erpnext.accounts.utils import build_qb_match_conditions
+from erpnext.stock.doctype.company_restriction.company_restriction import get_blocked_masters
 from erpnext.stock.get_item_details import ItemDetailsCtx, _get_item_tax_template
 from erpnext.stock.utils import get_combine_datetime
 
@@ -176,12 +177,22 @@ def tax_account_query(doctype, txt, searchfield, start, page_len, filters):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=False):
+def item_query(
+	doctype: str,
+	txt: str,
+	searchfield: str,
+	start: int,
+	page_len: int,
+	filters: dict | str | None = None,
+	as_dict: bool = False,
+):
 	doctype = "Item"
 	conditions = []
 
 	if isinstance(filters, str):
 		filters = json.loads(filters)
+
+	company = filters.pop("company", None) if isinstance(filters, dict) else None
 
 	# Get searchfields from meta and use in Item Link field query
 	meta = frappe.get_meta(doctype, cached=True)
@@ -258,6 +269,14 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 		else:
 			filters.pop("customer", None)
 			filters.pop("supplier", None)
+
+	if company:
+		restricted = frappe.get_all("Item", filters={"restrict_to_companies": 1}, pluck="name")
+		blocked = get_blocked_masters("Item", restricted, company) if restricted else []
+		if blocked:
+			if (existing := filters.get("name")) and existing[0] == "not in":
+				blocked = sorted(set(blocked) | set(existing[1]))
+			filters["name"] = ["not in", blocked]
 
 	description_cond = ""
 	if frappe.db.estimate_count(doctype) < 50000:

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -308,6 +308,18 @@ sounds = [
 
 has_upload_permission = {"Employee": "erpnext.setup.doctype.employee.employee.has_upload_permission"}
 
+permission_query_conditions = {
+	"Item": "erpnext.stock.doctype.company_restriction.company_restriction.get_permission_query_conditions",
+	"Customer": "erpnext.stock.doctype.company_restriction.company_restriction.get_permission_query_conditions",
+	"Supplier": "erpnext.stock.doctype.company_restriction.company_restriction.get_permission_query_conditions",
+}
+
+has_permission = {
+	"Item": "erpnext.stock.doctype.company_restriction.company_restriction.has_permission",
+	"Customer": "erpnext.stock.doctype.company_restriction.company_restriction.has_permission",
+	"Supplier": "erpnext.stock.doctype.company_restriction.company_restriction.has_permission",
+}
+
 has_website_permission = {
 	"Sales Order": "erpnext.controllers.website_list_for_contact.has_website_permission",
 	"Quotation": "erpnext.controllers.website_list_for_contact.has_website_permission",

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -361,10 +361,14 @@ doc_events = {
 		"validate": [
 			"erpnext.support.doctype.service_level_agreement.service_level_agreement.apply",
 			"erpnext.setup.doctype.transaction_deletion_record.transaction_deletion_record.check_for_running_deletion_job",
+			"erpnext.stock.doctype.company_restriction.company_restriction.validate_transaction_company",
 		],
 	},
 	tuple(period_closing_doctypes): {
 		"validate": "erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save",
+	},
+	("Item", "Customer", "Supplier"): {
+		"validate": "erpnext.stock.doctype.company_restriction.company_restriction.validate_allowed_companies",
 	},
 	"Stock Entry": {
 		"on_submit": "erpnext.stock.doctype.material_request.material_request.update_completed_and_requested_qty",

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -91,7 +91,7 @@ erpnext.buying = {
 
 				this.frm.set_query("item_code", "items", function () {
 					if (me.frm.doc.is_subcontracted) {
-						var filters = { supplier: me.frm.doc.supplier };
+						var filters = { supplier: me.frm.doc.supplier, company: me.frm.doc.company };
 						if (me.frm.doc.is_old_subcontracting_flow) {
 							filters["is_sub_contracted_item"] = 1;
 						} else {
@@ -105,7 +105,12 @@ erpnext.buying = {
 					} else {
 						return {
 							query: "erpnext.controllers.queries.item_query",
-							filters: { supplier: me.frm.doc.supplier, is_purchase_item: 1, has_variants: 0 },
+							filters: {
+								supplier: me.frm.doc.supplier,
+								is_purchase_item: 1,
+								has_variants: 0,
+								company: me.frm.doc.company,
+							},
 						};
 					}
 				});

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -81,7 +81,12 @@ erpnext.sales_common = {
 						}
 						return {
 							query: "erpnext.controllers.queries.item_query",
-							filters: { is_sales_item: 1, customer: customer, has_variants: 0 },
+							filters: {
+								is_sales_item: 1,
+								customer: customer,
+								has_variants: 0,
+								company: me.frm.doc.company,
+							},
 						};
 					});
 				}

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -2,6 +2,12 @@
 // License: GNU General Public License v3. See license.txt
 
 frappe.ui.form.on("Customer", {
+	restrict_to_companies(frm) {
+		if (!frm.doc.restrict_to_companies) {
+			frm.set_value("allowed_companies", []);
+		}
+	},
+
 	setup: function (frm) {
 		frm.set_query("allowed_companies", () => ({
 			query: "erpnext.stock.doctype.company_restriction.company_restriction.company_query",

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -3,6 +3,9 @@
 
 frappe.ui.form.on("Customer", {
 	setup: function (frm) {
+		frm.set_query("allowed_companies", () => ({
+			query: "erpnext.stock.doctype.company_restriction.company_restriction.company_query",
+		}));
 		frm.custom_make_buttons = {
 			Opportunity: "Opportunity",
 			Quotation: "Quotation",

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -4,7 +4,7 @@
  "allow_import": 1,
  "allow_rename": 1,
  "autoname": "naming_series:",
- "creation": "2013-06-11 14:26:44",
+ "creation": "2026-07-14 12:46:50.256889",
  "description": "Buyer of Goods and Services.",
  "doctype": "DocType",
  "document_type": "Setup",
@@ -65,6 +65,9 @@
   "tax_withholding_group",
   "tax_withholding_category",
   "settings_tab",
+  "company_restrictions_section",
+  "allowed_companies",
+  "section_break_ario",
   "so_required",
   "dn_required",
   "column_break_53",
@@ -521,6 +524,20 @@
    "label": "Settings"
   },
   {
+   "description": "If set, this Customer is only available for transactions in the listed companies. Leave empty for no restriction.",
+   "fieldname": "company_restrictions_section",
+   "fieldtype": "Section Break",
+   "label": "Company Restrictions",
+   "depends_on": "eval:cint(frappe.sys_defaults.enable_company_wise_masters)"
+  },
+  {
+   "fieldname": "allowed_companies",
+   "fieldtype": "Table MultiSelect",
+   "label": "Allowed Companies",
+   "options": "Company Restriction",
+   "depends_on": "eval:cint(frappe.sys_defaults.enable_company_wise_masters)"
+  },
+  {
    "collapsible": 1,
    "collapsible_depends_on": "default_sales_partner",
    "fieldname": "sales_team_tab",
@@ -683,6 +700,10 @@
   {
    "fieldname": "credit_limit_column",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_ario",
+   "fieldtype": "Section Break"
   }
  ],
  "icon": "fa fa-user",
@@ -696,7 +717,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-06-27 16:12:10.457900",
+ "modified": "2026-07-14 21:00:00.000000",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -66,6 +66,7 @@
   "tax_withholding_category",
   "settings_tab",
   "company_restrictions_section",
+  "restrict_to_companies",
   "allowed_companies",
   "section_break_ario",
   "so_required",
@@ -524,18 +525,24 @@
    "label": "Settings"
   },
   {
-   "description": "If set, this Customer is only available for transactions in the listed companies. Leave empty for no restriction.",
    "fieldname": "company_restrictions_section",
    "fieldtype": "Section Break",
-   "label": "Company Restrictions",
-   "depends_on": "eval:cint(frappe.sys_defaults.enable_company_wise_masters)"
+   "label": "Company Restrictions"
+  },
+  {
+   "default": "0",
+   "fieldname": "restrict_to_companies",
+   "fieldtype": "Check",
+   "label": "Restrict to Companies",
+   "description": "If checked, this Customer is only available for transactions in the companies listed below."
   },
   {
    "fieldname": "allowed_companies",
    "fieldtype": "Table MultiSelect",
    "label": "Allowed Companies",
    "options": "Company Restriction",
-   "depends_on": "eval:cint(frappe.sys_defaults.enable_company_wise_masters)"
+   "depends_on": "eval:doc.restrict_to_companies",
+   "mandatory_depends_on": "eval:doc.restrict_to_companies"
   },
   {
    "collapsible": 1,
@@ -717,7 +724,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-07-14 21:00:00.000000",
+ "modified": "2026-07-14 23:00:00.000000",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -28,7 +28,6 @@ from erpnext.controllers.website_list_for_contact import (
 	add_role_for_portal_user,
 	link_portal_users_to_contacts,
 )
-from erpnext.stock.doctype.company_restriction.company_restriction import validate_allowed_companies
 from erpnext.utilities.transaction_base import TransactionBase
 
 
@@ -191,7 +190,6 @@ class Customer(TransactionBase):
 		self.validate_internal_customer()
 		self.add_role_for_user()
 		self.validate_currency_for_receivable_payable_and_advance_account()
-		validate_allowed_companies(self)
 
 		# set loyalty program tier
 		if not self.is_new() and (customer := self.get_doc_before_save()):

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -94,6 +94,7 @@ class Customer(TransactionBase):
 		primary_address: DF.TextEditor | None
 		prospect_name: DF.Link | None
 		represents_company: DF.Link | None
+		restrict_to_companies: DF.Check
 		sales_team: DF.Table[SalesTeam]
 		so_required: DF.Check
 		supplier_numbers: DF.Table[SupplierNumberAtCustomer]

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -28,6 +28,7 @@ from erpnext.controllers.website_list_for_contact import (
 	add_role_for_portal_user,
 	link_portal_users_to_contacts,
 )
+from erpnext.stock.doctype.company_restriction.company_restriction import validate_allowed_companies
 from erpnext.utilities.transaction_base import TransactionBase
 
 
@@ -49,11 +50,13 @@ class Customer(TransactionBase):
 		from erpnext.selling.doctype.supplier_number_at_customer.supplier_number_at_customer import (
 			SupplierNumberAtCustomer,
 		)
+		from erpnext.stock.doctype.company_restriction.company_restriction import CompanyRestriction
 		from erpnext.utilities.doctype.portal_user.portal_user import PortalUser
 
 		account_manager: DF.Link | None
 		accounts: DF.Table[PartyAccount]
 		alias: DF.Data | None
+		allowed_companies: DF.TableMultiSelect[CompanyRestriction]
 		companies: DF.Table[AllowedToTransactWith]
 		credit_limits: DF.Table[CustomerCreditLimit]
 		customer_details: DF.Text | None
@@ -187,6 +190,7 @@ class Customer(TransactionBase):
 		self.validate_internal_customer()
 		self.add_role_for_user()
 		self.validate_currency_for_receivable_payable_and_advance_account()
+		validate_allowed_companies(self)
 
 		# set loyalty program tier
 		if not self.is_new() and (customer := self.get_doc_before_save()):

--- a/erpnext/setup/doctype/global_defaults/global_defaults.json
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.json
@@ -5,16 +5,20 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "defaults_section",
   "default_company",
   "country",
-  "default_distance_unit",
   "column_break_8",
   "default_currency",
+  "default_distance_unit",
+  "demo_company",
+  "general_settings_section",
   "hide_currency_symbol",
   "disable_rounded_total",
   "disable_in_words",
+  "column_break_hnew",
   "use_posting_datetime_for_naming_documents",
-  "demo_company"
+  "enable_company_wise_masters"
  ],
  "fields": [
   {
@@ -27,7 +31,7 @@
   {
    "fieldname": "country",
    "fieldtype": "Link",
-   "label": "Country",
+   "label": "Default Country",
    "options": "Country"
   },
   {
@@ -88,6 +92,27 @@
    "fieldname": "use_posting_datetime_for_naming_documents",
    "fieldtype": "Check",
    "label": "Use Posting Datetime for Naming Documents"
+  },
+  {
+   "default": "0",
+   "description": "When enabled, Supplier, Customer, and Item records can be restricted to specific companies via their <b>Allowed Companies</b> table. Transactions will only show masters configured for the selected company.",
+   "fieldname": "enable_company_wise_masters",
+   "fieldtype": "Check",
+   "label": "Enable Company-wise Master Filtering"
+  },
+  {
+   "fieldname": "defaults_section",
+   "fieldtype": "Section Break",
+   "label": "Defaults"
+  },
+  {
+   "fieldname": "general_settings_section",
+   "fieldtype": "Section Break",
+   "label": "General Settings"
+  },
+  {
+   "fieldname": "column_break_hnew",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
@@ -97,7 +122,7 @@
  "in_create": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-16 13:28:20.155574",
+ "modified": "2026-07-14 15:18:25.829886",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Global Defaults",

--- a/erpnext/setup/doctype/global_defaults/global_defaults.json
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.json
@@ -17,8 +17,7 @@
   "disable_rounded_total",
   "disable_in_words",
   "column_break_hnew",
-  "use_posting_datetime_for_naming_documents",
-  "enable_company_wise_masters"
+  "use_posting_datetime_for_naming_documents"
  ],
  "fields": [
   {
@@ -94,13 +93,6 @@
    "label": "Use Posting Datetime for Naming Documents"
   },
   {
-   "default": "0",
-   "description": "When enabled, Supplier, Customer, and Item records can be restricted to specific companies via their <b>Allowed Companies</b> table. Transactions will only show masters configured for the selected company.",
-   "fieldname": "enable_company_wise_masters",
-   "fieldtype": "Check",
-   "label": "Enable Company-wise Master Filtering"
-  },
-  {
    "fieldname": "defaults_section",
    "fieldtype": "Section Break",
    "label": "Defaults"
@@ -122,7 +114,7 @@
  "in_create": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-07-14 15:18:25.829886",
+ "modified": "2026-07-14 23:00:00.000000",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Global Defaults",

--- a/erpnext/setup/doctype/global_defaults/global_defaults.py
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.py
@@ -17,7 +17,6 @@ keydict = {
 	"account_url": "account_url",
 	"disable_rounded_total": "disable_rounded_total",
 	"disable_in_words": "disable_in_words",
-	"enable_company_wise_masters": "enable_company_wise_masters",
 }
 
 from frappe.model.document import Document
@@ -39,7 +38,6 @@ class GlobalDefaults(Document):
 		demo_company: DF.Link | None
 		disable_in_words: DF.Check
 		disable_rounded_total: DF.Check
-		enable_company_wise_masters: DF.Check
 		hide_currency_symbol: DF.Literal["", "No", "Yes"]
 		use_posting_datetime_for_naming_documents: DF.Check
 	# end: auto-generated types

--- a/erpnext/setup/doctype/global_defaults/global_defaults.py
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.py
@@ -17,6 +17,7 @@ keydict = {
 	"account_url": "account_url",
 	"disable_rounded_total": "disable_rounded_total",
 	"disable_in_words": "disable_in_words",
+	"enable_company_wise_masters": "enable_company_wise_masters",
 }
 
 from frappe.model.document import Document
@@ -38,6 +39,7 @@ class GlobalDefaults(Document):
 		demo_company: DF.Link | None
 		disable_in_words: DF.Check
 		disable_rounded_total: DF.Check
+		enable_company_wise_masters: DF.Check
 		hide_currency_symbol: DF.Literal["", "No", "Yes"]
 		use_posting_datetime_for_naming_documents: DF.Check
 	# end: auto-generated types

--- a/erpnext/stock/doctype/company_restriction/company_restriction.json
+++ b/erpnext/stock/doctype/company_restriction/company_restriction.json
@@ -1,0 +1,39 @@
+{
+ "actions": [],
+ "allow_bulk_edit": 1,
+ "allow_rename": 1,
+ "creation": "2026-07-13 21:39:49.805859",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "company"
+ ],
+ "fields": [
+  {
+   "allow_on_submit": 1,
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "in_list_view": 1,
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-07-14 00:15:00.000000",
+ "modified_by": "Administrator",
+ "module": "Stock",
+ "name": "Company Restriction",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext/stock/doctype/company_restriction/company_restriction.py
+++ b/erpnext/stock/doctype/company_restriction/company_restriction.py
@@ -26,9 +26,6 @@ class CompanyRestriction(Document):
 def get_allowed_companies(user, doctype):
 	from frappe.permissions import get_allowed_docs_for_doctype, get_user_permissions
 
-	if not frappe.get_single_value("Global Defaults", "enable_company_wise_masters"):
-		return None
-
 	user_permissions = get_user_permissions(user or frappe.session.user)
 	if "Company" not in user_permissions:
 		return None
@@ -45,31 +42,39 @@ def get_permission_query_conditions(user, doctype=None):
 
 	parent = frappe.qb.DocType(doctype)
 	restriction = frappe.qb.DocType("Company Restriction")
-	restriction_rows = (
+	allowed_rows = (
 		frappe.qb.from_(restriction)
 		.select(restriction.name)
 		.where(
 			(restriction.parenttype == doctype)
 			& (restriction.parentfield == "allowed_companies")
 			& (restriction.parent == parent.name)
+			& (restriction.company.isin(allowed_companies))
 		)
 	)
-	allowed_rows = restriction_rows.where(restriction.company.isin(allowed_companies))
-	return Bracket(ExistsCriterion(allowed_rows) | ExistsCriterion(restriction_rows).negate())
+	return Bracket((parent.restrict_to_companies == 0) | ExistsCriterion(allowed_rows))
 
 
 def has_permission(doc, ptype=None, user=None):
+	if not doc.get("restrict_to_companies"):
+		return True
+
 	allowed_companies = get_allowed_companies(user, doc.doctype)
 	if not allowed_companies:
 		return True
 
-	companies = [row.company for row in doc.get("allowed_companies") or []]
-	if not companies:
-		return True
-	return any(company in allowed_companies for company in companies)
+	return any(row.company in allowed_companies for row in doc.get("allowed_companies") or [])
 
 
 def validate_allowed_companies(doc):
+	if not doc.get("restrict_to_companies"):
+		doc.set("allowed_companies", [])
+	elif not doc.get("allowed_companies") and not doc.flags.ignore_mandatory:
+		frappe.throw(
+			_("Allowed Companies is required when Restrict to Companies is checked"),
+			frappe.MandatoryError,
+		)
+
 	if doc.flags.ignore_permissions:
 		return
 

--- a/erpnext/stock/doctype/company_restriction/company_restriction.py
+++ b/erpnext/stock/doctype/company_restriction/company_restriction.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from pypika.terms import Bracket, ExistsCriterion
+
+
+class CompanyRestriction(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		company: DF.Link
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
+
+def get_allowed_companies(user, doctype):
+	from frappe.permissions import get_allowed_docs_for_doctype, get_user_permissions
+
+	if not frappe.get_single_value("Global Defaults", "enable_company_wise_masters"):
+		return None
+
+	user_permissions = get_user_permissions(user or frappe.session.user)
+	if "Company" not in user_permissions:
+		return None
+	return get_allowed_docs_for_doctype(user_permissions["Company"], doctype) or None
+
+
+def get_permission_query_conditions(user, doctype=None):
+	if not doctype:
+		return None
+
+	allowed_companies = get_allowed_companies(user, doctype)
+	if not allowed_companies:
+		return None
+
+	parent = frappe.qb.DocType(doctype)
+	restriction = frappe.qb.DocType("Company Restriction")
+	restriction_rows = (
+		frappe.qb.from_(restriction)
+		.select(restriction.name)
+		.where(
+			(restriction.parenttype == doctype)
+			& (restriction.parentfield == "allowed_companies")
+			& (restriction.parent == parent.name)
+		)
+	)
+	allowed_rows = restriction_rows.where(restriction.company.isin(allowed_companies))
+	return Bracket(ExistsCriterion(allowed_rows) | ExistsCriterion(restriction_rows).negate())
+
+
+def has_permission(doc, ptype=None, user=None):
+	allowed_companies = get_allowed_companies(user, doc.doctype)
+	if not allowed_companies:
+		return True
+
+	companies = [row.company for row in doc.get("allowed_companies") or []]
+	if not companies:
+		return True
+	return any(company in allowed_companies for company in companies)
+
+
+def validate_allowed_companies(doc):
+	if doc.flags.ignore_permissions:
+		return
+
+	allowed_companies = get_allowed_companies(frappe.session.user, doc.doctype)
+	if not allowed_companies:
+		return
+
+	previous_companies = set()
+	if previous_doc := doc.get_doc_before_save():
+		previous_companies = {row.company for row in previous_doc.get("allowed_companies") or []}
+
+	current_companies = {row.company for row in doc.get("allowed_companies") or []}
+	for company in current_companies.symmetric_difference(previous_companies):
+		if company not in allowed_companies:
+			frappe.throw(
+				_("You are not permitted to add or remove Company {0} in Allowed Companies").format(company),
+				frappe.PermissionError,
+			)
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def company_query(
+	doctype: str,
+	txt: str,
+	searchfield: str,
+	start: int,
+	page_len: int,
+	filters: dict | str | None = None,
+):
+	filters = frappe.parse_json(filters) if filters else {}
+	if isinstance(filters, list):
+		filters.append(["Company", "name", "like", f"%{txt}%"])
+	else:
+		filters["name"] = ("like", f"%{txt}%")
+
+	return frappe.get_list(
+		"Company",
+		filters=filters,
+		limit_start=start,
+		limit_page_length=page_len,
+		order_by="name",
+		as_list=True,
+	)

--- a/erpnext/stock/doctype/company_restriction/company_restriction.py
+++ b/erpnext/stock/doctype/company_restriction/company_restriction.py
@@ -1,10 +1,38 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+from collections import defaultdict
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import comma_and
 from pypika.terms import Bracket, ExistsCriterion
+
+RESTRICTABLE_MASTER_DOCTYPES = ("Item", "Customer", "Supplier")
+
+COMPANY_RESTRICTION_EXEMPT_DOCTYPES = frozenset(
+	{
+		"Asset",
+		"Bank Transaction",
+		"Exchange Rate Revaluation",
+		"Landed Cost Voucher",
+		"POS Closing Entry",
+		"POS Invoice Merge Log",
+		"Payment Reconciliation",
+		"Process Payment Reconciliation",
+		"Repost Accounting Ledger",
+		"Repost Item Valuation",
+		"Repost Payment Ledger",
+		"Serial No",
+		"Serial and Batch Bundle",
+		"Unreconcile Payment",
+	}
+)
+
+
+class CompanyRestrictionError(frappe.ValidationError):
+	pass
 
 
 class CompanyRestriction(Document):
@@ -40,6 +68,10 @@ def get_permission_query_conditions(user, doctype=None):
 	if not allowed_companies:
 		return None
 
+	return get_restriction_criterion(doctype, allowed_companies)
+
+
+def get_restriction_criterion(doctype, companies):
 	parent = frappe.qb.DocType(doctype)
 	restriction = frappe.qb.DocType("Company Restriction")
 	allowed_rows = (
@@ -49,7 +81,7 @@ def get_permission_query_conditions(user, doctype=None):
 			(restriction.parenttype == doctype)
 			& (restriction.parentfield == "allowed_companies")
 			& (restriction.parent == parent.name)
-			& (restriction.company.isin(allowed_companies))
+			& (restriction.company.isin(companies))
 		)
 	)
 	return Bracket((parent.restrict_to_companies == 0) | ExistsCriterion(allowed_rows))
@@ -66,7 +98,7 @@ def has_permission(doc, ptype=None, user=None):
 	return any(row.company in allowed_companies for row in doc.get("allowed_companies") or [])
 
 
-def validate_allowed_companies(doc):
+def validate_allowed_companies(doc, method=None):
 	if not doc.get("restrict_to_companies"):
 		doc.set("allowed_companies", [])
 	elif not doc.get("allowed_companies") and not doc.flags.ignore_mandatory:
@@ -93,6 +125,75 @@ def validate_allowed_companies(doc):
 				_("You are not permitted to add or remove Company {0} in Allowed Companies").format(company),
 				frappe.PermissionError,
 			)
+
+
+def validate_transaction_company(doc, method=None):
+	if doc.doctype in COMPANY_RESTRICTION_EXEMPT_DOCTYPES or doc.meta.in_create:
+		return
+
+	company_field = doc.meta.get_field("company")
+	if not company_field or company_field.fieldtype != "Link" or company_field.options != "Company":
+		return
+
+	company = doc.get("company")
+	if not company:
+		return
+
+	for doctype, names in get_master_references(doc).items():
+		if blocked := get_blocked_masters(doctype, names, company):
+			frappe.throw(
+				_("{0} {1} cannot be used with Company {2} because of Company Restrictions").format(
+					_(doctype),
+					comma_and([frappe.bold(name) for name in blocked], add_quotes=False),
+					frappe.bold(company),
+				),
+				CompanyRestrictionError,
+				title=_("Restricted to Other Companies"),
+			)
+
+
+def get_master_references(doc):
+	references = defaultdict(set)
+	collect_master_references(doc, references)
+	for table_field in doc.meta.get_table_fields():
+		for row in doc.get(table_field.fieldname) or []:
+			collect_master_references(row, references)
+
+	return references
+
+
+def collect_master_references(row, references):
+	meta = frappe.get_meta(row.doctype)
+	for field in meta.get_link_fields():
+		if field.options in RESTRICTABLE_MASTER_DOCTYPES and (value := row.get(field.fieldname)):
+			references[field.options].add(value)
+
+	for field in meta.get_dynamic_link_fields():
+		doctype = row.get(field.options)
+		if doctype in RESTRICTABLE_MASTER_DOCTYPES and (value := row.get(field.fieldname)):
+			references[doctype].add(value)
+
+
+def get_blocked_masters(doctype, names, company):
+	restricted = frappe.get_all(
+		doctype,
+		filters={"name": ("in", sorted(names)), "restrict_to_companies": 1},
+		pluck="name",
+	)
+	if not restricted:
+		return []
+
+	allowed = frappe.get_all(
+		"Company Restriction",
+		filters={
+			"parenttype": doctype,
+			"parentfield": "allowed_companies",
+			"parent": ("in", restricted),
+			"company": company,
+		},
+		pluck="parent",
+	)
+	return sorted(set(restricted) - set(allowed))
 
 
 @frappe.whitelist()

--- a/erpnext/stock/doctype/company_restriction/test_company_restriction.py
+++ b/erpnext/stock/doctype/company_restriction/test_company_restriction.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+
+from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+from erpnext.selling.doctype.customer.test_customer import make_customer
+from erpnext.selling.doctype.quotation.test_quotation import make_quotation
+from erpnext.stock.doctype.company_restriction.company_restriction import CompanyRestrictionError
+from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.stock.doctype.material_request.test_material_request import make_material_request
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestCompanyRestriction(ERPNextTestSuite):
+	def restrict_to_companies(self, doctype, name, companies):
+		doc = frappe.get_doc(doctype, name)
+		doc.restrict_to_companies = 1
+		doc.set("allowed_companies", [])
+		for company in companies:
+			doc.append("allowed_companies", {"company": company})
+		doc.save()
+
+	def test_restricted_item_blocks_transaction_in_other_company(self):
+		item = make_item()
+		self.restrict_to_companies("Item", item.name, ["_Test Company 1"])
+
+		self.assertRaises(CompanyRestrictionError, make_material_request, item_code=item.name)
+
+		self.restrict_to_companies("Item", item.name, ["_Test Company 1", "_Test Company"])
+		make_material_request(item_code=item.name)
+
+	def test_restricted_customer_blocks_transaction_in_other_company(self):
+		customer = make_customer("_Test Company Restricted Customer")
+		self.restrict_to_companies("Customer", customer, ["_Test Company 1"])
+
+		self.assertRaises(CompanyRestrictionError, make_quotation, party_name=customer, do_not_submit=1)
+
+		self.restrict_to_companies("Customer", customer, ["_Test Company"])
+		make_quotation(party_name=customer, do_not_submit=1)
+
+	def test_restricted_supplier_blocks_transaction_in_other_company(self):
+		supplier = create_supplier(supplier_name="_Test Company Restricted Supplier")
+		self.restrict_to_companies("Supplier", supplier.name, ["_Test Company 1"])
+
+		self.assertRaises(
+			CompanyRestrictionError, create_purchase_order, supplier=supplier.name, do_not_submit=1
+		)
+
+		self.restrict_to_companies("Supplier", supplier.name, ["_Test Company"])
+		create_purchase_order(supplier=supplier.name, do_not_submit=1)
+
+	def test_unrestricted_item_is_not_blocked(self):
+		item = make_item()
+		make_material_request(item_code=item.name)
+
+	def test_allowed_companies_is_mandatory_when_restricted(self):
+		item = make_item()
+		item.restrict_to_companies = 1
+		self.assertRaises(frappe.MandatoryError, item.save)
+
+	def test_exempt_doctypes_exist(self):
+		from erpnext.stock.doctype.company_restriction.company_restriction import (
+			COMPANY_RESTRICTION_EXEMPT_DOCTYPES,
+		)
+
+		for doctype in COMPANY_RESTRICTION_EXEMPT_DOCTYPES:
+			self.assertTrue(frappe.db.exists("DocType", doctype), f"{doctype} is not a DocType")
+
+	def test_cancel_works_after_restriction_change(self):
+		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+		item = make_item()
+		stock_entry = make_stock_entry(
+			item_code=item.name, qty=5, to_warehouse="_Test Warehouse - _TC", rate=100
+		)
+
+		self.restrict_to_companies("Item", item.name, ["_Test Company 1"])
+		stock_entry.reload()
+		stock_entry.cancel()

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -37,6 +37,9 @@ frappe.ui.form.on("Item", {
 	},
 
 	setup: function (frm) {
+		frm.set_query("allowed_companies", () => ({
+			query: "erpnext.stock.doctype.company_restriction.company_restriction.company_query",
+		}));
 		frm.add_fetch("attribute", "numeric_values", "numeric_values");
 		frm.add_fetch("attribute", "from_range", "from_range");
 		frm.add_fetch("attribute", "to_range", "to_range");

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -36,6 +36,12 @@ frappe.ui.form.on("Item", {
 		}
 	},
 
+	restrict_to_companies(frm) {
+		if (!frm.doc.restrict_to_companies) {
+			frm.set_value("allowed_companies", []);
+		}
+	},
+
 	setup: function (frm) {
 		frm.set_query("allowed_companies", () => ({
 			query: "erpnext.stock.doctype.company_restriction.company_restriction.company_query",

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -3,7 +3,7 @@
  "allow_import": 1,
  "allow_rename": 1,
  "autoname": "field:item_code",
- "creation": "2026-02-02 14:41:23.105228",
+ "creation": "2026-07-13 23:00:47.512490",
  "description": "A Product or a Service that is bought, sold or kept in stock.",
  "doctype": "DocType",
  "document_type": "Setup",
@@ -40,6 +40,8 @@
   "over_delivery_receipt_allowance",
   "column_break_wugd",
   "over_billing_allowance",
+  "company_restrictions_section",
+  "allowed_companies",
   "section_break_11",
   "brand",
   "description",
@@ -240,7 +242,6 @@
    "description": "ERPNext will make a stock ledger entry for each transaction of this item. Keep unchecked for non-stock or service items.",
    "fieldname": "is_stock_item",
    "fieldtype": "Check",
-   "in_list_view": 0,
    "label": "Maintain Stock",
    "oldfieldname": "is_stock_item",
    "oldfieldtype": "Select",
@@ -283,9 +284,9 @@
    "description": "Enable if this item is a company asset like machinery or furniture.",
    "fieldname": "is_fixed_asset",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Is Fixed Asset",
-   "read_only_depends_on": "eval:doc.is_stock_item",
-   "in_list_view": 1
+   "read_only_depends_on": "eval:doc.is_stock_item"
   },
   {
    "allow_in_quick_entry": 1,
@@ -598,7 +599,7 @@
    "oldfieldtype": "Currency"
   },
   {
-   "description": "Minimum stock level to maintain as a buffer. Used to calculate recommended reorder level: Reorder Level = Safety Stock + (Average Daily Consumption × Lead Time).",
+   "description": "Minimum stock level to maintain as a buffer. Used to calculate recommended reorder level: Reorder Level = Safety Stock + (Average Daily Consumption \u00d7 Lead Time).",
    "fieldname": "safety_stock",
    "fieldtype": "Float",
    "label": "Safety Stock",
@@ -701,9 +702,9 @@
    "description": "Allow this item to be used in sales transactions.",
    "fieldname": "is_sales_item",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Allow Sales",
-   "show_description_on_click": 1,
-   "in_list_view": 1
+   "show_description_on_click": 1
   },
   {
    "fieldname": "column_break3",
@@ -1086,6 +1087,20 @@
    "fieldname": "item_prices_column",
    "fieldtype": "Column Break",
    "label": "Item Prices"
+  },
+  {
+   "fieldname": "company_restrictions_section",
+   "fieldtype": "Section Break",
+   "label": "Company Restrictions",
+   "description": "If set, this Item is only available for transactions in the listed companies. Leave empty for no restriction.",
+   "depends_on": "eval:cint(frappe.sys_defaults.enable_company_wise_masters)"
+  },
+  {
+   "fieldname": "allowed_companies",
+   "fieldtype": "Table MultiSelect",
+   "label": "Allowed Companies",
+   "options": "Company Restriction",
+   "depends_on": "eval:cint(frappe.sys_defaults.enable_company_wise_masters)"
   }
  ],
  "icon": "fa fa-tag",
@@ -1093,7 +1108,7 @@
  "image_field": "image",
  "links": [],
  "make_attachments_public": 1,
- "modified": "2026-07-05 23:24:45.734144",
+ "modified": "2026-07-14 21:00:00.000000",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -41,6 +41,7 @@
   "column_break_wugd",
   "over_billing_allowance",
   "company_restrictions_section",
+  "restrict_to_companies",
   "allowed_companies",
   "section_break_11",
   "brand",
@@ -1091,16 +1092,22 @@
   {
    "fieldname": "company_restrictions_section",
    "fieldtype": "Section Break",
-   "label": "Company Restrictions",
-   "description": "If set, this Item is only available for transactions in the listed companies. Leave empty for no restriction.",
-   "depends_on": "eval:cint(frappe.sys_defaults.enable_company_wise_masters)"
+   "label": "Company Restrictions"
+  },
+  {
+   "default": "0",
+   "fieldname": "restrict_to_companies",
+   "fieldtype": "Check",
+   "label": "Restrict to Companies",
+   "description": "If checked, this Item is only available for transactions in the companies listed below."
   },
   {
    "fieldname": "allowed_companies",
    "fieldtype": "Table MultiSelect",
    "label": "Allowed Companies",
    "options": "Company Restriction",
-   "depends_on": "eval:cint(frappe.sys_defaults.enable_company_wise_masters)"
+   "depends_on": "eval:doc.restrict_to_companies",
+   "mandatory_depends_on": "eval:doc.restrict_to_companies"
   }
  ],
  "icon": "fa fa-tag",
@@ -1108,7 +1115,7 @@
  "image_field": "image",
  "links": [],
  "make_attachments_public": 1,
- "modified": "2026-07-14 21:00:00.000000",
+ "modified": "2026-07-14 23:00:00.000000",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -33,6 +33,7 @@ from erpnext.controllers.item_variant import (
 	make_variant_item_code,
 	validate_item_variant_attributes,
 )
+from erpnext.stock.doctype.company_restriction.company_restriction import validate_allowed_companies
 from erpnext.stock.doctype.item_default.item_default import ItemDefault
 from erpnext.stock.utils import get_valuation_method
 
@@ -62,6 +63,7 @@ class Item(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		from erpnext.stock.doctype.company_restriction.company_restriction import CompanyRestriction
 		from erpnext.stock.doctype.item_barcode.item_barcode import ItemBarcode
 		from erpnext.stock.doctype.item_customer_detail.item_customer_detail import ItemCustomerDetail
 		from erpnext.stock.doctype.item_default.item_default import ItemDefault
@@ -73,6 +75,7 @@ class Item(Document):
 
 		allow_alternative_item: DF.Check
 		allow_negative_stock: DF.Check
+		allowed_companies: DF.TableMultiSelect[CompanyRestriction]
 		asset_category: DF.Link | None
 		asset_naming_series: DF.Literal[None]
 		attributes: DF.Table[ItemVariantAttribute]
@@ -227,6 +230,7 @@ class Item(Document):
 		self.cant_change()
 		self.validate_serialized_change_with_bundle()
 		self.validate_item_tax_net_rate_range()
+		validate_allowed_companies(self)
 
 		if not self.is_new():
 			self.old_item_group = frappe.db.get_value(self.doctype, self.name, "item_group")

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -33,7 +33,6 @@ from erpnext.controllers.item_variant import (
 	make_variant_item_code,
 	validate_item_variant_attributes,
 )
-from erpnext.stock.doctype.company_restriction.company_restriction import validate_allowed_companies
 from erpnext.stock.doctype.item_default.item_default import ItemDefault
 from erpnext.stock.utils import get_valuation_method
 
@@ -231,7 +230,6 @@ class Item(Document):
 		self.cant_change()
 		self.validate_serialized_change_with_bundle()
 		self.validate_item_tax_net_rate_range()
-		validate_allowed_companies(self)
 
 		if not self.is_new():
 			self.old_item_group = frappe.db.get_value(self.doctype, self.name, "item_group")

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -136,6 +136,7 @@ class Item(Document):
 		quality_inspection_template: DF.Link | None
 		reorder_levels: DF.Table[ItemReorder]
 		retain_sample: DF.Check
+		restrict_to_companies: DF.Check
 		safety_stock: DF.Float
 		sales_tax_withholding_category: DF.Link | None
 		sales_uom: DF.Link | None

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -22,9 +22,10 @@ frappe.ui.form.on("Material Request", {
 			return doc.stock_qty <= doc.ordered_qty ? "green" : "orange";
 		});
 
-		frm.set_query("item_code", "items", function () {
+		frm.set_query("item_code", "items", function (doc) {
 			return {
 				query: "erpnext.controllers.queries.item_query",
+				filters: { company: doc.company },
 			};
 		});
 
@@ -604,7 +605,7 @@ erpnext.buying.MaterialRequestController = class MaterialRequestController exten
 
 	onload() {
 		this.frm.set_query("item_code", "items", function (doc, cdt, cdn) {
-			let filters = { is_stock_item: 1 };
+			let filters = { is_stock_item: 1, company: doc.company };
 
 			if (doc.material_request_type == "Customer Provided") {
 				filters.customer = doc.customer;

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -1234,7 +1234,7 @@ erpnext.stock.StockEntry = class StockEntry extends erpnext.stock.StockControlle
 		};
 
 		this.frm.fields_dict.items.grid.get_field("item_code").get_query = function () {
-			return erpnext.queries.item({ is_stock_item: 1 });
+			return erpnext.queries.item({ is_stock_item: 1, company: me.frm.doc.company });
 		};
 
 		this.frm.set_query("purchase_order", function () {

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
@@ -22,6 +22,7 @@ frappe.ui.form.on("Stock Reconciliation", {
 				query: "erpnext.controllers.queries.item_query",
 				filters: {
 					is_stock_item: 1,
+					company: doc.company,
 				},
 			};
 		});


### PR DESCRIPTION
Manual backport of #57124, #57258 and #57352 to version-16-hotfix.

Conflicts were limited to import ordering and develop-only context (customer mapper refactor, `hide_currency_symbol` type, `allow_negative_stock` handler, QB rewrite of `item_query`); feature code is identical to develop. One adaptation: v16's `item_query` is still raw SQL, so the company restriction filter is applied as a parameterized SQL condition instead of develop's query-builder criterion.