### PR TITLE
fix: stop storing raw title template on subcontracting orders

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -503,3 +503,4 @@ erpnext.patches.v16_0.enable_book_stock_expense_gl_entries
 execute:frappe.db.set_single_value("Stock Settings", "use_inline_serial_batch_editor", 0)
 erpnext.patches.v16_0.recompute_production_plan_reserved_qty
 erpnext.patches.v16_0.rename_ar_ap_ageing_filter
+erpnext.patches.v16_0.fix_subcontracting_titles

--- a/erpnext/patches/v16_0/fix_subcontracting_titles.py
+++ b/erpnext/patches/v16_0/fix_subcontracting_titles.py
@@ -1,0 +1,28 @@
+import frappe
+
+
+def execute():
+	"""
+	This patch corrects the titles of the subcontracting order doctypes set to
+	the text strings "{customer_name}" or "{supplier_name}" instead of the
+	actual customer or supplier name.
+
+	Their `title_field` never pointed at `title`, so the template default was
+	stored verbatim instead of being substituted.
+	"""
+
+	party_fields = {
+		"Subcontracting Order": "supplier_name",
+		"Subcontracting Inward Order": "customer_name",
+	}
+
+	for doctype, party_field in party_fields.items():
+		if not frappe.db.has_column(doctype, "title"):
+			continue
+
+		table = frappe.qb.DocType(doctype)
+		(
+			frappe.qb.update(table)
+			.set(table.title, table[party_field])
+			.where(table.title == f"{{{party_field}}}")
+		).run()

--- a/erpnext/subcontracting/doctype/subcontracting_inward_order/subcontracting_inward_order.json
+++ b/erpnext/subcontracting/doctype/subcontracting_inward_order/subcontracting_inward_order.json
@@ -8,7 +8,6 @@
  "document_type": "Document",
  "engine": "InnoDB",
  "field_order": [
-  "title",
   "naming_series",
   "sales_order",
   "customer",
@@ -29,6 +28,7 @@
   "service_items_section",
   "service_items",
   "tab_other_info",
+  "title",
   "order_status_section",
   "status",
   "per_raw_material_received",
@@ -43,10 +43,8 @@
  "fields": [
   {
    "allow_on_submit": 1,
-   "default": "{customer_name}",
    "fieldname": "title",
    "fieldtype": "Data",
-   "hidden": 1,
    "label": "Title",
    "no_copy": 1,
    "print_hide": 1
@@ -306,7 +304,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-02-26 17:16:21.697846",
+ "modified": "2026-07-27 11:20:14.512336",
  "modified_by": "Administrator",
  "module": "Subcontracting",
  "name": "Subcontracting Inward Order",

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.json
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.json
@@ -8,7 +8,6 @@
  "document_type": "Document",
  "engine": "InnoDB",
  "field_order": [
-  "title",
   "naming_series",
   "purchase_order",
   "supplier",
@@ -55,6 +54,7 @@
   "additional_costs",
   "total_additional_costs",
   "tab_other_info",
+  "title",
   "order_status_section",
   "status",
   "column_break_39",
@@ -69,10 +69,8 @@
  "fields": [
   {
    "allow_on_submit": 1,
-   "default": "{supplier_name}",
    "fieldname": "title",
    "fieldtype": "Data",
-   "hidden": 1,
    "label": "Title",
    "no_copy": 1,
    "print_hide": 1
@@ -494,7 +492,7 @@
  "icon": "fa fa-file-text",
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-14 10:31:40.682892",
+ "modified": "2026-07-27 11:20:14.512336",
  "modified_by": "Administrator",
  "module": "Subcontracting",
  "name": "Subcontracting Order",


### PR DESCRIPTION

**Fixes :**#57448

**Description:**

Subcontracting Order and Subcontracting Inward Order have a hidden `title` field whose default
value is the text `{supplier_name}` / `{customer_name}`. That text is meant to be a template that
gets replaced with the real supplier or customer name when the document is created.

It never gets replaced. The framework substitutes such a template only when the doctype's
`title_field` is set to `title` itself. On both these doctypes `title_field` points at
`supplier_name` / `customer_name` instead, so the substitution step is skipped and the placeholder
text is saved to the database exactly as written. Every Subcontracting Order and Subcontracting
Inward Order ever created carries it.

The same problem was fixed for Purchase Invoice, Purchase Order and Purchase Receipt in #53710 and
#54051, and their old records were repaired by the patch `v16_0/fix_titles.py`. The subcontracting
doctypes were missed.

So:
- Remove the dead template default and the `hidden` flag from the `title` field on both doctypes,
  and move the field into the Other Info tab so it matches how Purchase Order looks today.
- Add the patch `v16_0/fix_subcontracting_titles.py` to repair records that already hold the
  placeholder text, replacing it with the actual supplier or customer name.


**Actual behaviour:**

The `title` field of every Subcontracting Order stores the literal text `{supplier_name}`, and every
Subcontracting Inward Order stores `{customer_name}`, instead of the supplier or customer name.
Nothing in the framework revisits the value later, so it stays wrong forever.

**Expected behaviour:**

New records leave `title` empty, since the supplier or customer name is what actually gets shown in
list view, search, and the form heading. Existing records that hold the placeholder text get
corrected to the real supplier or customer name.

**Backport Needed For V16 and V15**