### PR TITLE
fix: map pick list customer to delivery note when no sales order

### DIFF
--- a/erpnext/stock/doctype/pick_list/mapper.py
+++ b/erpnext/stock/doctype/pick_list/mapper.py
@@ -89,6 +89,9 @@ def create_delivery_wo_so(pick_list, target, target_doc=None):
 
 	target_doc.company = pick_list.company
 
+	if not target_doc.customer:
+		target_doc.customer = pick_list.customer
+
 	item_table_mapper_without_so = {
 		"doctype": f"{target} Item",
 		"field_map": {


### PR DESCRIPTION
**Issue:** #[57337](https://github.com/frappe/erpnext/issues/57337)

**Description:** When a Pick List has a Customer set but no Sales Order linked, clicking "Create Delivery Note" creates a Delivery Note with a blank Customer field. This happens because the code only copies the Customer from a Sales Order, and never falls back to the Pick List's own Customer field when there's no Sales Order.

**Before:**

[Screencast from 2026-07-23 17-17-11.webm](https://github.com/user-attachments/assets/0fdfdc25-9725-4aed-a435-54731db9644a)


**After:**

[Screencast from 2026-07-23 17-16-24.webm](https://github.com/user-attachments/assets/4fcaafb6-a767-4069-9129-4d11129a0585)


**Backport needed for v15, v16**
