### PR TITLE
refactor: move new-doc route options to StockController

### DIFF
--- a/erpnext/public/js/controllers/stock_controller.js
+++ b/erpnext/public/js/controllers/stock_controller.js
@@ -11,6 +11,36 @@ erpnext.stock.StockController = class StockController extends frappe.ui.form.Con
 		}
 	}
 
+	onload_post_render() {
+		this.set_route_options_for_new_doc();
+	}
+
+	set_route_options_for_new_doc() {
+		// While creating a Batch or Serial and Batch Bundle from the link
+		// field, copy details from the line item to the new form
+		if (!this.frm.fields_dict.items) return;
+
+		let batch_no_field = this.frm.get_docfield("items", "batch_no");
+		if (batch_no_field) {
+			batch_no_field.get_route_options_for_new_doc = (row) => {
+				return {
+					item: row.doc.item_code,
+				};
+			};
+		}
+
+		let sbb_field = this.frm.get_docfield("items", "serial_and_batch_bundle");
+		if (sbb_field) {
+			sbb_field.get_route_options_for_new_doc = (row) => {
+				return {
+					item_code: row.doc.item_code,
+					warehouse: row.doc.warehouse || row.doc.s_warehouse || row.doc.t_warehouse,
+					voucher_type: this.frm.doc.doctype,
+				};
+			};
+		}
+	}
+
 	barcode(doc, cdt, cdn) {
 		let row = locals[cdt][cdn];
 		if (row.barcode) {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -668,34 +668,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		erpnext.toggle_serial_batch_fields(this.frm);
 	}
 
-	set_route_options_for_new_doc() {
-		// While creating the batch from the link field, copy item from line item to batch form
-
-		if (this.frm.fields_dict["items"].grid.get_field("batch_no")) {
-			let batch_no_field = this.frm.get_docfield("items", "batch_no");
-			if (batch_no_field) {
-				batch_no_field.get_route_options_for_new_doc = function (row) {
-					return {
-						item: row.doc.item_code,
-					};
-				};
-			}
-		}
-
-		// While creating the SABB from the link field, copy item, doctype from line item to SABB form
-		if (this.frm.fields_dict["items"].grid.get_field("serial_and_batch_bundle")) {
-			let sbb_field = this.frm.get_docfield("items", "serial_and_batch_bundle");
-			if (sbb_field) {
-				sbb_field.get_route_options_for_new_doc = (row) => {
-					return {
-						item_code: row.doc.item_code,
-						voucher_type: this.frm.doc.doctype,
-					};
-				};
-			}
-		}
-	}
-
 	scan_barcode() {
 		frappe.flags.dialog_set = false;
 		this.barcode_scanner.process_scan();

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -568,8 +568,6 @@ frappe.ui.form.on("Stock Entry", {
 			erpnext.accounts.dimensions.update_dimension(frm, frm.doctype);
 		}
 
-		frm.events.set_route_options_for_new_doc(frm);
-
 		frm.set_df_property(
 			"items",
 			"cannot_add_rows",
@@ -580,28 +578,6 @@ frappe.ui.form.on("Stock Entry", {
 					"Subcontracting Delivery",
 				].includes(frm.doc.purpose)
 		);
-	},
-
-	set_route_options_for_new_doc(frm) {
-		let batch_no_field = frm.get_docfield("items", "batch_no");
-		if (batch_no_field) {
-			batch_no_field.get_route_options_for_new_doc = function (row) {
-				return {
-					item: row.doc.item_code,
-				};
-			};
-		}
-
-		let sbb_field = frm.get_docfield("items", "serial_and_batch_bundle");
-		if (sbb_field) {
-			sbb_field.get_route_options_for_new_doc = (row) => {
-				return {
-					item_code: row.doc.item_code,
-					voucher_type: frm.doc.doctype,
-					warehouse: row.doc.s_warehouse || row.doc.t_warehouse,
-				};
-			};
-		}
 	},
 
 	get_items_from_transit_entry: function (frm) {
@@ -1306,6 +1282,7 @@ erpnext.stock.StockEntry = class StockEntry extends erpnext.stock.StockControlle
 	}
 
 	onload_post_render() {
+		super.onload_post_render();
 		var me = this;
 		if (me.frm.doc.__islocal && me.frm.doc.company && !me.frm.doc.amended_from) {
 			me.company();

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
@@ -47,17 +47,6 @@ frappe.ui.form.on("Stock Reconciliation", {
 			};
 		});
 
-		let sbb_field = frm.get_docfield("items", "serial_and_batch_bundle");
-		if (sbb_field) {
-			sbb_field.get_route_options_for_new_doc = (row) => {
-				return {
-					item_code: row.doc.item_code,
-					warehouse: row.doc.warehouse,
-					voucher_type: frm.doc.doctype,
-				};
-			};
-		}
-
 		if (frm.doc.company) {
 			erpnext.queries.setup_queries(frm, "Warehouse", function () {
 				return erpnext.queries.warehouse(frm.doc);


### PR DESCRIPTION
`set_route_options_for_new_doc` lived in `TransactionController`, so doctypes extending `StockController` directly missed the Batch/SABB prefill (Stock Reconciliation) or duplicated it locally (Stock Entry). Moved it to `StockController` (which `TransactionController` already inherits via `taxes_and_totals → payments`) and called it from `onload_post_render`.

- Batch quick entry from Stock Reconciliation items now prefills Item
- SABB route options unified as `warehouse || s_warehouse || t_warehouse`, so transaction doctypes now also prefill warehouse
- Stock Entry's duplicate handler removed; its `onload_post_render` now calls `super`

Subcontracting Receipt keeps its own handler (different tables, supplier warehouse logic) — it overrides the generic one on refresh, same as before.