### PR TITLE
fix/payment-request-subscription-plans-population

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.js
+++ b/erpnext/accounts/doctype/payment_request/payment_request.js
@@ -90,6 +90,7 @@ frappe.ui.form.on("Payment Request", "is_a_subscription", function (frm) {
 			freeze: true,
 			callback: function (data) {
 				if (!data.exc) {
+					frm.clear_table("subscription_plans");
 					$.each(data.message || [], function (i, v) {
 						var d = frappe.model.add_child(
 							frm.doc,

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -854,7 +854,7 @@ def make_payment_request(**args):
 		if not party_account_currency:
 			party_account = get_party_account(party_type, ref_doc.get(party_type.lower()), ref_doc.company)
 			party_account_currency = get_account_currency(party_account)
-
+		is_a_subscription = 1 if ref_doc.get("subscription") else 0
 		pr.update(
 			{
 				"payment_gateway_account": gateway_account.get("name"),
@@ -886,12 +886,25 @@ def make_payment_request(**args):
 					or gateway_account.get("payment_channel", "Email") != "Email"
 				),
 				"phone_number": args.get("phone_number") if args.get("phone_number") else None,
+				"is_a_subscription": is_a_subscription,
 			}
 		)
 
 		if selected_payment_schedules:
 			apply_payment_references(pr, payment_reference)
+		if is_a_subscription:
+			values = get_subscription_details(ref_doc.doctype, ref_doc.name)
 
+			pr.set(
+				"subscription_plans",
+				[
+					{
+						"plan": row.plan,
+						"qty": row.qty,
+					}
+					for row in values
+				],
+			)
 		# Dimensions
 		pr.update(
 			{
@@ -1211,19 +1224,24 @@ def get_dummy_message(doc):
 
 @frappe.whitelist()
 def get_subscription_details(reference_doctype: str, reference_name: str):
-	if reference_doctype == "Sales Invoice":
-		subscriptions = frappe.get_all(
-			"Subscription Invoice",
-			filters={"invoice": reference_name},
-			fields=["parent as sub_name"],
-			order_by="",  # match the original query (no ORDER BY); avoid get_all's default sort
-		)
-		subscription_plans = []
-		for subscription in subscriptions:
-			plans = frappe.get_doc("Subscription", subscription.sub_name).plans
-			for plan in plans:
-				subscription_plans.append(plan)
-		return subscription_plans
+	if reference_doctype != "Sales Invoice":
+		return []
+
+	subscription = frappe.db.get_value("Sales Invoice", reference_name, "subscription")
+
+	if not subscription:
+		return []
+
+	subscription_plan = frappe.get_all(
+		"Subscription Plan Detail",
+		filters={"parent": subscription, "parenttype": "Subscription", "parentfield": "plans"},
+		fields=[
+			"plan",
+			"qty",
+		],
+	)
+
+	return subscription_plan
 
 
 @frappe.whitelist()

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -14,9 +14,15 @@ from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_pay
 from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+from erpnext.accounts.doctype.subscription.test_subscription import (
+	create_plan,
+	create_subscription,
+	make_plans,
+)
 from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 from erpnext.setup.utils import get_exchange_rate
+from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.tests.utils import ERPNextTestSuite
 
 PAYMENT_URL = "https://example.com/payment"
@@ -2009,3 +2015,54 @@ class TestPaymentRequestV2Gateway(ERPNextTestSuite):
 					call_kwargs = mock_log_error.call_args
 					self.assertIn("Payment Initialization Failed", str(call_kwargs))
 					self.assertIn("_Test Gateway", str(call_kwargs))
+
+	def test_payment_request_with_subscription(self):
+		make_plans()
+
+		subscription_plan = frappe.get_doc("Subscription Plan", "_Test Plan Name")
+		subscription_plan.payment_gateway = "_Test Gateway - INR - _TC"
+		subscription_plan.save()
+
+		subscription = create_subscription(
+			plans=[{"plan": "_Test Plan Name", "qty": 1}],
+			start_date=nowdate(),
+			generate_invoice_at="Prepaid (bill at period start)",
+			submit_invoice=1,
+		)
+		invoice_name = frappe.get_value(
+			"Sales Invoice",
+			{
+				"subscription": subscription.name,
+				"docstatus": 1,
+				"is_return": 0,
+			},
+			"name",
+			order_by="from_date asc",
+		)
+
+		payment_request = make_payment_request(
+			dt="Sales Invoice",
+			dn=invoice_name,
+			recipient_id="test@example.com",
+		)
+
+		self.assertEqual(payment_request.is_a_subscription, 1)
+		self.assertEqual(len(payment_request.subscription_plans), 1)
+
+		subscription_plan = payment_request.subscription_plans[0]
+		self.assertEqual(subscription_plan.plan, "_Test Plan Name")
+		self.assertEqual(subscription_plan.qty, 1)
+		self.assertEqual(payment_request.reference_doctype, "Sales Invoice")
+		self.assertEqual(payment_request.reference_name, invoice_name)
+
+	def test_payment_request_without_subscription(self):
+		si = create_sales_invoice()
+		payment_request = make_payment_request(
+			dt="Sales Invoice",
+			dn=si.name,
+			recipient_id="test@example.com",
+		)
+		self.assertEqual(payment_request.is_a_subscription, 0)
+		self.assertEqual(len(payment_request.subscription_plans), 0)
+		self.assertEqual(payment_request.reference_doctype, "Sales Invoice")
+		self.assertEqual(payment_request.reference_name, si.name)


### PR DESCRIPTION
 **Issue:**
 Subscription plan is not populated in Payment Requests created from subscription-based Sales Invoices.

**Fix:**
Set is_a_subscription when creating a Payment Request.
Populate the subscription_plans child table during Payment Request creation.
Simplify subscription plan retrieval by fetching plans directly from the linked Subscription.
Clear existing subscription plans before repopulating them to prevent duplicates.

**Before:**

[Before.webm](https://github.com/user-attachments/assets/876ffeb9-2e39-46d1-8445-3bccbf3362e9)

**After:**

[After.webm](https://github.com/user-attachments/assets/472efbb4-3d36-489e-99cd-33f5ffb93aab)

Raising this PR on behalf of @Dharanidharan2813 
