### PR TITLE
fix: do not translate root Item Group lookup key

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -32,8 +32,11 @@ class ItemGroup(NestedSet):
 
 	def validate(self):
 		if not self.parent_item_group and not frappe.in_test:
-			if frappe.db.exists("Item Group", "All Item Groups"):
-				self.parent_item_group = "All Item Groups"
+			root = frappe.db.get_value(
+				"Item Group", {"parent_item_group": ("is", "not set"), "is_group": 1}, order_by="lft asc"
+			)
+			if root and root != self.name:
+				self.parent_item_group = root
 		self.validate_item_group_defaults()
 		self.check_item_tax()
 

--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -32,8 +32,8 @@ class ItemGroup(NestedSet):
 
 	def validate(self):
 		if not self.parent_item_group and not frappe.in_test:
-			if frappe.db.exists("Item Group", _("All Item Groups")):
-				self.parent_item_group = _("All Item Groups")
+			if frappe.db.exists("Item Group", "All Item Groups"):
+				self.parent_item_group = "All Item Groups"
 		self.validate_item_group_defaults()
 		self.check_item_tax()
 


### PR DESCRIPTION
`ItemGroup.validate()` looked up the tree root with `_("All Item Groups")`, which resolves in the session language. For non-English users the lookup missed the root (stored in English by `install_fixtures`), so new groups saved with a blank parent became uneditable second roots.

Use `get_root_of` like sibling tree doctypes (e.g. Customer Group), so the default also works on legacy sites whose root was created under a translated name or renamed. Guard against self-parenting since `get_root_of` returns the root itself when the root doc is saved.

Supersedes #57386 (stale head after force-push).

Closes #57345