### PR TITLE
fix: respect allow_negative_rates_for_items for order-stage grand total

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -259,7 +259,11 @@ class AccountsController(TransactionBase):
 			self.calculate_taxes_and_totals()
 
 			if not self.meta.get_field("is_return") or not self.is_return:
-				self.validate_value("base_grand_total", ">=", 0)
+				settings_doctype = (
+					"Selling Settings" if self.meta.has_field("customer") else "Buying Settings"
+				)
+				if not frappe.get_single_value(settings_doctype, "allow_negative_rates_for_items"):
+					self.validate_value("base_grand_total", ">=", 0)
 
 			validate_return(self)
 

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -292,10 +292,11 @@ class StatusUpdater(Document):
 					frappe.throw(_("For an item {0}, quantity must be a negative number").format(d.item_code))
 
 				if (
-					not selling_negative_rate_allowed and self.doctype in ["Sales Invoice", "Delivery Note"]
+					not selling_negative_rate_allowed
+					and self.doctype in ["Sales Order", "Sales Invoice", "Delivery Note"]
 				) or (
 					not buying_negative_rate_allowed
-					and self.doctype in ["Purchase Invoice", "Purchase Receipt"]
+					and self.doctype in ["Purchase Order", "Purchase Invoice", "Purchase Receipt"]
 				):
 					if hasattr(d, "item_code") and hasattr(d, "rate") and flt(d.rate) < 0:
 						frappe.throw(


### PR DESCRIPTION
Sales Order and Purchase Order lack an `is_return` field, so the base_grand_total >= 0 guard in `AccountsController.validate` fired unconditionally, blocking legitimate negative-total change orders.

- accounts_controller: skip the >= 0 check when `allow_negative_rates_for_items` is enabled in the relevant Selling/Buying Settings (mirrors the existing `is_return` escape hatch for invoices)
- status_updater: extend the per-item negative rate guard to cover Sales Order and Purchase Order, which were previously absent

refs: https://github.com/frappe/erpnext/issues/56632