### PR TITLE
fix: recalculate operating cost on hour rate change in routing

### DIFF
--- a/erpnext/manufacturing/doctype/routing/routing.js
+++ b/erpnext/manufacturing/doctype/routing/routing.js
@@ -79,6 +79,11 @@ frappe.ui.form.on("BOM Operation", {
 		const d = locals[cdt][cdn];
 		frm.events.calculate_operating_cost(frm, d);
 	},
+
+	hour_rate: function (frm, cdt, cdn) {
+		const d = locals[cdt][cdn];
+		frm.events.calculate_operating_cost(frm, d);
+	},
 });
 
 frappe.tour["Routing"] = [


### PR DESCRIPTION
Editing **Hour Rate** in an Operation row did not recalculate **Operating Cost** on the Routing table row

The Routing grid recalculated operating cost on `operation`, `workstation`, and `time_in_mins` changes, but had no `hour_rate` handler (BOM already has one). This adds it so Operating Cost updates immediately when Hour Rate is edited.