### PR TITLE
fix: accept dict target_doc in mapper endpoints

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/mapper.py
+++ b/erpnext/accounts/doctype/journal_entry/mapper.py
@@ -220,7 +220,7 @@ def make_inter_company_journal_entry(name: str, voucher_type: str, company: str)
 
 
 @frappe.whitelist()
-def make_reverse_journal_entry(source_name: str, target_doc: str | Document | None = None) -> Document:
+def make_reverse_journal_entry(source_name: str, target_doc: str | dict | Document | None = None) -> Document:
 	"""Map a submitted Journal Entry to a reversing one (debits and credits swapped)."""
 	existing_reverse = frappe.db.exists("Journal Entry", {"reversal_of": source_name, "docstatus": 1})
 	if existing_reverse:

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -3277,7 +3277,7 @@ def get_paid_amount(dt, dn, party_type, party, account, due_date):
 
 
 @frappe.whitelist()
-def make_payment_order(source_name: str, target_doc: str | Document | None = None):
+def make_payment_order(source_name: str, target_doc: str | dict | Document | None = None):
 	from frappe.model.mapper import get_mapped_doc
 
 	def set_missing_values(source, target):

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -1227,7 +1227,7 @@ def get_subscription_details(reference_doctype: str, reference_name: str):
 
 
 @frappe.whitelist()
-def make_payment_order(source_name: str, target_doc: str | Document | None = None):
+def make_payment_order(source_name: str, target_doc: str | dict | Document | None = None):
 	from frappe.model.mapper import get_mapped_doc
 
 	def set_missing_values(source, target):

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -1025,7 +1025,7 @@ def get_pos_reserved_qty_from_table(child_table, item_code, warehouse):
 
 
 @frappe.whitelist()
-def make_sales_return(source_name: str, target_doc: Document | str | None = None):
+def make_sales_return(source_name: str, target_doc: str | dict | Document | None = None):
 	from erpnext.controllers.sales_and_purchase_return import make_return_doc
 
 	return make_return_doc("POS Invoice", source_name, target_doc)

--- a/erpnext/accounts/doctype/purchase_invoice/mapper.py
+++ b/erpnext/accounts/doctype/purchase_invoice/mapper.py
@@ -13,14 +13,14 @@ from erpnext.controllers.accounts_controller import merge_taxes
 
 
 @frappe.whitelist()
-def make_debit_note(source_name: str, target_doc: str | Document | None = None):
+def make_debit_note(source_name: str, target_doc: str | dict | Document | None = None):
 	from erpnext.controllers.sales_and_purchase_return import make_return_doc
 
 	return make_return_doc("Purchase Invoice", source_name, target_doc)
 
 
 @frappe.whitelist()
