### PR TITLE
fix: do not translate root Item Group lookup key

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -32,8 +32,8 @@ class ItemGroup(NestedSet):
 
 	def validate(self):
 		if not self.parent_item_group and not frappe.in_test:
-			if frappe.db.exists("Item Group", _("All Item Groups")):
-				self.parent_item_group = _("All Item Groups")
+			if frappe.db.exists("Item Group", "All Item Groups"):
+				self.parent_item_group = "All Item Groups"
 		self.validate_item_group_defaults()
 		self.check_item_tax()
 

--- a/erpnext/setup/setup_wizard/operations/install_fixtures.py
+++ b/erpnext/setup/setup_wizard/operations/install_fixtures.py
@@ -30,7 +30,7 @@ def get_preset_records(country=None):
 		# item group
 		{
 			"doctype": "Item Group",
-			"item_group_name": _("All Item Groups"),
+			"item_group_name": "All Item Groups",
 			"is_group": 1,
 			"parent_item_group": "",
 		},
@@ -38,32 +38,32 @@ def get_preset_records(country=None):
 			"doctype": "Item Group",
 			"item_group_name": _("Products"),
 			"is_group": 0,
-			"parent_item_group": _("All Item Groups"),
+			"parent_item_group": "All Item Groups",
 			"show_in_website": 1,
 		},
 		{
 			"doctype": "Item Group",
 			"item_group_name": _("Raw Material"),
 			"is_group": 0,
-			"parent_item_group": _("All Item Groups"),
+			"parent_item_group": "All Item Groups",
 		},
 		{
 			"doctype": "Item Group",
 			"item_group_name": _("Services"),
 			"is_group": 0,
-			"parent_item_group": _("All Item Groups"),
+			"parent_item_group": "All Item Groups",
 		},
 		{
 			"doctype": "Item Group",
 			"item_group_name": _("Sub Assemblies"),
 			"is_group": 0,
-			"parent_item_group": _("All Item Groups"),
+			"parent_item_group": "All Item Groups",
 		},
 		{
 			"doctype": "Item Group",
 			"item_group_name": _("Consumable"),
 			"is_group": 0,
-			"parent_item_group": _("All Item Groups"),
+			"parent_item_group": "All Item Groups",
 		},
 		# Stock Entry Type
 		{


### PR DESCRIPTION
`ItemGroup.validate()` looked up the tree root with `_("All Item Groups")`, which resolves in the session language. For non-English users the lookup missed the root (stored in English by `install_fixtures`, which already uses the identity `_`), so new groups saved with a blank parent became uneditable second roots.

Use the canonical name for the lookup and assignment.

Closes #57345