### PR TITLE
fix: allow non-admin roles to import chart of accounts

### DIFF
--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -461,14 +461,10 @@ def unset_existing_data(company):
 	frappe.db.set_value("Company", company, update_values, update_values)
 
 	# remove accounts data from various doctypes
-	for doctype in [
-		"Account",
-		"Party Account",
-		"Mode of Payment Account",
-		"Tax Withholding Account",
-		"Sales Taxes and Charges Template",
-		"Purchase Taxes and Charges Template",
-	]:
+	for doctype in ["Account", "Sales Taxes and Charges Template", "Purchase Taxes and Charges Template"]:
+		frappe.get_query(doctype, delete=True, filters={"company": company}, ignore_permissions=False).run()
+
+	for doctype in ["Party Account", "Mode of Payment Account", "Tax Withholding Account"]:
 		frappe.get_query(doctype, delete=True, filters={"company": company}, ignore_permissions=True).run()
 
 

--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -469,7 +469,7 @@ def unset_existing_data(company):
 		"Sales Taxes and Charges Template",
 		"Purchase Taxes and Charges Template",
 	]:
-		frappe.get_query(doctype, delete=True, filters={"company": company}, ignore_permissions=False).run()
+		frappe.get_query(doctype, delete=True, filters={"company": company}, ignore_permissions=True).run()
 
 
 def set_default_accounts(company):


### PR DESCRIPTION
**Issue:**
Error while uploading Charts of Accounts Importer as "Insufficient Permission for Party Account". But as per Role Permission Manager, there is no DocType as “Party Account” to provide the permissions. 

<img width="1913" height="953" alt="image" src="https://github.com/user-attachments/assets/780421b4-4bc3-4250-a11f-571cb534f30d" />
