### PR TITLE
revert: canonical default warehouse names (#57392, #57409)

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -448,8 +448,6 @@ class Company(NestedSet):
 		frappe.clear_cache()
 
 	def create_default_warehouses(self):
-		from erpnext.setup.utils import identity as _
-
 		parent_warehouse = None
 		for wh_detail in [
 			{"warehouse_name": _("All Warehouses"), "is_group": 1},
@@ -461,10 +459,7 @@ class Company(NestedSet):
 			if frappe.db.exists(
 				"Warehouse",
 				{
-					"warehouse_name": (
-						"in",
-						(wh_detail["warehouse_name"], frappe._(wh_detail["warehouse_name"])),
-					),
+					"warehouse_name": wh_detail["warehouse_name"],
 					"company": self.name,
 				},
 			):

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -448,18 +448,23 @@ class Company(NestedSet):
 		frappe.clear_cache()
 
 	def create_default_warehouses(self):
+		from erpnext.setup.utils import identity as _
+
 		parent_warehouse = None
 		for wh_detail in [
-			{"warehouse_name": "All Warehouses", "is_group": 1},
-			{"warehouse_name": "Stores", "is_group": 0},
-			{"warehouse_name": "Work In Progress", "is_group": 0},
-			{"warehouse_name": "Finished Goods", "is_group": 0},
-			{"warehouse_name": "Goods In Transit", "is_group": 0, "warehouse_type": "Transit"},
+			{"warehouse_name": _("All Warehouses"), "is_group": 1},
+			{"warehouse_name": _("Stores"), "is_group": 0},
+			{"warehouse_name": _("Work In Progress"), "is_group": 0},
+			{"warehouse_name": _("Finished Goods"), "is_group": 0},
+			{"warehouse_name": _("Goods In Transit"), "is_group": 0, "warehouse_type": "Transit"},
 		]:
 			if frappe.db.exists(
 				"Warehouse",
 				{
-					"warehouse_name": ("in", (wh_detail["warehouse_name"], _(wh_detail["warehouse_name"]))),
+					"warehouse_name": (
+						"in",
+						(wh_detail["warehouse_name"], frappe._(wh_detail["warehouse_name"])),
+					),
 					"company": self.name,
 				},
 			):

--- a/erpnext/setup/doctype/company/test_company.py
+++ b/erpnext/setup/doctype/company/test_company.py
@@ -15,7 +15,6 @@ from erpnext.accounts.doctype.account.chart_of_accounts.chart_of_accounts import
 from erpnext.accounts.doctype.account.test_account import create_account
 from erpnext.setup.doctype.company.company import get_default_company_address
 from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
-from erpnext.stock.doctype.item.item import get_stores_warehouse
 from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 from erpnext.tests.utils import ERPNextTestSuite
@@ -214,34 +213,6 @@ class TestCompany(ERPNextTestSuite):
 		self.assertTrue(departments)
 		self.assertEqual({d.parent_department for d in departments}, {"All Departments"})
 		self.assertIn("Buchhaltung - DTTC", [d.name for d in departments])
-
-	def test_default_warehouses_ignore_session_translations(self):
-		translations = {"Stores": "Lager", "All Warehouses": "Alle Lagerhäuser"}
-		with patch("frappe.translate.get_all_translations", return_value=translations):
-			company = frappe.new_doc("Company")
-			company.company_name = "Warehouse Translation Test Co"
-			company.abbr = "WTTC"
-			company.default_currency = "INR"
-			company.country = "India"
-			company.insert()
-
-			self.assertEqual(get_stores_warehouse(company.name), "Stores - WTTC")
-
-		warehouse_names = frappe.get_all("Warehouse", filters={"company": company.name}, pluck="name")
-		for warehouse_name in (
-			"All Warehouses",
-			"Stores",
-			"Work In Progress",
-			"Finished Goods",
-			"Goods In Transit",
-		):
-			self.assertIn(f"{warehouse_name} - WTTC", warehouse_names)
-		self.assertNotIn("Lager - WTTC", warehouse_names)
-		self.assertEqual(get_stores_warehouse(company.name), "Stores - WTTC")
-
-		frappe.db.set_value("Warehouse", "Stores - WTTC", "warehouse_name", "Lager", update_modified=False)
-		with patch("frappe.translate.get_all_translations", return_value=translations):
-			self.assertEqual(get_stores_warehouse(company.name), "Stores - WTTC")
 
 	def test_change_parent_company(self):
 		child_company = frappe.get_doc("Company", "_Test Company 5")

--- a/erpnext/setup/setup_wizard/operations/defaults_setup.py
+++ b/erpnext/setup/setup_wizard/operations/defaults_setup.py
@@ -30,7 +30,7 @@ def set_default_settings(args):
 	stock_settings = frappe.get_doc("Stock Settings")
 	stock_settings.item_naming_by = "Item Code"
 	stock_settings.valuation_method = "FIFO"
-	stock_settings.default_warehouse = frappe.db.get_value("Warehouse", {"warehouse_name": "Stores"})
+	stock_settings.default_warehouse = frappe.db.get_value("Warehouse", {"warehouse_name": _("Stores")})
 	stock_settings.stock_uom = "Nos"
 	stock_settings.auto_indent = 1
 	stock_settings.auto_insert_price_list_rate_if_missing = 1

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -328,7 +328,9 @@ class Item(Document):
 				warehouse_company = frappe.db.get_value("Warehouse", default_warehouse, "company")
 
 			if not default_warehouse or warehouse_company != default.company:
-				default_warehouse = get_stores_warehouse(default.company)
+				default_warehouse = frappe.db.get_value(
+					"Warehouse", {"warehouse_name": _("Stores"), "company": default.company}
+				)
 
 			if default_warehouse:
 				opening_account = frappe.db.get_value(
@@ -1774,7 +1776,7 @@ def get_default_warehouse_for_opening_stock(item, company: str, warehouse: str |
 		if warehouse_company == company:
 			return settings_warehouse
 
-	stores_warehouse = get_stores_warehouse(company)
+	stores_warehouse = frappe.db.get_value("Warehouse", {"warehouse_name": _("Stores"), "company": company})
 
 	if stores_warehouse:
 		return stores_warehouse
@@ -1784,17 +1786,6 @@ def get_default_warehouse_for_opening_stock(item, company: str, warehouse: str |
 			"No warehouse found for company {0}. Please set a Default Warehouse in Item Defaults or Stock Settings."
 		).format(frappe.bold(company))
 	)
-
-
-def get_stores_warehouse(company: str) -> str | None:
-	stores_warehouse = frappe.db.get_value("Warehouse", {"warehouse_name": "Stores", "company": company})
-
-	if not stores_warehouse and _("Stores") != "Stores":
-		stores_warehouse = frappe.db.get_value(
-			"Warehouse", {"warehouse_name": _("Stores"), "company": company}
-		)
-
-	return stores_warehouse
 
 
 def on_doctype_update():

--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -246,7 +246,7 @@ class BootStrapTestData:
 		stock_settings = frappe.get_doc("Stock Settings")
 		stock_settings.item_naming_by = "Item Code"
 		stock_settings.valuation_method = "FIFO"
-		stock_settings.default_warehouse = frappe.db.get_value("Warehouse", {"warehouse_name": "Stores"})
+		stock_settings.default_warehouse = frappe.db.get_value("Warehouse", {"warehouse_name": _("Stores")})
 		stock_settings.stock_uom = "Nos"
 		stock_settings.auto_indent = 1
 		stock_settings.auto_insert_price_list_rate_if_missing = 1


### PR DESCRIPTION
Reverts #57392 and #57409, restoring the tree to its exact pre-#57392 state (the combined diff against a81524ea14e is empty).