### PR TITLE
feat: make Shipping Rule Cost Center optional with company default fallback

### DIFF
--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.json
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.json
@@ -82,8 +82,7 @@
    "fieldname": "cost_center",
    "fieldtype": "Link",
    "label": "Cost Center",
-   "options": "Cost Center",
-   "reqd": 1
+   "options": "Cost Center"
   },
   {
    "fieldname": "shipping_amount_section",
@@ -141,19 +140,20 @@
    "fieldtype": "Column Break"
   },
   {
-    "fieldname": "project",
-    "fieldtype": "Link",
-    "label": "Project",
-    "options": "Project"
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
   }
  ],
  "icon": "fa fa-truck",
  "idx": 1,
  "links": [],
- "modified": "2024-03-27 13:10:41.653314",
+ "modified": "2026-07-22 14:53:27.315435",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Shipping Rule",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -197,6 +197,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "ASC",
  "states": []

--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
@@ -36,18 +36,17 @@ class ShippingRule(Document):
 		from erpnext.accounts.doctype.shipping_rule_condition.shipping_rule_condition import (
 			ShippingRuleCondition,
 		)
-		from erpnext.accounts.doctype.shipping_rule_country.shipping_rule_country import (
-			ShippingRuleCountry,
-		)
+		from erpnext.accounts.doctype.shipping_rule_country.shipping_rule_country import ShippingRuleCountry
 
 		account: DF.Link
 		calculate_based_on: DF.Literal["Fixed", "Net Total", "Net Weight"]
 		company: DF.Link
 		conditions: DF.Table[ShippingRuleCondition]
-		cost_center: DF.Link
+		cost_center: DF.Link | None
 		countries: DF.Table[ShippingRuleCountry]
 		disabled: DF.Check
 		label: DF.Data
+		project: DF.Link | None
 		shipping_amount: DF.Currency
 		shipping_rule_type: DF.Literal["Selling", "Buying"]
 	# end: auto-generated types


### PR DESCRIPTION
### Problem
Cost Center on the Shipping Rule was mandatory, so teams that do not track a cost center on shipping charges were still forced to pick one.

### Change
Cost Center on the Shipping Rule is now optional. When it is left blank, the shipping charge added to the taxes table falls back to the company's default cost center. This avoids the "Cost Center is required for Profit and Loss account" error on submit, since shipping accounts are usually income accounts. The rule's Project is now applied to the shipping tax row as well (the field existed but was never being used).

### How to test
1. Open a Shipping Rule, clear the Cost Center, and save.
2. Add that rule to a Sales Order or Sales Invoice. The shipping tax row should pick up the company default cost center.
3. Submit. It should post without a missing cost center error.
no-docs