### PR TITLE
fix: do not translate default record lookup keys

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -459,11 +459,11 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None, return_agai
 
 			# look for Print Heading "Credit Note"
 			if not doc.select_print_heading:
-				doc.select_print_heading = frappe.get_cached_value("Print Heading", _("Credit Note"))
+				doc.select_print_heading = frappe.get_cached_value("Print Heading", "Credit Note")
 
 		elif doctype == "Purchase Invoice":
 			# look for Print Heading "Debit Note"
-			doc.select_print_heading = frappe.get_cached_value("Print Heading", _("Debit Note"))
+			doc.select_print_heading = frappe.get_cached_value("Print Heading", "Debit Note")
 		elif doctype == "Delivery Note":
 			# manual additions to the return should hit the return warehous, too
 			doc.set_warehouse = default_warehouse_for_sales_return

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -23,7 +23,7 @@ from frappe.utils import (
 	nowdate,
 	today,
 )
-from frappe.utils.nestedset import NestedSet, rebuild_tree
+from frappe.utils.nestedset import NestedSet, get_root_of, rebuild_tree
 
 from erpnext.accounts.doctype.account.account import get_account_currency
 from erpnext.accounts.doctype.financial_report_template.financial_report_template import (
@@ -501,91 +501,92 @@ class Company(NestedSet):
 		)
 
 	def create_default_departments(self):
+		root = get_root_of("Department") or "All Departments"
 		records = [
 			# Department
 			{
 				"doctype": "Department",
-				"department_name": _("All Departments"),
+				"department_name": root,
 				"is_group": 1,
 				"parent_department": "",
-				"__condition": lambda: not frappe.db.exists("Department", _("All Departments")),
+				"__condition": lambda: not frappe.db.exists("Department", root),
 			},
 			{
 				"doctype": "Department",
 				"department_name": _("Accounts"),
-				"parent_department": _("All Departments"),
+				"parent_department": root,
 				"company": self.name,
 			},
 			{
 				"doctype": "Department",
 				"department_name": _("Marketing"),
-				"parent_department": _("All Departments"),
+				"parent_department": root,
 				"company": self.name,
 			},
 			{
 				"doctype": "Department",
 				"department_name": _("Sales"),
-				"parent_department": _("All Departments"),
+				"parent_department": root,
 				"company": self.name,
 			},
 			{
 				"doctype": "Department",
 				"department_name": _("Purchase"),
-				"parent_department": _("All Departments"),
+				"parent_department": root,
 				"company": self.name,
 			},
 			{
 				"doctype": "Department",
 				"department_name": _("Operations"),
-				"parent_department": _("All Departments"),
+				"parent_department": root,
 				"company": self.name,
 			},
 			{
 				"doctype": "Department",
 				"department_name": _("Production"),
-				"parent_department": _("All Departments"),
+				"parent_department": root,
 				"company": self.name,
 			},
 			{
 				"doctype": "Department",
 				"department_name": _("Dispatch"),
-				"parent_department": _("All Departments"),
+				"parent_department": root,
 				"company": self.name,
 			},
 			{
 				"doctype": "Department",
 				"department_name": _("Customer Service"),
-				"parent_department": _("All Departments"),
+				"parent_department": root,
 				"company": self.name,
 			},
 			{
 				"doctype": "Department",
 				"department_name": _("Human Resources"),
-				"parent_department": _("All Departments"),
+				"parent_department": root,
 				"company": self.name,
 			},
 			{
 				"doctype": "Department",
 				"department_name": _("Management"),
-				"parent_department": _("All Departments"),
+				"parent_department": root,
 				"company": self.name,
 			},
 			{
 				"doctype": "Department",
 				"department_name": _("Quality Management"),
-				"parent_department": _("All Departments"),
+				"parent_department": root,
 				"company": self.name,
 			},
 			{
 				"doctype": "Department",
 				"department_name": _("Research & Development"),
-				"parent_department": _("All Departments"),
+				"parent_department": root,
 				"company": self.name,
 			},
 			{
 				"doctype": "Department",
 				"department_name": _("Legal"),
-				"parent_department": _("All Departments"),
+				"parent_department": root,
 				"company": self.name,
 			},
 		]

--- a/erpnext/setup/doctype/company/test_company.py
+++ b/erpnext/setup/doctype/company/test_company.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 import json
+from unittest.mock import patch
 
 import frappe
 from frappe import _
 from frappe.query_builder.functions import IfNull
 from frappe.utils import random_string
+from frappe.utils.nestedset import get_root_of
 
 from erpnext.accounts.doctype.account.chart_of_accounts.chart_of_accounts import (
 	get_charts_for_country,
@@ -186,6 +188,31 @@ class TestCompany(ERPNextTestSuite):
 				return no_of_children
 
 		return get_no_of_children([company], 0)
+
+	def test_default_departments_ignore_session_translations(self):
+		self.assertEqual(get_root_of("Department"), "All Departments")
+
+		translations = {"All Departments": "Alle Abteilungen", "Accounts": "Buchhaltung"}
+		with patch("frappe.translate.get_all_translations", return_value=translations):
+			company = frappe.new_doc("Company")
+			company.company_name = "Dept Translation Test Co"
+			company.abbr = "DTTC"
+			company.default_currency = "INR"
+			company.country = "India"
+			company.insert()
+
+		self.assertFalse(frappe.db.exists("Department", "Alle Abteilungen"))
+		self.assertEqual(
+			frappe.get_all("Department", filters={"parent_department": ("is", "not set")}, pluck="name"),
+			["All Departments"],
+		)
+
+		departments = frappe.get_all(
+			"Department", filters={"company": company.name}, fields=["name", "parent_department"]
+		)
+		self.assertTrue(departments)
+		self.assertEqual({d.parent_department for d in departments}, {"All Departments"})
+		self.assertIn("Buchhaltung - DTTC", [d.name for d in departments])
 
 	def test_change_parent_company(self):
 		child_company = frappe.get_doc("Company", "_Test Company 5")

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -291,7 +291,7 @@ class Item(Document):
 		if not price_list:
 			price_list = frappe.get_single_value(
 				"Selling Settings", "selling_price_list"
-			) or frappe.db.get_value("Price List", _("Standard Selling"))
+			) or frappe.db.get_value("Price List", "Standard Selling")
 		if price_list:
 			item_price = frappe.get_doc(
 				{


### PR DESCRIPTION
`Company.create_default_departments` named and looked up the root Department with `_("All Departments")`, which resolves in the session language. A site set up in a non-English language stores the root under the translated name, and a company created later from a session in a different language misses it and inserts a second root, corrupting the Department tree.

Resolve the root once via `get_root_of("Department")` — falling back to the canonical English name on fresh installs, so existing sites with a translated root keep working — and reuse it for the root record, its exists-guard, and the child departments' parent.

Also stop translating lookups of records that `install_fixtures` stores under English names (it uses the identity `_`): Price List "Standard Selling" in `Item.add_price`, and Print Headings "Credit Note" / "Debit Note" in the return mapper.

Same bug class as #57345 (root Item Group, fixed in #57386). The regression test simulates a translated session and asserts company creation reuses the canonical root instead of inserting a translated duplicate.
