### PR TITLE
fix: update operating cost when propagating workstation hour rate to routing

### DIFF
--- a/erpnext/manufacturing/doctype/workstation/test_workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/test_workstation.py
@@ -113,12 +113,13 @@ class TestWorkstation(ERPNextTestSuite):
 		# update_bom_operation() (run on w1.save()) must write the new rate directly onto the
 		# Routing's BOM Operation rows. This is the converted query's own effect (not the BOM
 		# update_cost above) and is what silently skipped on Postgres when parenttype was 'routing'.
-		routing_op_rate = frappe.db.get_value(
+		routing_op_rate, routing_op_operating_cost = frappe.db.get_value(
 			"BOM Operation",
 			{"parent": routing_doc.name, "parenttype": "Routing", "workstation": "_Test Workstation A"},
-			"hour_rate",
+			["hour_rate", "operating_cost"],
 		)
 		self.assertEqual(routing_op_rate, 250)
+		self.assertEqual(routing_op_operating_cost, 250)
 
 
 def make_workstation(*args, **kwargs):

--- a/erpnext/manufacturing/doctype/workstation/workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/workstation.py
@@ -206,6 +206,7 @@ class Workstation(Document):
 			(
 				frappe.qb.update(bom_op)
 				.set(bom_op.hour_rate, self.hour_rate)
+				.set(bom_op.operating_cost, self.hour_rate * bom_op.time_in_mins / 60)
 				.where(bom_op.parent.isin(bom_list) & (bom_op.workstation == self.name))
 				.run()
 			)


### PR DESCRIPTION
Update operating_cost in Routing Bom Operation row when the operational cost changes in the workstation doc