### PR TITLE
fix(crm): align Opportunity status checks with Quotation statuses

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -286,7 +286,11 @@ class Opportunity(TransactionBase, CRMNote):
 		if not self.get("items", []):
 			return frappe.get_all(
 				"Quotation",
-				{"opportunity": self.name, "status": ("not in", ["Lost", "Closed"]), "docstatus": 1},
+				{
+					"opportunity": self.name,
+					"status": ("not in", ["Lost", "Cancelled", "Expired"]),
+					"docstatus": 1,
+				},
 				"name",
 			)
 		else:
@@ -300,7 +304,7 @@ class Opportunity(TransactionBase, CRMNote):
 				.where(
 					(q.docstatus == 1)
 					& (qi.prevdoc_docname == self.name)
-					& q.status.notin(["Lost", "Closed"])
+					& q.status.notin(["Lost", "Cancelled", "Expired"])
 				)
 				.run()
 			)
@@ -308,7 +312,13 @@ class Opportunity(TransactionBase, CRMNote):
 	def has_ordered_quotation(self):
 		if not self.get("items", []):
 			return frappe.get_all(
-				"Quotation", {"opportunity": self.name, "status": "Ordered", "docstatus": 1}, "name"
+				"Quotation",
+				{
+					"opportunity": self.name,
+					"status": ("in", ["Ordered", "Partially Ordered"]),
+					"docstatus": 1,
+				},
+				"name",
 			)
 		else:
 			q = frappe.qb.DocType("Quotation")
@@ -318,7 +328,11 @@ class Opportunity(TransactionBase, CRMNote):
 				.inner_join(qi)
 				.on(q.name == qi.parent)
 				.select(q.name)
-				.where((q.docstatus == 1) & (qi.prevdoc_docname == self.name) & (q.status == "Ordered"))
+				.where(
+					(q.docstatus == 1)
+					& (qi.prevdoc_docname == self.name)
+					& (q.status.isin(["Ordered", "Partially Ordered"]))
+				)
 				.run()
 			)
 


### PR DESCRIPTION
## Summary
- Align Opportunity quotation probes with current Quotation statuses: treat `Cancelled` and `Expired` as inactive instead of the obsolete `Closed` status.
- Treat `Partially Ordered` quotations as ordered so Opportunities become Converted as soon as a Sales Order is created against part of a Quotation.

## Behavior
Opportunity status still follows the reversed status map priority: Closed, then Converted, then Quotation, then Lost.

With these changes:
- Open or Replied quotations still set Opportunity to Quotation
- Partially Ordered or Ordered quotations set Opportunity to Converted
- Lost quotations with no active ones set Opportunity to Lost
- Expired-only quotations no longer keep Opportunity on Quotation, and declaring Lost is no longer blocked by them
