### PR TITLE
fix: respect selected BOM when creating work order for variant item

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/mapper.py
+++ b/erpnext/manufacturing/doctype/work_order/mapper.py
@@ -115,7 +115,7 @@ def make_work_order(
 		frappe.throw(_("Not permitted"), frappe.PermissionError)
 
 	item_details = get_item_details(item, project)
-	bom_no = _variant_default_bom(item) or bom_no
+	bom_no = _variant_default_bom(item, bom_no) or bom_no
 	wo_doc = _new_work_order(item, bom_no, company, item_details, use_multi_level_bom)
 
 	if flt(qty) > 0:
@@ -128,8 +128,11 @@ def make_work_order(
 	return wo_doc
 
 
-def _variant_default_bom(item):
+def _variant_default_bom(item, bom_no=None):
 	if not frappe.db.get_value("Item", item, "variant_of"):
+		return None
+	# selected BOM already belongs to this variant
+	if bom_no and frappe.db.get_value("BOM", bom_no, "item") == item:
 		return None
 	return frappe.db.get_value("BOM", {"item": item, "is_default": 1, "docstatus": 1})
 


### PR DESCRIPTION
### Problem

Creating a Work Order from a **non-default** BOM of a **variant** item silently resets `bom_no` to the variant's default BOM, forcing the user to re-select the intended one.

### How the intended logic regressed

For variant items, `make_work_order` substitutes the variant's own default BOM for the passed `bom_no`. This was meant only for the **template-BOM flow** — creating a Work Order from a *template* BOM and picking a variant in the prompt, where the template BOM doesn't apply to the variant, so it correctly swaps in the variant's default BOM.

The substitution, however, is **unconditional**: it never checks whether the selected BOM already belongs to the variant. So when the user launches directly from one of the variant's *own* BOMs, that valid selection is overridden with the default too.

### Fix

Skip the substitution when the selected BOM already belongs to the variant item; keep it for the template-BOM case.

https://support.frappe.io/helpdesk/tickets/74463?view=VIEW-HD+Ticket-70177
