### PR TITLE
feat(ux): show the form dashboard on the first tab of transaction documents

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -1482,8 +1482,7 @@
   {
    "fieldname": "connections_tab",
    "fieldtype": "Tab Break",
-   "label": "Connections",
-   "show_dashboard": 1
+   "label": "Connections"
   },
   {
    "fieldname": "column_break_6",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -2018,8 +2018,7 @@
   {
    "fieldname": "connections_tab",
    "fieldtype": "Tab Break",
-   "label": "Connections",
-   "show_dashboard": 1
+   "label": "Connections"
   },
   {
    "fieldname": "column_break_14",

--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -1197,8 +1197,7 @@
   {
    "fieldname": "connections_tab",
    "fieldtype": "Tab Break",
-   "label": "Connections",
-   "show_dashboard": 1
+   "label": "Connections"
   },
   {
    "fieldname": "advance_payment_status",

--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
@@ -821,8 +821,7 @@
   {
    "fieldname": "connections_tab",
    "fieldtype": "Tab Break",
-   "label": "Connections",
-   "show_dashboard": 1
+   "label": "Connections"
   },
   {
    "fieldname": "column_break_26",

--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -946,8 +946,7 @@
   {
    "fieldname": "connections_tab",
    "fieldtype": "Tab Break",
-   "label": "Connections",
-   "show_dashboard": 1
+   "label": "Connections"
   },
   {
    "fieldname": "column_break_7",

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -1542,8 +1542,7 @@
   {
    "fieldname": "connections_tab",
    "fieldtype": "Tab Break",
-   "label": "Connections",
-   "show_dashboard": 1
+   "label": "Connections"
   },
   {
    "fieldname": "payment_terms_section",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -1308,8 +1308,7 @@
   {
    "fieldname": "connections_tab",
    "fieldtype": "Tab Break",
-   "label": "Connections",
-   "show_dashboard": 1
+   "label": "Connections"
   },
   {
    "fieldname": "column_break_10",

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
@@ -1168,8 +1168,7 @@
   {
    "fieldname": "connections_tab",
    "fieldtype": "Tab Break",
-   "label": "Connections",
-   "show_dashboard": 1
+   "label": "Connections"
   },
   {
    "fieldname": "column_break_12",


### PR DESCRIPTION
## What

Unchecks `show_dashboard` on the **Connections** tab of the eight core transaction doctypes (Quotation, Sales Order, Delivery Note, Sales Invoice, Supplier Quotation, Purchase Order, Purchase Receipt, Purchase Invoice).

When no tab claims `show_dashboard`, the framework mounts the form dashboard at the top of the **first tab** ([form.js fallback](https://github.com/frappe/frappe/blob/develop/frappe/public/js/frappe/form/form.js)). Indicators, headline, and linked-document connections then render on the Details tab, where users already work. The now-empty Connections tab hides itself automatically (tabs with no visible sections are hidden by the framework), and the `connections_tab` field stays in the schema so custom fields anchored with `insert_after` keep working.

## Why

The Connections tab hides operationally important context (billing/delivery status, linked documents, dashboard indicators) behind an extra click on every transaction, and its only content is the dashboard mount point.

## How to test

1. Open any Sales Order or Purchase Invoice with linked documents.
2. The Details tab now starts with the form dashboard; the Connections tab no longer appears.
3. Verify dashboard behavior is unchanged on doctypes that keep their own `show_dashboard` tab.

no-docs