### PR TITLE
fix: Recalculate Values fails on legacy submitted Bins

### DIFF
--- a/erpnext/stock/doctype/bin/bin.py
+++ b/erpnext/stock/doctype/bin/bin.py
@@ -68,6 +68,7 @@ class Bin(Document):
 		self.update_reserved_qty_for_sub_contracting(update_qty=False)
 		self.update_reserved_qty_for_production_plan(skip_project_qty_update=True, update_qty=False)
 		self.set_projected_qty()
+		self.flags.ignore_validate_update_after_submit = True
 		self.save()
 
 	def before_save(self):

--- a/erpnext/stock/doctype/bin/test_bin.py
+++ b/erpnext/stock/doctype/bin/test_bin.py
@@ -57,6 +57,21 @@ class TestBin(ERPNextTestSuite):
 		self.assertEqual(bin.valuation_rate, 0)
 		self.assertEqual(bin.stock_value, 0)
 
+	def test_recalculate_values_on_legacy_submitted_bin(self):
+		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+		item_code = make_item().name
+		warehouse = "_Test Warehouse - _TC"
+		make_stock_entry(item_code=item_code, target=warehouse, qty=10, rate=100)
+
+		bin = frappe.get_doc("Bin", {"item_code": item_code, "warehouse": warehouse})
+		bin.db_set({"docstatus": 1, "valuation_rate": 40, "stock_value": 400})
+		bin.reload()
+		bin.recalculate_values()
+
+		self.assertEqual(bin.valuation_rate, 100)
+		self.assertEqual(bin.stock_value, 1000)
+
 	def test_index_exists(self):
 		# has_index is db-agnostic; raw "SHOW INDEX" is MySQL-only and errors on Postgres
 		if not frappe.db.has_index("tabBin", "unique_item_warehouse"):


### PR DESCRIPTION
Follow-up to #57300. Legacy sites have Bin rows with `docstatus = 1`, and no Bin field allows on-submit changes, so **Recalculate Values** raised *Cannot Update After Submit* as soon as recalculation actually changed a value.

Since every field the method writes is recomputed from the ledger, the update-after-submit check is skipped for this save. Regression test included (fails without the fix).