### PR TITLE
fix: get reserved batch qty precision from settings (v16)

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1371,8 +1371,9 @@ class StockController(AccountsController):
 			if outstanding > 0:
 				reservations[key].append(row)
 
+		precision = frappe.get_precision("Serial and Batch Entry", "qty")
 		for (batch_no, warehouse), reserved_qty in outstanding_qty.items():
-			if flt(reserved_qty, 6) <= 0:
+			if flt(reserved_qty, precision) <= 0:
 				continue
 
 			batch_qty = get_batch_qty(
@@ -1383,7 +1384,7 @@ class StockController(AccountsController):
 				consider_negative_batches=True,
 			)
 
-			if flt(batch_qty, 6) >= flt(reserved_qty, 6):
+			if flt(batch_qty, precision) >= flt(reserved_qty, precision):
 				continue
 
 			vouchers = ", ".join(


### PR DESCRIPTION
Follow-up to #57170 (backport of #57169). The reserved-batch comparison hardcoded precision 6; use the Serial and Batch Entry qty field precision (falls back to System Settings float precision) instead. Same fix as #57353 — code lives in stock_controller.py on this branch.