### PR TITLE
fix: rename misleading filter labels in AR/AP reports

### DIFF
--- a/erpnext/accounts/report/accounts_payable/accounts_payable.js
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.js
@@ -13,7 +13,7 @@ frappe.query_reports["Accounts Payable"] = {
 		},
 		{
 			fieldname: "report_date",
-			label: __("Posting Date"),
+			label: __("Report Date"),
 			fieldtype: "Date",
 			default: frappe.datetime.get_today(),
 		},
@@ -69,10 +69,10 @@ frappe.query_reports["Accounts Payable"] = {
 			default: "Due Date",
 		},
 		{
-			fieldname: "calculate_ageing_with",
-			label: __("Calculate Ageing With"),
+			fieldname: "age_as_on",
+			label: __("Age as on"),
 			fieldtype: "Select",
-			options: "Report Date\nToday Date",
+			options: "Report Date\nToday",
 			default: "Report Date",
 		},
 		{

--- a/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
+++ b/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
@@ -12,7 +12,7 @@ frappe.query_reports["Accounts Payable Summary"] = {
 		},
 		{
 			fieldname: "report_date",
-			label: __("Posting Date"),
+			label: __("Report Date"),
 			fieldtype: "Date",
 			default: frappe.datetime.get_today(),
 		},
@@ -24,10 +24,10 @@ frappe.query_reports["Accounts Payable Summary"] = {
 			default: "Due Date",
 		},
 		{
-			fieldname: "calculate_ageing_with",
-			label: __("Calculate Ageing With"),
+			fieldname: "age_as_on",
+			label: __("Age as on"),
 			fieldtype: "Select",
-			options: "Report Date\nToday Date",
+			options: "Report Date\nToday",
 			default: "Report Date",
 		},
 		{

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -15,7 +15,7 @@ frappe.query_reports["Accounts Receivable"] = {
 		},
 		{
 			fieldname: "report_date",
-			label: __("Posting Date"),
+			label: __("Report Date"),
 			fieldtype: "Date",
 			default: frappe.datetime.get_today(),
 		},
@@ -98,10 +98,10 @@ frappe.query_reports["Accounts Receivable"] = {
 			default: "Due Date",
 		},
 		{
-			fieldname: "calculate_ageing_with",
-			label: __("Calculate Ageing With"),
+			fieldname: "age_as_on",
+			label: __("Age as on"),
 			fieldtype: "Select",
-			options: "Report Date\nToday Date",
+			options: "Report Date\nToday",
 			default: "Report Date",
 		},
 		{

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -54,8 +54,7 @@ class ReceivablePayableReport:
 		self.filters.report_date = getdate(self.filters.report_date or nowdate())
 		self.age_as_on = (
 			getdate(nowdate())
-			if "calculate_ageing_with" not in self.filters
-			or self.filters.calculate_ageing_with == "Today Date"
+			if "age_as_on" not in self.filters or self.filters.age_as_on == "Today"
 			else self.filters.report_date
 		)
 

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
@@ -12,7 +12,7 @@ frappe.query_reports["Accounts Receivable Summary"] = {
 		},
 		{
 			fieldname: "report_date",
-			label: __("Posting Date"),
+			label: __("Report Date"),
 			fieldtype: "Date",
 			default: frappe.datetime.get_today(),
 		},
@@ -24,10 +24,10 @@ frappe.query_reports["Accounts Receivable Summary"] = {
 			default: "Due Date",
 		},
 		{
-			fieldname: "calculate_ageing_with",
-			label: __("Calculate Ageing With"),
+			fieldname: "age_as_on",
+			label: __("Age as on"),
 			fieldtype: "Select",
-			options: "Report Date\nToday Date",
+			options: "Report Date\nToday",
 			default: "Report Date",
 		},
 		{

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -502,3 +502,4 @@ erpnext.patches.v16_0.access_control_for_project_users
 erpnext.patches.v16_0.enable_book_stock_expense_gl_entries
 execute:frappe.db.set_single_value("Stock Settings", "use_inline_serial_batch_editor", 0)
 erpnext.patches.v16_0.recompute_production_plan_reserved_qty
+erpnext.patches.v16_0.rename_ar_ap_ageing_filter

--- a/erpnext/patches/v16_0/rename_ar_ap_ageing_filter.py
+++ b/erpnext/patches/v16_0/rename_ar_ap_ageing_filter.py
@@ -1,0 +1,45 @@
+import frappe
+
+REPORTS = (
+	"Accounts Receivable",
+	"Accounts Payable",
+	"Accounts Receivable Summary",
+	"Accounts Payable Summary",
+)
+
+
+def execute():
+	# filter `calculate_ageing_with` -> `age_as_on`, option "Today Date" -> "Today"
+	_migrate("Auto Email Report", "filters", "report")
+	_migrate("Dashboard Chart", "filters_json", "report_name", type_field="chart_type")
+	_migrate("Number Card", "filters_json", "report_name", type_field="type")
+
+
+def _migrate(doctype, filter_field, report_field, type_field=None):
+	conditions = {report_field: ("in", REPORTS)}
+	if type_field:
+		conditions[type_field] = "Report"
+
+	for row in frappe.get_all(doctype, filters=conditions, fields=["name", filter_field]):
+		updated = _rewrite(row.get(filter_field))
+		if updated is not None:
+			frappe.db.set_value(doctype, row.name, filter_field, updated, update_modified=False)
+
+
+def _rewrite(raw):
+	if not raw:
+		return None
+
+	try:
+		filters = frappe.parse_json(raw)
+	except ValueError:
+		return None
+
+	if not isinstance(filters, dict) or "calculate_ageing_with" not in filters:
+		return None
+
+	filters["age_as_on"] = filters.pop("calculate_ageing_with")
+	if filters["age_as_on"] == "Today Date":
+		filters["age_as_on"] = "Today"
+
+	return frappe.as_json(filters, indent=None)


### PR DESCRIPTION
Renames filter labels in Accounts Receivable, Accounts Payable, and both Summary reports to match their actual behaviour:

- "Posting Date" → "Report Date" (it acts as an *as-on* date)
- "Calculate Ageing With" → "Age as on"; option "Today Date" → "Today"

Fieldname `calculate_ageing_with` renamed to `age_as_on` and updated in the backend.

Closes #57442