### PR TITLE
fix(stock): narrow legacy serial ledger lookup by item

### DIFF
--- a/erpnext/stock/deprecated_serial_batch.py
+++ b/erpnext/stock/deprecated_serial_batch.py
@@ -75,6 +75,7 @@ class DeprecatedSerialNoValuation:
 						| (table.serial_no.like("%\n" + serial_no))
 						| (table.serial_no.like("%\n" + serial_no + "\n%"))
 					)
+					& (table.item_code == self.sle.item_code)
 					& (table.company == self.sle.company)
 					& (table.warehouse == self.sle.warehouse)
 					& (table.serial_and_batch_bundle.isnull())


### PR DESCRIPTION
**Issue:**
ERPNext checks old Stock Ledger Entries when calculating rates for legacy serial numbers. Previously, this search looked through entries belonging to every item. The search is now limited to the current item, reducing the number of rows checked. This improves performance without changing the valuation result.

**Ref:** [#74698](https://support.frappe.io/helpdesk/tickets/74698)

**Backport Needed for v15 & v16**