### PR TITLE
fix(accounts): respect user permissions in party dashboard company list

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -869,7 +869,7 @@ def get_dashboard_info(party_type, party, loyalty_program=None):
 
 	doctype = "Sales Invoice" if party_type == "Customer" else "Purchase Invoice"
 
-	companies = frappe.get_all(
+	companies = frappe.get_list(
 		doctype, filters={"docstatus": 1, party_type.lower(): party}, distinct=1, fields=["company"]
 	)
 


### PR DESCRIPTION
**Description:**
get_dashboard_info in erpnext/accounts/party.py builds the list of companies for a party's dashboard (the connections/summary shown on a Customer/Supplier form) using frappe.get_all, which bypasses user permissions.

When a party has invoices across multiple companies, and the logged-in user is restricted (via User Permission) to only a subset of those companies, the function still iterates over all companies and calls get_party_account for each. For a company the user cannot access, get_party_account's permission check throws, breaking the whole dashboard.

The fix switches that query from frappe.get_all to frappe.get_list, so the company list honors the user's permissions. Companies the user has no access to are simply excluded (also closing an incidental data leak of their billing/unpaid totals).

**Fixes** :frappe/erpnext#57428


**Steps to Reproduce:**

1. Have 2+ companies in the system (e.g. Company A, Company B).
2. Create a Customer/Supplier with submitted invoices in both companies.
3. Create a user with a role that grants only select permission on Account (e.g. Accounts User), and add a User Permission restricting them to Company A only.
4. Log in as that user and open the Customer/Supplier document (which triggers the dashboard).
2. Create a Customer/Supplier with submitted invoices in both companies.
3. Create a user with a role that grants only select permission on Account (e.g. Accounts User), and add a User Permission restricting them to Company A only.
4. Log in as that user and open the Customer/Supplier document (which triggers the dashboard).

**Actual Behaviour**

The document fails to load the dashboard and throws: **User doesn't have permissions to select/read this account.**

**Expected Behaviour:**

The dashboard loads successfully, showing summary info only for the companies the user is permitted to access (Company A), with no permission error. 

**Backport Needed For V16 and V15**