### PR TITLE
refactor: drop translation marking from default warehouse names

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -448,23 +448,18 @@ class Company(NestedSet):
 		frappe.clear_cache()
 
 	def create_default_warehouses(self):
-		from erpnext.setup.utils import identity as _
-
 		parent_warehouse = None
 		for wh_detail in [
-			{"warehouse_name": _("All Warehouses"), "is_group": 1},
-			{"warehouse_name": _("Stores"), "is_group": 0},
-			{"warehouse_name": _("Work In Progress"), "is_group": 0},
-			{"warehouse_name": _("Finished Goods"), "is_group": 0},
-			{"warehouse_name": _("Goods In Transit"), "is_group": 0, "warehouse_type": "Transit"},
+			{"warehouse_name": "All Warehouses", "is_group": 1},
+			{"warehouse_name": "Stores", "is_group": 0},
+			{"warehouse_name": "Work In Progress", "is_group": 0},
+			{"warehouse_name": "Finished Goods", "is_group": 0},
+			{"warehouse_name": "Goods In Transit", "is_group": 0, "warehouse_type": "Transit"},
 		]:
 			if frappe.db.exists(
 				"Warehouse",
 				{
-					"warehouse_name": (
-						"in",
-						(wh_detail["warehouse_name"], frappe._(wh_detail["warehouse_name"])),
-					),
+					"warehouse_name": ("in", (wh_detail["warehouse_name"], _(wh_detail["warehouse_name"]))),
 					"company": self.name,
 				},
 			):


### PR DESCRIPTION
Follow-up to #57392, which created the default warehouses under identity-`_` so the names stayed in the POT. The marking serves nothing: `warehouse_name` is a Data field shown as stored, and everywhere else users see the docname, which carries the company abbr ("Stores - F") and is never translated — a translated bare "Stores" has no display use. Use plain literals.

The exists-guard keeps the runtime session-translation match that protects legacy sites from duplicate English warehouses, and the `_("Stores")` legacy fallback in item.py keeps "Stores" extracted.