### PR TITLE
fix: don't require cancel and delete perms to remove items via Update Items

### DIFF
--- a/erpnext/accounts/services/child_item_update.py
+++ b/erpnext/accounts/services/child_item_update.py
@@ -432,6 +432,7 @@ def validate_and_delete_children(parent, data, ordered_item=None) -> bool:
 
 	for d in deleted_children:
 		validate_child_on_delete(d, parent, ordered_item)
+		d.flags.ignore_permissions = True
 		d.cancel()
 		d.delete()
 

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -691,6 +691,44 @@ class TestSalesOrder(ERPNextTestSuite):
 				frappe.ValidationError, update_child_qty_rate, "Sales Order", trans_item, so.name
 			)
 
+	def test_update_child_removing_item_without_cancel_and_delete_perms(self):
+		role = "_Test Sales Order Item Editor"
+		if not frappe.db.exists("Role", role):
+			frappe.get_doc({"doctype": "Role", "role_name": role, "desk_access": 1}).insert()
+
+		frappe.permissions.add_permission("Sales Order", role, 0)
+		for right, value in {
+			"read": 1,
+			"write": 1,
+			"create": 1,
+			"submit": 1,
+			"cancel": 0,
+			"delete": 0,
+		}.items():
+			frappe.permissions.update_permission_property("Sales Order", role, 0, right, value)
+		frappe.clear_cache()
+
+		so = make_sales_order(**{"item_list": [{"item_code": "_Test Item", "qty": 5, "rate": 1000}]})
+		trans_item = json.dumps(
+			[
+				{"item_code": "_Test Item", "qty": 5, "rate": 1000, "docname": so.items[0].name},
+				{"item_code": "_Test Item 2", "qty": 2, "rate": 500},
+			]
+		)
+		update_child_qty_rate("Sales Order", trans_item, so.name)
+		so.reload()
+		self.assertEqual(len(so.items), 2)
+
+		test_user = create_user("test_so_item_editor@example.com", role, "Accounts User", "Stock User")
+		trans_item = json.dumps(
+			[{"item_code": "_Test Item", "qty": 5, "rate": 1000, "docname": so.items[0].name}]
+		)
+		with self.set_user(test_user.name):
+			update_child_qty_rate("Sales Order", trans_item, so.name)
+
+		so.reload()
+		self.assertEqual(len(so.items), 1)
+
 	def test_update_child_qty_rate_with_workflow(self):
 		from frappe.model.workflow import apply_workflow
 

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -692,6 +692,13 @@ class TestSalesOrder(ERPNextTestSuite):
 			)
 
 	def test_update_child_removing_item_without_cancel_and_delete_perms(self):
+		for workflow_name in frappe.get_all(
+			"Workflow", filters={"document_type": "Sales Order", "is_active": 1}, pluck="name"
+		):
+			workflow = frappe.get_doc("Workflow", workflow_name)
+			workflow.is_active = 0
+			workflow.save()
+
 		role = "_Test Sales Order Item Editor"
 		if not frappe.db.exists("Role", role):
 			frappe.get_doc({"doctype": "Role", "role_name": role, "desk_access": 1}).insert()


### PR DESCRIPTION
## Problem
Row removal in **Update Items** fails with `Not permitted` for users holding Write but not Cancel/Delete on the order. 
Error message is misleading ("valid parent DocType for Sales Order Item").

## Cause
`validate_and_delete_children` calls `d.cancel()` and `d.delete()`, both of which check permissions against the parent doctype; so dropping a row requires Cancel + Delete on Sales Order. 
The rest of the dialog only needs Write (button gated on `has_perm("write")`, `update_child_qty_rate` checks parent Write, edits save with `ignore_permissions=True`).

## Fix
Set `ignore_permissions` on the row before cancel/delete. Removal now sits behind the same parent Write check as add/edit. `validate_child_on_delete` unchanged - rows with ordered/received/delivered/billed qty still refused.

## Note
Will handle misleading error in FW.