### PR TITLE
fix: recalculate whole bin in Production Plan reservation patch

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -501,5 +501,5 @@ erpnext.patches.v16_0.crm_settings_handle_allowed_users_for_frappe_crm
 erpnext.patches.v16_0.access_control_for_project_users
 erpnext.patches.v16_0.enable_book_stock_expense_gl_entries
 execute:frappe.db.set_single_value("Stock Settings", "use_inline_serial_batch_editor", 0)
-erpnext.patches.v16_0.recompute_production_plan_reserved_qty
+erpnext.patches.v16_0.recalculate_bins_for_production_plan_items
 erpnext.patches.v16_0.rename_ar_ap_ageing_filter

--- a/erpnext/patches/v16_0/recalculate_bins_for_production_plan_items.py
+++ b/erpnext/patches/v16_0/recalculate_bins_for_production_plan_items.py
@@ -20,4 +20,4 @@ def execute():
 		bin_name = frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": warehouse})
 		if not bin_name:
 			continue
-		frappe.get_doc("Bin", bin_name, for_update=True).update_reserved_qty_for_production_plan()
+		frappe.get_doc("Bin", bin_name, for_update=True).recalculate_values()


### PR DESCRIPTION
Follow-up to #57399.

That patch called `Bin.update_reserved_qty_for_production_plan()`, which refreshes only `reserved_qty_for_production_plan`. `projected_qty` is derived from every bin quantity, so any bin whose other fields had drifted stays wrong. Uses `Bin.recalculate_values()` instead — same bin set (items of open submitted plans), all quantities recomputed.

Renamed the patch so it re-runs on sites that already applied `recompute_production_plan_reserved_qty`.