### PR TITLE
fix: update doc status in period closing voucher

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -14,6 +14,7 @@ from erpnext.accounts.doctype.account_closing_balance.account_closing_balance im
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
 )
+from erpnext.accounts.general_ledger import check_freezing_date, is_immutable_ledger_enabled
 from erpnext.accounts.utils import get_account_currency, get_fiscal_year
 from erpnext.controllers.accounts_controller import AccountsController
 
@@ -45,6 +46,14 @@ class PeriodClosingVoucher(AccountsController):
 		self.block_if_future_closing_voucher_exists()
 		self.check_closing_account_type()
 		self.check_closing_account_currency()
+		self.validate_accounts_not_frozen()
+
+	def validate_accounts_not_frozen(self, for_cancellation=False):
+		posting_date = self.period_end_date
+		if for_cancellation and is_immutable_ledger_enabled():
+			posting_date = getdate()
+
+		check_freezing_date(posting_date, self.company)
 
 	def validate_start_and_end_date(self):
 		self.fy_start_date, self.fy_end_date = frappe.db.get_value(
@@ -149,6 +158,7 @@ class PeriodClosingVoucher(AccountsController):
 			"Process Period Closing Voucher",
 		)
 		self.block_if_future_closing_voucher_exists()
+		self.validate_accounts_not_frozen(for_cancellation=True)
 
 		if not frappe.get_single_value("Accounts Settings", "use_legacy_controller_for_pcv"):
 			self.cancel_process_pcv_docs()


### PR DESCRIPTION
**Issue:** [#57406](https://github.com/frappe/erpnext/issues/57406)
[#74562](https://support.frappe.io/helpdesk/tickets/74562?view=VIEW-HD+Ticket-745)

**Description:** Submitting/cancelling a PCV against a frozen accounts date (or closed period) left the UI showing the new status while the DB reverted, because the synchronous path did a manual db.rollback() mid-transaction and recorded "Failed". Re-raise on the synchronous path (via an in_background flag set only from the enqueue calls) so the framework rolls back atomically and surfaces the real error.

**Before:**

[Screencast from 2026-07-24 12-07-39.webm](https://github.com/user-attachments/assets/14869726-286f-4ac6-92c8-7578ef00845a)


**After:**

[Screencast from 2026-07-24 11-58-08.webm](https://github.com/user-attachments/assets/8032e26d-fd4f-4c94-8b30-da8324b127d0)

