### PR TITLE
refactor: use get_root_of for Item Group root resolution

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -4,7 +4,7 @@
 
 import frappe
 from frappe import _
-from frappe.utils.nestedset import NestedSet
+from frappe.utils.nestedset import NestedSet, get_root_of
 
 
 class ItemGroup(NestedSet):
@@ -32,9 +32,7 @@ class ItemGroup(NestedSet):
 
 	def validate(self):
 		if not self.parent_item_group and not frappe.in_test:
-			root = frappe.db.get_value(
-				"Item Group", {"parent_item_group": ("is", "not set"), "is_group": 1}, order_by="lft asc"
-			)
+			root = get_root_of(self.doctype)
 			if root and root != self.name:
 				self.parent_item_group = root
 		self.validate_item_group_defaults()


### PR DESCRIPTION
Follow-up to #57390: replace the hand-rolled parentless-group query with `get_root_of(self.doctype)`, matching sibling tree doctypes like Customer Group. The self-parenting guard stays since `get_root_of` returns the root itself when the root doc is saved.