### PR TITLE
fix: restore Save button on reverse journal entry

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -41,7 +41,7 @@ frappe.ui.form.on("Journal Entry", {
 
 	refresh: function (frm) {
 		if (frm.doc.reversal_of && (frm.is_new() || frm.doc.docstatus == 0)) {
-			frm.set_read_only();
+			erpnext.journal_entry.lock_reversal_entry(frm);
 		}
 
 		erpnext.toggle_naming_series();
@@ -511,6 +511,13 @@ $.extend(erpnext.journal_entry, {
 				frm.doc.multi_currency ? label + " in Account Currency" : label
 			);
 		});
+	},
+
+	lock_reversal_entry: function (frm) {
+		frm.fields
+			.filter((field) => field.has_input)
+			.forEach((field) => frm.set_df_property(field.df.fieldname, "read_only", 1));
+		frm.set_df_property("accounts", "read_only", 1);
 	},
 
 	set_debit_credit_in_company_currency: function (frm, cdt, cdn) {


### PR DESCRIPTION
Changes:
- Backport for https://github.com/frappe/erpnext/pull/56770 on version 15
- Restore the Save button on reverse journal entry

Before Change:
<img width="2900" height="2068" alt="Screenshot 2026-07-23 at 09-23-13 New Journal Entry - new-journal-entry-awcecvaice" src="https://github.com/user-attachments/assets/ccd3491c-07dd-46ab-8cb5-f5d4d898a8ec" />

After Change:
<img width="2900" height="2068" alt="Screenshot 2026-07-23 at 09-29-35 New Journal Entry - new-journal-entry-yklyukwjmm" src="https://github.com/user-attachments/assets/0bbb973b-4e97-464b-9448-1d05b54ccd8c" />
