### PR TITLE
fix: reject zero quantity in return document validation

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2025,6 +2025,14 @@ class TestSalesInvoice(ERPNextTestSuite):
 		cr_note.items[0].qty = 0
 		self.assertRaises(frappe.ValidationError, cr_note.save)
 
+	def test_zero_qty_return_invoice_without_update_stock(self):
+		si = create_sales_invoice(qty=1, rate=100)
+		cr_note = create_sales_invoice(
+			qty=-1, rate=100, is_return=1, return_against=si.name, do_not_save=True
+		)
+		cr_note.items[0].qty = 0
+		self.assertRaises(frappe.ValidationError, cr_note.save)
+
 	def test_return_invoice_with_account_mismatch(self):
 		debtors2 = create_account(
 			parent_account="Accounts Receivable - _TC",

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -118,6 +118,7 @@ def validate_returned_items(doc):
 	)
 
 	items_returned = False
+	has_negative_return_qty = False
 	for d in doc.get("items"):
 		key = d.item_code
 		raise_exception = False
@@ -161,12 +162,16 @@ def validate_returned_items(doc):
 					frappe.throw(_("Warehouse is mandatory"))
 
 			items_returned = True
+			if flt(d.qty) < 0 or flt(d.get("received_qty")) < 0 or flt(d.get("rejected_qty")) < 0:
+				has_negative_return_qty = True
 
 		elif d.item_name:
 			items_returned = True
 
 	if not items_returned:
 		frappe.throw(_("At least one item should be entered with negative quantity in return document"))
+	elif not has_negative_return_qty:
+		frappe.throw(_("At least one item must have a negative quantity in the return document"))
 
 
 def validate_quantity(doc, key, args, ref, valid_items, already_returned_items):
@@ -215,7 +220,7 @@ def validate_quantity(doc, key, args, ref, valid_items, already_returned_items):
 		label = column.replace("_", " ").title()
 
 		if reference_qty:
-			if flt(args.get(column)) >= 0:
+			if flt(args.get(column)) > 0:
 				frappe.throw(_("{0} must be negative in return document").format(label))
 			elif returned_qty >= reference_qty and args.get(column) >= 0:
 				frappe.throw(

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -215,7 +215,7 @@ def validate_quantity(doc, key, args, ref, valid_items, already_returned_items):
 		label = column.replace("_", " ").title()
 
 		if reference_qty:
-			if flt(args.get(column)) > 0:
+			if flt(args.get(column)) >= 0:
 				frappe.throw(_("{0} must be negative in return document").format(label))
 			elif returned_qty >= reference_qty and args.get(column) >= 0:
 				frappe.throw(


### PR DESCRIPTION
**Description:** Fixes quantity validation in Sales/Purchase Return documents (validate_quantity in erpnext/controllers/sales_and_purchase_return.py). Previously, only positive quantities were rejected (> 0), so a return row with quantity 0 passed validation silently. The check now rejects zero as well (>= 0), so any non-negative quantity in a return item correctly triggers the "must be negative in return document" validation error.

**Fixes:** [#57418](https://github.com/frappe/erpnext/issues/57418)

**Before:** 

[Screencast from 2026-07-24 15-44-01.webm](https://github.com/user-attachments/assets/0c1e44bc-adef-4026-bfbb-52656e8aad72)


**After:**

[Screencast from 2026-07-24 15-42-06.webm](https://github.com/user-attachments/assets/284d66c5-5990-45cf-aa78-e0d76e0384d5)



**Backport needed for v15, v16**
