### PR TITLE
refactor: configurable date in reverse ERR journals

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -623,15 +623,27 @@ class ExchangeRateRevaluation(Document):
 		if journals:
 			from erpnext.accounts.doctype.journal_entry.mapper import make_reverse_journal_entry
 
-			for x in journals:
-				reversal = make_reverse_journal_entry(x)
-				reversal.posting_date = nowdate()
-				reversal.submit()
-				frappe.msgprint(
-					_("Revaluation journal for {0} has been created: {1}").format(
-						frappe.bold(x), get_link_to_form("Journal Entry", reversal.name)
-					)
+			if drafts := frappe.db.get_all(
+				"Journal Entry",
+				filters={"docstatus": 0, "reversal_of": ["in", journals]},
+				pluck="name",
+				as_list=1,
+			):
+				part = "journals are" if len(drafts) > 1 else "journal is"
+				doc_links = ", ".join(["{}".format(get_link_to_form("Journal Entry", x)) for x in drafts])
+				frappe.throw(
+					msg=_("Reverse {0} already available in draft status: {1}").format(part, doc_links),
 				)
+			else:
+				for x in journals:
+					reversal = make_reverse_journal_entry(x)
+					reversal.posting_date = nowdate()
+					reversal.save()
+					frappe.msgprint(
+						_("A draft reverse journal for {0} has been created: {1}").format(
+							frappe.bold(x), get_link_to_form("Journal Entry", reversal.name)
+						)
+					)
 
 
 def calculate_exchange_rate_using_last_gle(company, account, party_type, party):

--- a/erpnext/accounts/doctype/exchange_rate_revaluation/test_exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/test_exchange_rate_revaluation.py
@@ -377,6 +377,15 @@ class TestExchangeRateRevaluation(ERPNextTestSuite, AccountsTestMixin):
 		self.assertFalse(ret.get("reversals_posted"))
 
 		err.make_reverse_journal()
+		# submit
+		draft = frappe.db.get_all(
+			"Journal Entry",
+			filters={"docstatus": 0, "reversal_of": je.name, "voucher_type": "Exchange Rate Revaluation"},
+			pluck="name",
+			as_list=1,
+		)
+		self.assertIsNotNone(draft)
+		frappe.get_doc("Journal Entry", draft[0]).submit()
 		ret = err.check_journal_and_reversal()
 		self.assertTrue(ret.get("journals_posted"))
 		self.assertTrue(ret.get("reversals_posted"))

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -235,6 +235,7 @@ Object.assign(erpnext.journal_entry, {
 	lock_reversal_entry(frm) {
 		frm.fields
 			.filter((field) => field.has_input)
+			.filter((field) => field.df.fieldname != "posting_date")
 			.forEach((field) => frm.set_df_property(field.df.fieldname, "read_only", 1));
 		frm.set_df_property("accounts", "read_only", 1);
 	},


### PR DESCRIPTION
Users want control how when the reverse journal should be posted - ERR was done last year which is closed and they want reversal on 1st of Apr, instead of current date.