-def make_stock_entry(source_name: str, target_doc: str | Document | None = None):
+def make_stock_entry(source_name: str, target_doc: str | dict | Document | None = None):
 	doc = get_mapped_doc(
 		"Purchase Invoice",
 		source_name,
@@ -38,7 +38,7 @@ def make_stock_entry(source_name: str, target_doc: str | Document | None = None)
 
 
 @frappe.whitelist()
-def make_inter_company_sales_invoice(source_name: str, target_doc: Document | None = None):
+def make_inter_company_sales_invoice(source_name: str, target_doc: str | dict | Document | None = None):
 	from erpnext.accounts.doctype.sales_invoice.mapper import make_inter_company_transaction
 
 	return make_inter_company_transaction("Purchase Invoice", source_name, target_doc)
@@ -46,7 +46,7 @@ def make_inter_company_sales_invoice(source_name: str, target_doc: Document | No
 
 @frappe.whitelist()
 def make_purchase_receipt(
-	source_name: str, target_doc: str | Document | None = None, args: str | dict | None = None
+	source_name: str, target_doc: str | dict | Document | None = None, args: str | dict | None = None
 ):
 	if args is None:
 		args = {}

--- a/erpnext/accounts/doctype/sales_invoice/mapper.py
+++ b/erpnext/accounts/doctype/sales_invoice/mapper.py
@@ -13,7 +13,7 @@ from erpnext.accounts.party import CROSS_PARTY_FIELD_NO_MAP, _get_party_details
 
 
 @frappe.whitelist()
-def make_maintenance_schedule(source_name: str, target_doc: str | Document | None = None):
+def make_maintenance_schedule(source_name: str, target_doc: str | dict | Document | None = None):
 	doclist = get_mapped_doc(
 		"Sales Invoice",
 		source_name,
@@ -30,7 +30,7 @@ def make_maintenance_schedule(source_name: str, target_doc: str | Document | Non
 
 
 @frappe.whitelist()
-def make_delivery_note(source_name: str, target_doc: Document | None = None):
+def make_delivery_note(source_name: str, target_doc: str | dict | Document | None = None):
 	def set_missing_values(source, target):
 		target.run_method("set_missing_values")
 		target.run_method("set_po_nos")
@@ -79,7 +79,7 @@ def make_delivery_note(source_name: str, target_doc: Document | None = None):
 
 
 @frappe.whitelist()
-def make_sales_return(source_name: str, target_doc: Document | None = None):
+def make_sales_return(source_name: str, target_doc: str | dict | Document | None = None):
 	from erpnext.controllers.sales_and_purchase_return import make_return_doc
 
 	return make_return_doc("Sales Invoice", source_name, target_doc)
@@ -173,7 +173,7 @@ def validate_inter_company_transaction(doc, doctype):
 
 
 @frappe.whitelist()
-def make_inter_company_purchase_invoice(source_name: str, target_doc: Document | None = None):
+def make_inter_company_purchase_invoice(source_name: str, target_doc: str | dict | Document | None = None):
 	return make_inter_company_transaction("Sales Invoice", source_name, target_doc)
 
 
@@ -549,7 +549,7 @@ def update_address(doc, address_field, address_display_field, address_name):
 
 
 @frappe.whitelist()
-def create_invoice_discounting(source_name: str, target_doc: str | Document | None = None):
+def create_invoice_discounting(source_name: str, target_doc: str | dict | Document | None = None):
 	invoice = frappe.get_doc("Sales Invoice", source_name)
 	invoice_discounting = frappe.new_doc("Invoice Discounting")
 	invoice_discounting.company = invoice.company
@@ -568,7 +568,7 @@ def create_invoice_discounting(source_name: str, target_doc: str | Document | No
 
 @frappe.whitelist()
 def create_dunning(
-	source_name: str, target_doc: str | Document | None = None, ignore_permissions: bool = False
+	source_name: str, target_doc: str | dict | Document | None = None, ignore_permissions: bool = False
 ):
 	def postprocess_dunning(source, target):
 		dunning_type = frappe.db.exists("Dunning Type", {"is_default": 1, "company": source.company})

--- a/erpnext/buying/doctype/purchase_order/mapper.py
+++ b/erpnext/buying/doctype/purchase_order/mapper.py
@@ -23,7 +23,7 @@ def set_missing_values(source, target):
 
 @frappe.whitelist()
 def make_purchase_receipt(
-	source_name: str, target_doc: str | Document | None = None, args: str | dict | None = None
+	source_name: str, target_doc: str | dict | Document | None = None, args: str | dict | None = None
 ):
 	if args is None:
 		args = {}
@@ -102,7 +102,7 @@ def make_purchase_receipt(
 
 @frappe.whitelist()
 def make_purchase_invoice(
-	source_name: str, target_doc: str | Document | None = None, args: str | dict | None = None
+	source_name: str, target_doc: str | dict | Document | None = None, args: str | dict | None = None
 ):
 	return get_mapped_purchase_invoice(source_name, target_doc, args=args)
 
@@ -211,7 +211,7 @@ def get_mapped_purchase_invoice(source_name, target_doc=None, ignore_permissions
 
 
 @frappe.whitelist()
-def make_inter_company_sales_order(source_name: str, target_doc: str | Document | None = None):
+def make_inter_company_sales_order(source_name: str, target_doc: str | dict | Document | None = None):
 	from erpnext.accounts.doctype.sales_invoice.mapper import make_inter_company_transaction
 
 	return make_inter_company_transaction("Purchase Order", source_name, target_doc)
@@ -220,7 +220,7 @@ def make_inter_company_sales_order(source_name: str, target_doc: str | Document 
 @frappe.whitelist()
 def make_subcontracting_order(
 	source_name: str,
-	target_doc: str | Document | None = None,
+	target_doc: str | dict | Document | None = None,
 	save: bool = False,
 	submit: bool = False,
 	notify: bool = False,
@@ -263,7 +263,9 @@ def is_po_fully_subcontracted(po_name: str) -> bool:
 	return not query.run(as_dict=True)
 
 
-def get_mapped_subcontracting_order(source_name: str, target_doc: str | Document | None = None) -> Document:
+def get_mapped_subcontracting_order(
+	source_name: str, target_doc: str | dict | Document | None = None
+) -> Document:
 	def post_process(source_doc, target_doc):
 		target_doc.populate_items_table()
 

--- a/erpnext/buying/doctype/request_for_quotation/mapper.py
+++ b/erpnext/buying/doctype/request_for_quotation/mapper.py
@@ -14,7 +14,7 @@ from erpnext.stock.doctype.material_request.mapper import set_missing_values
 
 @frappe.whitelist()
 def make_supplier_quotation_from_rfq(
-	source_name: str, target_doc: str | Document | None = None, for_supplier: str | None = None
+	source_name: str, target_doc: str | dict | Document | None = None, for_supplier: str | None = None
 ):
 	def postprocess(source, target_doc):
 		if for_supplier:
@@ -129,7 +129,7 @@ def create_rfq_items(sq_doc, supplier, data):
 
 @frappe.whitelist()
 def get_item_from_material_requests_based_on_supplier(
-	source_name: str, target_doc: str | Document | None = None
+	source_name: str, target_doc: str | dict | Document | None = None
 ):
 	Item = frappe.qb.DocType("Item")
 	Item_Supp = frappe.qb.DocType("Item Supplier")

--- a/erpnext/buying/doctype/supplier_quotation/mapper.py
+++ b/erpnext/buying/doctype/supplier_quotation/mapper.py
@@ -11,7 +11,7 @@ from frappe.utils import flt
 
 @frappe.whitelist()
 def make_purchase_order(
-	source_name: str, target_doc: str | Document | None = None, args: str | dict | None = None
+	source_name: str, target_doc: str | dict | Document | None = None, args: str | dict | None = None
 ):
 	if args is None:
 		args = {}
@@ -65,7 +65,7 @@ def make_purchase_order(
 
 
 @frappe.whitelist()
-def make_purchase_invoice(source_name: str, target_doc: str | Document | None = None):
+def make_purchase_invoice(source_name: str, target_doc: str | dict | Document | None = None):
 	doc = get_mapped_doc(
 		"Supplier Quotation",
 		source_name,
@@ -86,7 +86,7 @@ def make_purchase_invoice(source_name: str, target_doc: str | Document | None = 
 
 
 @frappe.whitelist()
-def make_quotation(source_name: str, target_doc: str | Document | None = None):
+def make_quotation(source_name: str, target_doc: str | dict | Document | None = None):
 	doclist = get_mapped_doc(
 		"Supplier Quotation",
 		source_name,

--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -1345,7 +1345,7 @@ def make_rm_stock_entry(
 	subcontract_order: str,
 	rm_items: list | None = None,
 	order_doctype: str = "Subcontracting Order",
-	target_doc: dict | None = None,
+	target_doc: str | dict | Document | None = None,
 ):
 	if subcontract_order:
 		subcontract_order = frappe.get_doc(order_doctype, subcontract_order)
@@ -1534,7 +1534,7 @@ def make_return_stock_entry_for_subcontract(
 
 
 @frappe.whitelist()
-def get_materials_from_supplier(source_name: str, target_doc: Document | str | None = None):
+def get_materials_from_supplier(source_name: str, target_doc: str | dict | Document | None = None):
 	args = frappe.flags.args or {}
 
 	subcontract_order = args.get("subcontract_order") or source_name

--- a/erpnext/crm/doctype/lead/mapper.py
+++ b/erpnext/crm/doctype/lead/mapper.py
@@ -11,12 +11,12 @@ from frappe.model.mapper import get_mapped_doc
 
 
 @frappe.whitelist()
-def make_customer(source_name: str, target_doc: str | Document | None = None):
+def make_customer(source_name: str, target_doc: str | dict | Document | None = None):
 	return _make_customer(source_name, target_doc)
 
 
 def _make_customer(
-	source_name: str, target_doc: str | Document | None = None, ignore_permissions: bool = False
+	source_name: str, target_doc: str | dict | Document | None = None, ignore_permissions: bool = False
 ):
 	def set_missing_values(source, target):
 		if source.company_name:
@@ -60,7 +60,7 @@ def _make_customer(
 
 
 @frappe.whitelist()
-def make_opportunity(source_name: str, target_doc: str | Document | None = None):
+def make_opportunity(source_name: str, target_doc: str | dict | Document | None = None):
 	def set_missing_values(source, target):
 		_set_missing_values(source, target)
 
@@ -90,7 +90,7 @@ def make_opportunity(source_name: str, target_doc: str | Document | None = None)
 
 
 @frappe.whitelist()
-def make_quotation(source_name: str, target_doc: str | Document | None = None):
+def make_quotation(source_name: str, target_doc: str | dict | Document | None = None):
 	def set_missing_values(source, target):
 		_set_missing_values(source, target)
 

--- a/erpnext/crm/doctype/opportunity/mapper.py
+++ b/erpnext/crm/doctype/opportunity/mapper.py
@@ -11,7 +11,7 @@ from erpnext.setup.utils import get_exchange_rate
 
 
 @frappe.whitelist()
-def make_quotation(source_name: str, target_doc: str | Document | None = None):
+def make_quotation(source_name: str, target_doc: str | dict | Document | None = None):
 	def set_missing_values(source, target):
 		from erpnext.controllers.accounts_controller import get_default_taxes_and_charges
 
@@ -64,7 +64,7 @@ def make_quotation(source_name: str, target_doc: str | Document | None = None):
 
 
 @frappe.whitelist()
-def make_request_for_quotation(source_name: str, target_doc: str | Document | None = None):
+def make_request_for_quotation(source_name: str, target_doc: str | dict | Document | None = None):
 	def update_item(obj, target, source_parent):
 		target.conversion_factor = 1.0
 
@@ -86,7 +86,7 @@ def make_request_for_quotation(source_name: str, target_doc: str | Document | No
 
 
 @frappe.whitelist()
-def make_customer(source_name: str, target_doc: str | Document | None = None):
+def make_customer(source_name: str, target_doc: str | dict | Document | None = None):
 	def set_missing_values(source, target):
 		target.opportunity_name = source.name
 
@@ -110,7 +110,7 @@ def make_customer(source_name: str, target_doc: str | Document | None = None):
 
 
 @frappe.whitelist()
-def make_supplier_quotation(source_name: str, target_doc: str | Document | None = None):
+def make_supplier_quotation(source_name: str, target_doc: str | dict | Document | None = None):
 	doclist = get_mapped_doc(
 		"Opportunity",
 		source_name,

--- a/erpnext/crm/doctype/prospect/prospect.py
+++ b/erpnext/crm/doctype/prospect/prospect.py
@@ -95,7 +95,7 @@ class Prospect(CRMNote):
 
 
 @frappe.whitelist()
-def make_customer(source_name: str, target_doc: str | Document | None = None):
+def make_customer(source_name: str, target_doc: str | dict | Document | None = None):
 	def set_missing_values(source, target):
 		target.customer_type = "Company"
 		target.company_name = source.name
@@ -119,7 +119,7 @@ def make_customer(source_name: str, target_doc: str | Document | None = None):
 
 
 @frappe.whitelist()
-def make_opportunity(source_name: str, target_doc: str | Document | None = None):
+def make_opportunity(source_name: str, target_doc: str | dict | Document | None = None):
 	def set_missing_values(source, target):
 		target.opportunity_from = "Prospect"
 		target.customer_name = source.company_name

--- a/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe import _, throw
+from frappe.model.document import Document
 from frappe.utils import add_days, cint, cstr, date_diff, formatdate, getdate
 
 from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
@@ -452,7 +453,7 @@ def get_serial_nos_from_schedule(item_code: str, schedule: str):
 @frappe.whitelist()
 def make_maintenance_visit(
 	source_name: str,
-	target_doc: str | dict | None = None,
+	target_doc: str | dict | Document | None = None,
 	item_name: str | None = None,
 	s_id: str | None = None,
 ):

--- a/erpnext/manufacturing/doctype/bom/mapper.py
+++ b/erpnext/manufacturing/doctype/bom/mapper.py
@@ -179,7 +179,7 @@ def make_variant_bom(
 	bom_no: str,
 	item: str,
 	variant_items: str | list,
-	target_doc: Document | str | None = None,
+	target_doc: str | dict | Document | None = None,
 ):
 	frappe.has_permission("BOM", "write", throw=True)
 

--- a/erpnext/manufacturing/doctype/job_card/mapper.py
+++ b/erpnext/manufacturing/doctype/job_card/mapper.py
@@ -13,7 +13,7 @@ from erpnext.subcontracting.doctype.subcontracting_bom.subcontracting_bom import
 
 
 @frappe.whitelist()
-def make_subcontracting_po(source_name: str, target_doc: Document | str | None = None):
+def make_subcontracting_po(source_name: str, target_doc: str | dict | Document | None = None):
 	def set_missing_values(source, target):
 		_item_details = get_subcontracting_boms_for_finished_goods(source.finished_good)
 
@@ -54,7 +54,7 @@ def make_subcontracting_po(source_name: str, target_doc: Document | str | None =
 
 
 @frappe.whitelist()
-def make_material_request(source_name: str, target_doc: Document | str | None = None):
+def make_material_request(source_name: str, target_doc: str | dict | Document | None = None):
 	def update_item(obj, target, source_parent):
 		target.warehouse = source_parent.wip_warehouse
 
@@ -85,7 +85,7 @@ def make_material_request(source_name: str, target_doc: Document | str | None = 
 
 
 @frappe.whitelist()
-def make_stock_entry(source_name: str, target_doc: Document | str | None = None):
+def make_stock_entry(source_name: str, target_doc: str | dict | Document | None = None):
 	from erpnext.stock.doctype.stock_entry.services.manufacturing import (
 		set_previous_operation_serial_batch,
 	)
@@ -162,7 +162,7 @@ def make_corrective_job_card(
 	source_name: str,
 	operation: str | None = None,
 	for_operation: str | None = None,
-	target_doc: Document | str | None = None,
+	target_doc: str | dict | Document | None = None,
 ):
 	def set_missing_values(source, target):
 		target.is_corrective_job_card = 1

--- a/erpnext/manufacturing/doctype/sales_forecast/sales_forecast.py
+++ b/erpnext/manufacturing/doctype/sales_forecast/sales_forecast.py
@@ -67,7 +67,7 @@ class SalesForecast(Document):
 
 
 @frappe.whitelist()
-def create_mps(source_name: str, target_doc: Document | str | None = None):
+def create_mps(source_name: str, target_doc: str | dict | Document | None = None):
 	def postprocess(source, doc):
 		doc.naming_series = "MPS.YY.-.######"
 

--- a/erpnext/manufacturing/doctype/work_order/mapper.py
+++ b/erpnext/manufacturing/doctype/work_order/mapper.py
@@ -13,6 +13,7 @@ from functools import partial
 
 import frappe
 from frappe import _
+from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import cint, flt, get_link_to_form, nowdate
 
@@ -467,7 +468,9 @@ def get_work_order_operation_data(work_order, operation, workstation):
 
 
 @frappe.whitelist()
-def create_pick_list(source_name: str, target_doc: str | dict | None = None, for_qty: float | None = None):
+def create_pick_list(
+	source_name: str, target_doc: str | dict | Document | None = None, for_qty: float | None = None
+):
 	frappe.has_permission("Pick List", "create", throw=True)
 
 	for_qty = for_qty or frappe.parse_json(target_doc).get("for_qty")
@@ -517,7 +520,7 @@ def _set_pick_list_item_qty(source, target, source_parent, for_qty, max_finished
 
 
 @frappe.whitelist()
-def make_material_request(source_name: str, target_doc: str | dict | None = None):
+def make_material_request(source_name: str, target_doc: str | dict | Document | None = None):
 	frappe.has_permission("Material Request", "create", throw=True)
 
 	doc = get_mapped_doc("Work Order", source_name, _material_request_mapping(), target_doc)

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -7,6 +7,7 @@ import json
 import frappe
 from frappe import _, throw
 from frappe.desk.form.assign_to import clear, close_all_assignments
+from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.query_builder.functions import Max, Min, Sum
 from frappe.utils import add_days, add_to_date, date_diff, flt, get_link_to_form, getdate, today
@@ -392,7 +393,9 @@ def set_tasks_as_overdue():
 
 
 @frappe.whitelist()
-def make_timesheet(source_name: str, target_doc: dict | None = None, ignore_permissions: bool = False):
+def make_timesheet(
+	source_name: str, target_doc: str | dict | Document | None = None, ignore_permissions: bool = False
+):
 	def set_missing_values(source: dict, target: dict) -> None:
 		target.parent_project = source.project
 		target.append(

--- a/erpnext/selling/doctype/customer/mapper.py
+++ b/erpnext/selling/doctype/customer/mapper.py
@@ -8,7 +8,7 @@ from frappe.model.mapper import get_mapped_doc
 
 
 @frappe.whitelist()
-def make_quotation(source_name: str, target_doc: str | Document | None = None):
+def make_quotation(source_name: str, target_doc: str | dict | Document | None = None):
 	def set_missing_values(source, target):
 		_set_missing_values(source, target)
 
@@ -38,7 +38,7 @@ def make_quotation(source_name: str, target_doc: str | Document | None = None):
 
 
 @frappe.whitelist()
-def make_opportunity(source_name: str, target_doc: str | Document | None = None):
+def make_opportunity(source_name: str, target_doc: str | dict | Document | None = None):
 	def set_missing_values(source, target):
 		_set_missing_values(source, target)
 
@@ -62,7 +62,7 @@ def make_opportunity(source_name: str, target_doc: str | Document | None = None)
 
 
 @frappe.whitelist()
-def make_payment_entry(source_name: str, target_doc: str | Document | None = None):
+def make_payment_entry(source_name: str, target_doc: str | dict | Document | None = None):
 	def set_missing_values(source, target):
 		_set_missing_values(source, target)
 

--- a/erpnext/selling/doctype/product_bundle/product_bundle.py
+++ b/erpnext/selling/doctype/product_bundle/product_bundle.py
@@ -191,7 +191,7 @@ def get_active_product_bundle(item_code: str) -> str | None:
 
 
 @frappe.whitelist()
-def make_new_version(source_name: str, target_doc: str | None = None):
+def make_new_version(source_name: str, target_doc: str | dict | Document | None = None):
 	"""Create a fresh draft bundle copied from an existing (typically submitted) one.
 
 	The copy keeps the same parent item and component rows but gets a new version

--- a/erpnext/selling/doctype/quotation/mapper.py
+++ b/erpnext/selling/doctype/quotation/mapper.py
@@ -12,7 +12,7 @@ from frappe.utils import cint, flt, getdate, nowdate
 
 @frappe.whitelist()
 def make_sales_order(
-	source_name: str, target_doc: str | Document | None = None, args: str | dict | None = None
+	source_name: str, target_doc: str | dict | Document | None = None, args: str | dict | None = None
 ):
 	if not frappe.db.get_singles_value(
 		"Selling Settings", "allow_sales_order_creation_for_expired_quotation"
@@ -142,7 +142,7 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False, ar
 
 @frappe.whitelist()
 def make_sales_invoice(
-	source_name: str, target_doc: str | Document | None = None, args: str | dict | None = None
+	source_name: str, target_doc: str | dict | Document | None = None, args: str | dict | None = None
 ):
 	return _make_sales_invoice(source_name, target_doc, args=args)
 

--- a/erpnext/selling/doctype/sales_order/mapper.py
+++ b/erpnext/selling/doctype/sales_order/mapper.py
@@ -49,7 +49,7 @@ def get_requested_item_qty(sales_order: str) -> dict:
 
 
 @frappe.whitelist()
-def make_material_request(source_name: str, target_doc: str | Document | None = None):
+def make_material_request(source_name: str, target_doc: str | dict | Document | None = None):
 	requested_item_qty = get_requested_item_qty(source_name)
 
 	def postprocess(source, target):
@@ -156,7 +156,7 @@ def make_material_request(source_name: str, target_doc: str | Document | None = 
 
 
 @frappe.whitelist()
-def make_project(source_name: str, target_doc: str | Document | None = None):
+def make_project(source_name: str, target_doc: str | dict | Document | None = None):
 	def postprocess(source, doc):
 		doc.project_type = "External"
 		doc.project_name = source.name
@@ -230,7 +230,7 @@ def set_serial_batch_for_bundle_reservation(source, target, use_serial_batch_fie
 
 @frappe.whitelist()
 def make_delivery_note(
-	source_name: str, target_doc: str | Document | None = None, kwargs: dict | None = None
+	source_name: str, target_doc: str | dict | Document | None = None, kwargs: dict | None = None
 ):
 	if not kwargs:
 		kwargs = {
@@ -424,7 +424,7 @@ def make_delivery_note(
 @frappe.whitelist()
 def make_sales_invoice(
 	source_name: str,
-	target_doc: str | Document | None = None,
+	target_doc: str | dict | Document | None = None,
 	ignore_permissions: bool = False,
 	args: str | dict | None = None,
 ):
@@ -609,7 +609,7 @@ def make_sales_invoice(
 
 
 @frappe.whitelist()
-def make_maintenance_schedule(source_name: str, target_doc: str | Document | None = None):
+def make_maintenance_schedule(source_name: str, target_doc: str | dict | Document | None = None):
 	maint_schedule = frappe.db.exists(
 		"Maintenance Schedule Item", {"sales_order": source_name, "docstatus": 1}
 	)
@@ -632,7 +632,7 @@ def make_maintenance_schedule(source_name: str, target_doc: str | Document | Non
 
 
 @frappe.whitelist()
-def make_maintenance_visit(source_name: str, target_doc: str | Document | None = None):
+def make_maintenance_visit(source_name: str, target_doc: str | dict | Document | None = None):
 	MaintenanceVisit = frappe.qb.DocType("Maintenance Visit")
 	MaintenanceVisitPurpose = frappe.qb.DocType("Maintenance Visit Purpose")
 
@@ -665,7 +665,9 @@ def make_maintenance_visit(source_name: str, target_doc: str | Document | None =
 
 @frappe.whitelist()
 def make_purchase_order(
-	source_name: str, selected_items: str | list | None = None, target_doc: str | Document | None = None
+	source_name: str,
+	selected_items: str | list | None = None,
+	target_doc: str | dict | Document | None = None,
 ):
 	"""Creates Purchase Order for each Supplier. Returns a list of doc objects."""
 
@@ -873,7 +875,7 @@ def make_work_orders(items: str | dict, sales_order: str, company: str, project:
 
 
 @frappe.whitelist()
-def make_production_plan(source_name: str, target_doc: str | Document | None = None):
+def make_production_plan(source_name: str, target_doc: str | dict | Document | None = None):
 	sales_order = frappe.get_doc("Sales Order", source_name)
 
 	production_plan = frappe.new_doc(
@@ -965,14 +967,14 @@ def make_raw_material_request(
 
 
 @frappe.whitelist()
-def make_inter_company_purchase_order(source_name: str, target_doc: str | Document | None = None):
+def make_inter_company_purchase_order(source_name: str, target_doc: str | dict | Document | None = None):
 	from erpnext.accounts.doctype.sales_invoice.mapper import make_inter_company_transaction
 
 	return make_inter_company_transaction("Sales Order", source_name, target_doc)
 
 
 @frappe.whitelist()
-def create_pick_list(source_name: str, target_doc: str | Document | None = None):
+def create_pick_list(source_name: str, target_doc: str | dict | Document | None = None):
 	def validate_sales_order():
 		so = frappe.get_doc("Sales Order", source_name)
 		for item in so.items:
@@ -1051,7 +1053,7 @@ def create_pick_list(source_name: str, target_doc: str | Document | None = None)
 
 
 @frappe.whitelist()
-def make_subcontracting_inward_order(source_name: str, target_doc: str | Document | None = None):
+def make_subcontracting_inward_order(source_name: str, target_doc: str | dict | Document | None = None):
 	if not is_so_fully_subcontracted(source_name):
 		return get_mapped_subcontracting_inward_order(source_name, target_doc)
 	else:
@@ -1069,7 +1071,7 @@ def is_so_fully_subcontracted(so_name: str) -> bool:
 
 
 def get_mapped_subcontracting_inward_order(
-	source_name: str, target_doc: str | Document | None = None
+	source_name: str, target_doc: str | dict | Document | None = None
 ) -> Document:
 	def post_process(source_doc, target_doc):
 		if (

--- a/erpnext/stock/doctype/delivery_note/mapper.py
+++ b/erpnext/stock/doctype/delivery_note/mapper.py
@@ -60,7 +60,7 @@ def get_returned_qty_map(delivery_note: str) -> dict:
 
 @frappe.whitelist()
 def make_sales_invoice(
-	source_name: str, target_doc: str | Document | None = None, args: dict | str | None = None
+	source_name: str, target_doc: str | dict | Document | None = None, args: dict | str | None = None
 ):
 	from frappe.contacts.doctype.address.address import get_company_address
 
@@ -203,7 +203,7 @@ def make_sales_invoice(
 
 @frappe.whitelist()
 def make_delivery_trip(
-	source_name: str, target_doc: str | Document | None = None, kwargs: dict | None = None
+	source_name: str, target_doc: str | dict | Document | None = None, kwargs: dict | None = None
 ):
 	if not target_doc:
 		target_doc = frappe.new_doc("Delivery Trip")
@@ -235,7 +235,7 @@ def make_delivery_trip(
 
 @frappe.whitelist()
 def make_installation_note(
-	source_name: str, target_doc: str | Document | None = None, kwargs: dict | None = None
+	source_name: str, target_doc: str | dict | Document | None = None, kwargs: dict | None = None
 ):
 	def update_item(obj, target, source_parent):
 		target.qty = flt(obj.qty) - flt(obj.installed_qty)
@@ -264,7 +264,7 @@ def make_installation_note(
 
 
 @frappe.whitelist()
-def make_packing_slip(source_name: str, target_doc: str | Document | None = None):
+def make_packing_slip(source_name: str, target_doc: str | dict | Document | None = None):
 	def set_missing_values(source, target):
 		target.run_method("set_missing_values")
 
@@ -318,7 +318,7 @@ def make_packing_slip(source_name: str, target_doc: str | Document | None = None
 
 
 @frappe.whitelist()
-def make_shipment(source_name: str, target_doc: str | Document | None = None):
+def make_shipment(source_name: str, target_doc: str | dict | Document | None = None):
 	def postprocess(source, target):
 		user = frappe.db.get_value(
 			"User", frappe.session.user, ["email", "full_name", "phone", "mobile_no"], as_dict=1
@@ -399,14 +399,14 @@ def make_shipment(source_name: str, target_doc: str | Document | None = None):
 
 
 @frappe.whitelist()
-def make_sales_return(source_name: str, target_doc: str | Document | None = None):
+def make_sales_return(source_name: str, target_doc: str | dict | Document | None = None):
 	from erpnext.controllers.sales_and_purchase_return import make_return_doc
 
 	return make_return_doc("Delivery Note", source_name, target_doc)
 
 
 @frappe.whitelist()
-def make_inter_company_purchase_receipt(source_name: str, target_doc: str | Document | None = None):
+def make_inter_company_purchase_receipt(source_name: str, target_doc: str | dict | Document | None = None):
 	return make_inter_company_transaction("Delivery Note", source_name, target_doc)
 
 

--- a/erpnext/stock/doctype/material_request/mapper.py
+++ b/erpnext/stock/doctype/material_request/mapper.py
@@ -49,7 +49,7 @@ def update_item(obj, target, source_parent):
 
 @frappe.whitelist()
 def make_purchase_order(
-	source_name: str, target_doc: str | Document | None = None, args: dict | str | None = None
+	source_name: str, target_doc: str | dict | Document | None = None, args: dict | str | None = None
 ):
 	if args is None:
 		args = {}
@@ -115,7 +115,7 @@ def make_purchase_order(
 
 
 @frappe.whitelist()
-def make_request_for_quotation(source_name: str, target_doc: str | Document | None = None):
+def make_request_for_quotation(source_name: str, target_doc: str | dict | Document | None = None):
 	doclist = get_mapped_doc(
 		"Material Request",
 		source_name,
@@ -154,7 +154,7 @@ def get_items_based_on_default_supplier(supplier: str):
 
 @frappe.whitelist()
 def make_purchase_order_based_on_supplier(
-	source_name: str, target_doc: str | Document | None = None, args: dict | None = None
+	source_name: str, target_doc: str | dict | Document | None = None, args: dict | None = None
 ):
 	mr = source_name
 
@@ -198,7 +198,7 @@ def make_purchase_order_based_on_supplier(
 
 
 @frappe.whitelist()
-def make_supplier_quotation(source_name: str, target_doc: str | Document | None = None):
+def make_supplier_quotation(source_name: str, target_doc: str | dict | Document | None = None):
 	def postprocess(source, target_doc):
 		set_missing_values(source, target_doc)
 
@@ -228,7 +228,7 @@ def make_supplier_quotation(source_name: str, target_doc: str | Document | None 
 
 
 @frappe.whitelist()
-def make_stock_entry(source_name: str, target_doc: str | Document | None = None):
+def make_stock_entry(source_name: str, target_doc: str | dict | Document | None = None):
 	def update_item(obj, target, source_parent):
 		qty = (
 			flt(flt(obj.stock_qty) - flt(obj.ordered_qty)) / target.conversion_factor
@@ -335,7 +335,7 @@ def make_stock_entry(source_name: str, target_doc: str | Document | None = None)
 
 
 @frappe.whitelist()
-def create_pick_list(source_name: str, target_doc: str | Document | None = None):
+def create_pick_list(source_name: str, target_doc: str | dict | Document | None = None):
 	def update_item(obj, target, source_parent):
 		qty = flt((obj.stock_qty - obj.picked_qty) / target.conversion_factor, obj.precision("qty"))
 		target.qty = qty

--- a/erpnext/stock/doctype/pick_list/mapper.py
+++ b/erpnext/stock/doctype/pick_list/mapper.py
@@ -24,12 +24,14 @@ def validate_item_locations(pick_list):
 
 
 @frappe.whitelist()
-def create_delivery_note(source_name: str, target_doc: str | Document | None = None):
+def create_delivery_note(source_name: str, target_doc: str | dict | Document | None = None):
 	return create_delivery(source_name, target_doc, "Delivery Note")
 
 
 @frappe.whitelist()
-def create_delivery(source_name: str, target_doc: str | Document | None = None, target: str | None = None):
+def create_delivery(
+	source_name: str, target_doc: str | dict | Document | None = None, target: str | None = None
+):
 	pick_list = frappe.get_doc("Pick List", source_name)
 	target = target or (frappe.flags.args or {}).get("target") or "Delivery Note"
 	validate_item_locations(pick_list)
@@ -108,7 +110,7 @@ def create_delivery_wo_so(pick_list, target, target_doc=None):
 
 @frappe.whitelist()
 def create_dn_for_pick_lists(
-	source_name: str, target_doc: str | Document | None = None, kwargs: dict | str | None = None
+	source_name: str, target_doc: str | dict | Document | None = None, kwargs: dict | str | None = None
 ):
 	"""Get Items from Multiple Pick Lists and create a Delivery Note for filtered customer"""
 	if kwargs is None:

--- a/erpnext/stock/doctype/purchase_receipt/mapper.py
+++ b/erpnext/stock/doctype/purchase_receipt/mapper.py
@@ -56,7 +56,7 @@ def get_returned_qty_map(purchase_receipt: str) -> dict:
 
 @frappe.whitelist()
 def make_purchase_invoice(
-	source_name: str | None, target_doc: str | Document | None = None, args: dict | str | None = None
+	source_name: str | None, target_doc: str | dict | Document | None = None, args: dict | str | None = None
 ):
 	if args is None:
 		args = {}
@@ -179,14 +179,14 @@ def make_purchase_return_against_rejected_warehouse(source_name: str):
 
 
 @frappe.whitelist()
-def make_purchase_return(source_name: str, target_doc: str | Document | None = None):
+def make_purchase_return(source_name: str, target_doc: str | dict | Document | None = None):
 	from erpnext.controllers.sales_and_purchase_return import make_return_doc
 
 	return make_return_doc("Purchase Receipt", source_name, target_doc)
 
 
 @frappe.whitelist()
-def make_stock_entry(source_name: str, target_doc: str | Document | None = None):
+def make_stock_entry(source_name: str, target_doc: str | dict | Document | None = None):
 	def set_missing_values(source, target):
 		target.stock_entry_type = "Material Transfer"
 		target.purpose = "Material Transfer"
@@ -246,5 +246,5 @@ def make_stock_entry(source_name: str, target_doc: str | Document | None = None)
 
 
 @frappe.whitelist()
-def make_inter_company_delivery_note(source_name: str, target_doc: str | Document | None = None):
+def make_inter_company_delivery_note(source_name: str, target_doc: str | dict | Document | None = None):
 	return make_inter_company_transaction("Purchase Receipt", source_name, target_doc)

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -184,6 +184,21 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 		self.assertEqual(pi.payment_schedule[1].payment_amount, flt(pi.grand_total) / 2)
 		self.assertEqual(pi.payment_schedule[1].invoice_portion, 50)
 
+	def test_make_purchase_invoice_with_dict_target(self):
+		from frappe.model.mapper import map_docs
+
+		pr = make_purchase_receipt()
+		target = frappe.new_doc("Purchase Invoice").as_dict()
+
+		pi = map_docs(
+			method="erpnext.stock.doctype.purchase_receipt.mapper.make_purchase_invoice",
+			source_names=[pr.name],
+			target_doc=target,
+		)
+
+		self.assertEqual(pi.doctype, "Purchase Invoice")
+		self.assertEqual(len(pi.items), len(pr.items))
+
 	def test_purchase_receipt_no_gl_entry(self):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -489,7 +489,7 @@ def quality_inspection_query(
 
 
 @frappe.whitelist()
-def make_quality_inspection(source_name: str, target_doc: Document | str | None = None):
+def make_quality_inspection(source_name: str, target_doc: str | dict | Document | None = None):
 	def postprocess(source, doc):
 		doc.inspected_by = frappe.session.user
 		doc.get_quality_inspection_template()

--- a/erpnext/stock/doctype/stock_entry/services/subcontracting.py
+++ b/erpnext/stock/doctype/stock_entry/services/subcontracting.py
@@ -250,7 +250,7 @@ def get_supplied_items(
 
 
 @frappe.whitelist()
-def get_items_from_subcontract_order(source_name: str, target_doc: str | Document | None = None):
+def get_items_from_subcontract_order(source_name: str, target_doc: str | dict | Document | None = None):
 	from erpnext.controllers.subcontracting_controller import make_rm_stock_entry
 
 	target_doc = frappe.get_doc(frappe.parse_json(target_doc))

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1527,7 +1527,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 
 
 @frappe.whitelist()
-def make_stock_in_entry(source_name: str, target_doc: str | Document | None = None):
+def make_stock_in_entry(source_name: str, target_doc: str | dict | Document | None = None):
 	def set_missing_values(source, target):
 		target.stock_entry_type = "Material Transfer"
 		target.set_missing_values()

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -438,7 +438,7 @@ class SubcontractingOrder(SubcontractingController):
 
 
 @frappe.whitelist()
-def make_subcontracting_receipt(source_name: str, target_doc: Document | str | None = None):
+def make_subcontracting_receipt(source_name: str, target_doc: str | dict | Document | None = None):
 	items = frappe.flags.args.get("items") if frappe.flags.args else None
 	return get_mapped_subcontracting_receipt(source_name, target_doc, items=items)
 

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/mapper.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/mapper.py
@@ -16,7 +16,7 @@ def make_subcontract_return_against_rejected_warehouse(source_name: str):
 
 
 @frappe.whitelist()
-def make_subcontract_return(source_name: str, target_doc: Document | str | None = None):
+def make_subcontract_return(source_name: str, target_doc: str | dict | Document | None = None):
 	from erpnext.controllers.sales_and_purchase_return import make_return_doc
 
 	return make_return_doc("Subcontracting Receipt", source_name, target_doc)
@@ -25,7 +25,7 @@ def make_subcontract_return(source_name: str, target_doc: Document | str | None 
 @frappe.whitelist(methods=["POST"])
 def make_purchase_receipt(
 	source_name: Document | str,
-	target_doc: Document | str | None = None,
+	target_doc: str | dict | Document | None = None,
 	save: bool = False,
 	submit: bool = False,
 	notify: bool = False,

--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -269,7 +269,7 @@ def update_issue(contact, method):
 
 
 @frappe.whitelist()
-def make_task(source_name: str, target_doc: str | Document | None = None):
+def make_task(source_name: str, target_doc: str | dict | Document | None = None):
 	return get_mapped_doc("Issue", source_name, {"Issue": {"doctype": "Task"}}, target_doc)
 
 

--- a/erpnext/support/doctype/warranty_claim/warranty_claim.py
+++ b/erpnext/support/doctype/warranty_claim/warranty_claim.py
@@ -85,7 +85,7 @@ class WarrantyClaim(TransactionBase):
 
 
 @frappe.whitelist()
-def make_maintenance_visit(source_name: str, target_doc: str | Document | None = None):
+def make_maintenance_visit(source_name: str, target_doc: str | dict | Document | None = None):
 	from frappe.model.mapper import get_mapped_doc, map_child_doc
 
 	def _update_links(source_doc, target_doc, source_parent):


### PR DESCRIPTION
With native JSON request bodies, `map_docs` forwards `target_doc` as a parsed dict, which the `str | Document` type hints rejected — breaking every **Get Items From** button:

```
FrappeTypeError: Argument 'target_doc' in '...make_purchase_invoice' should be of type
'str | frappe.model.document.Document | None' but got 'dict' instead.
```

Unifies all whitelisted mapper endpoint hints to `str | dict | Document | None` and adds a test replaying the desk flow (dict of an unsaved target through `map_docs`).

Depends on frappe/frappe#41190 (`get_mapped_doc` dict conversion) — without it the dict passes validation but fails at `check_permission`.