### PR TITLE
fix: accept list payload for trans_items in update_child_qty_rate

### DIFF
--- a/erpnext/accounts/services/child_item_update.py
+++ b/erpnext/accounts/services/child_item_update.py
@@ -314,7 +314,7 @@ class ChildItemUpdater:
 
 @frappe.whitelist()
 def update_child_qty_rate(
-	parent_doctype: str, trans_items: str, parent_doctype_name: str, child_docname: str = "items"
+	parent_doctype: str, trans_items: str | list, parent_doctype_name: str, child_docname: str = "items"
 ) -> None:
 	ChildItemUpdater(parent_doctype, parent_doctype_name, child_docname).update(trans_items)
 


### PR DESCRIPTION
### Problem

Calling `erpnext.accounts.services.child_item_update.update_child_qty_rate` with `trans_items` as an actual JSON list fails before the method body runs:

```
frappe.exceptions.FrappeTypeError: Argument 'trans_items' in
'erpnext.accounts.services.child_item_update.update_child_qty_rate'
should be of type 'str' but got 'list' instead.
```

Frappe's typing validation enforces the whitelisted endpoint's `trans_items: str` hint, but clients can legitimately send the payload as a list. The underlying `ChildItemUpdater.update` already accepts `str | list` and normalizes via `frappe.parse_json` — only the wrapper's hint was too strict.

### Fix

Widen the endpoint's type hint to `trans_items: str | list`, matching `ChildItemUpdater.update`.

### How to test

1. Open a submitted Sales Order / Purchase Order and use **Update Items**, or call the endpoint directly passing `trans_items` as a list (not a JSON-encoded string).
2. Before this change it raises `FrappeTypeError`; after, the items update succeeds.