### PR TITLE
fix: typeerror in get_batches_by_oldest for mixed batch expiry

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -297,7 +297,7 @@ def get_batches_by_oldest(item_code: str, warehouse: str):
 	"""Returns the oldest batch and qty for the given item_code and warehouse"""
 	batches = get_batch_qty(item_code=item_code, warehouse=warehouse)
 	batches_dates = [[batch, frappe.get_value("Batch", batch.batch_no, "expiry_date")] for batch in batches]
-	batches_dates.sort(key=lambda tup: tup[1])
+	batches_dates.sort(key=lambda tup: (tup[1] is None, tup[1]))
 	return batches_dates
 
 


### PR DESCRIPTION
**Issue**: get_batches_by_oldest raises **TypeError** when a warehouse has both dated and non-expiring batches

**Description:**

erpnext.stock.doctype.batch.batch.get_batches_by_oldest sorts batches directly on their expiry_date:

batches_dates = [[batch, frappe.get_value("Batch", batch.batch_no, "expiry_date")] for batch in batches]
batches_dates.sort(key=lambda tup: tup[1])

expiry_date is nullable — it is only set when the linked Item has lf_life_in_days. So for a single item/warehouse, the list can hold a mix of datetime. date values and None. Python 3 can order-compare None against a date, and list. sort compares elements against each other, so the call raises:

**TypeError: '<' not supported between instances of 'NoneType'**

**Before:**

<img width="1841" height="823" alt="image" src="https://github.com/user-attachments/assets/5059de80-184f-4f8a-b5ed-b0c785eca6fd" />

**After:**

<img width="1078" height="394" alt="image" src="https://github.com/user-attachments/assets/fcd243a6-575d-4742-8cdf-33096e6b1f36" />



**Steps to reproduce:**

1. Create a batch-enabled Item without has_expiry_date / shelf_life
2. Create two batches for it in the same warehouse and receive stock into each.
3. Give one batch an expiry_date and leave the other with none (NULL).
4. Call the whitelisted method:
from erpnext.stock.doctype.batch.batch import get_batches_by_oldest
get_batches_by_oldest("<item_code>", "<warehouse>")

**Expected behavior:**

Returns the batches sorted by expiry (oldest first) without error.

**Actual behavior**

Raises TypeError: '<' not supported between instances of 'NoneType' and 'datetime.date' at batch.py:300. As a whitelisted API, it surfaces as an HTTP 500 / "Server Error" dialog.

File ".../erpnext/stock/doctype/batch/batch.py", line 300, in get_batches_by_oldest
    batches_dates.sort(key=lambda tup: tup[1])
TypeError: '<' not supported between instances of 'NoneType' and 'datetime.date'

**Backport Needed For V16 and V15**