### PR TITLE
fix: guard against missing is_your_company_address custom field on ad…

### DIFF
--- a/erpnext/accounts/custom/address.py
+++ b/erpnext/accounts/custom/address.py
@@ -17,7 +17,7 @@ class ERPNextAddress(Address):
 
 	def link_address(self):
 		"""Link address based on owner"""
-		if self.is_your_company_address:
+		if self.get("is_your_company_address"):
 			return
 
 		return super().link_address()
@@ -28,7 +28,9 @@ class ERPNextAddress(Address):
 				self.is_your_company_address = 1
 
 	def validate_reference(self):
-		if self.is_your_company_address and not [row for row in self.links if row.link_doctype == "Company"]:
+		if self.get("is_your_company_address") and not [
+			row for row in self.links if row.link_doctype == "Company"
+		]:
 			frappe.throw(
 				_(
 					"Address needs to be linked to a Company. Please add a row for Company in the Links table."


### PR DESCRIPTION
**Description:** is_your_company_address isn't a native Address field — it's an optional custom field created programmatically on install. The controller reads it as a bare attribute (self.is_your_company_address), so if that field is ever missing from the meta (e.g., an interrupted migration, since the migrate_address_contact_custom_fields patch deletes then recreates it), saving any Address crashes with AttributeError: 'ExtendedAddress' object has no attribute 'is_your_company_address'. Switched to self.get("is_your_company_address") so a missing field degrades to None instead of throwing; behavior on a normal site (field present) is unchanged.

Fixes: #57349

Before:

<img width="1280" height="616" alt="image" src="https://github.com/user-attachments/assets/a8391cf0-ce6f-46fa-8001-fcb7531b06ff" />


After:

<img width="1836" height="920" alt="image" src="https://github.com/user-attachments/assets/2faf779d-62ad-4d29-b231-6f6100b6340e" />


Backport Needed for v16 and V15