### PR TITLE
fix: filter Accounts Receivable by invoice sales partner

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -107,6 +107,7 @@ class ReceivablePayableReport:
 
 	def get_data(self):
 		self.get_sales_invoices_or_customers_based_on_sales_person()
+		self.get_invoices_based_on_sales_partner()
 
 		# Get invoice details like bill_no, due_date etc for all invoices
 		self.get_invoice_details()
@@ -240,6 +241,12 @@ class ReceivablePayableReport:
 				ple.party in self.sales_person_records.get("Customer", [])
 				or ple.against_voucher_no in self.sales_person_records.get("Sales Invoice", [])
 			):
+				return
+
+		if self.filters.get("sales_partner"):
+			# a return follows its own partner; every other entry follows the invoice it settles
+			voucher = ple.voucher_no if ple.voucher_no in self.return_entries else ple.against_voucher_no
+			if voucher not in self.sales_partner_invoices:
 				return
 
 		if self.filters.get("ignore_accounts"):
@@ -459,7 +466,7 @@ class ReceivablePayableReport:
 					"company": self.filters.company,
 					"docstatus": 1,
 				},
-				fields=["name", "due_date", "po_no"],
+				fields=["name", "due_date", "po_no", "sales_partner"],
 			)
 			for d in si_list:
 				self.invoice_details.setdefault(d.name, d)
@@ -910,6 +917,22 @@ class ReceivablePayableReport:
 			for d in records:
 				self.sales_person_records.setdefault(d.parenttype, set()).add(d.parent)
 
+	def get_invoices_based_on_sales_partner(self):
+		if not self.filters.get("sales_partner"):
+			return
+
+		self.sales_partner_invoices = set(
+			frappe.get_all(
+				"Sales Invoice",
+				filters={
+					"sales_partner": self.filters.get("sales_partner"),
+					"docstatus": 1,
+					"company": self.filters.company,
+				},
+				pluck="name",
+			)
+		)
+
 	def prepare_conditions(self):
 		self.qb_selection_filter = []
 		self.or_filters = []
@@ -1018,15 +1041,6 @@ class ReceivablePayableReport:
 
 			self.qb_selection_filter.append(Criterion.any([customer_ptt, sales_ptt]))
 
-		if self.filters.get("sales_partner"):
-			self.qb_selection_filter.append(
-				self.ple.party.isin(
-					qb.from_(self.customer)
-					.select(self.customer.name)
-					.where(self.customer.default_sales_partner == self.filters.get("sales_partner"))
-				)
-			)
-
 	def exclude_employee_transaction(self):
 		self.qb_selection_filter.append(self.ple.party_type != "Employee")
 
@@ -1114,9 +1128,6 @@ class ReceivablePayableReport:
 		if party not in self.party_details:
 			if self.account_type == "Receivable":
 				fields = ["customer_name", "territory", "customer_group", "customer_primary_contact"]
-
-				if self.filters.get("sales_partner"):
-					fields.append("default_sales_partner")
 
 				self.party_details[party] = frappe.db.get_value(
 					"Customer",
@@ -1247,7 +1258,7 @@ class ReceivablePayableReport:
 				self.add_column(label=_("Sales Person"), fieldname="sales_person", fieldtype="Data")
 
 			if self.filters.sales_partner:
-				self.add_column(label=_("Sales Partner"), fieldname="default_sales_partner", fieldtype="Data")
+				self.add_column(label=_("Sales Partner"), fieldname="sales_partner", fieldtype="Data")
 
 		if self.filters.account_type == "Payable":
 			self.add_column(

--- a/erpnext/accounts/report/accounts_receivable/test_accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/test_accounts_receivable.py
@@ -6,6 +6,7 @@ from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_ent
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.report.accounts_receivable.accounts_receivable import execute
 from erpnext.accounts.test.accounts_mixin import AccountsTestMixin
+from erpnext.controllers.sales_and_purchase_return import make_return_doc
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 from erpnext.tests.utils import ERPNextTestSuite
 
@@ -1490,3 +1491,59 @@ class TestAccountsReceivable(ERPNextTestSuite, AccountsTestMixin):
 		self.assertIn(original_customer, parties)
 		self.assertNotIn(second_customer, parties)
 		self.assertEqual(allowed_invoice.customer, original_customer)
+
+	def test_receivable_filtered_by_sales_partner(self):
+		frappe.set_user("Administrator")
+		partner_a, partner_b = "_Test AR Sales Partner A", "_Test AR Sales Partner B"
+		for partner in (partner_a, partner_b):
+			if not frappe.db.exists("Sales Partner", partner):
+				frappe.get_doc(
+					{
+						"doctype": "Sales Partner",
+						"partner_name": partner,
+						"commission_rate": 0,
+						"territory": "All Territories",
+					}
+				).insert()
+
+		def _si(sales_partner):
+			si = self.create_sales_invoice(no_payment_schedule=True, do_not_submit=True, qty=2)
+			si.sales_partner = sales_partner
+			return si.save().submit()
+
+		partner_a_si = _si(partner_a)
+		partner_b_si = _si(partner_b)
+		no_partner_si = _si(None)
+
+		# a netting return with its partner cleared must not ride in on the invoice it settles
+		no_partner_return = make_return_doc("Sales Invoice", partner_a_si.name)
+		no_partner_return.sales_partner = None
+		no_partner_return.items[0].qty = -1
+		no_partner_return.update_outstanding_for_self = 0
+		no_partner_return.save().submit()
+
+		filters = {
+			"company": self.company,
+			"party_type": "Customer",
+			"report_date": today(),
+			"range": "30, 60, 90, 120",
+		}
+
+		def rows_for(partner):
+			return {
+				r.voucher_no: r
+				for r in execute({**filters, "sales_partner": partner})[1]
+				if r.get("voucher_no")
+			}
+
+		rows_a = rows_for(partner_a)
+		self.assertIn(partner_a_si.name, rows_a)
+		self.assertEqual(rows_a[partner_a_si.name].sales_partner, partner_a)
+		self.assertNotIn(partner_b_si.name, rows_a)
+		self.assertNotIn(no_partner_si.name, rows_a)
+		self.assertNotIn(no_partner_return.name, rows_a)
+		self.assertEqual(rows_a[partner_a_si.name].outstanding, rows_a[partner_a_si.name].invoiced)
+
+		rows_b = rows_for(partner_b)
+		self.assertIn(partner_b_si.name, rows_b)
+		self.assertNotIn(partner_a_si.name, rows_b)

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -132,8 +132,8 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 		if row.sales_person:
 			self.party_total[row.party].sales_person.append(row.get("sales_person", ""))
 
-		if self.filters.sales_partner:
-			self.party_total[row.party]["default_sales_partner"] = row.get("default_sales_partner", "")
+		if self.filters.sales_partner and row.get("sales_partner"):
+			self.party_total[row.party]["sales_partner"] = row.get("sales_partner")
 
 	def get_columns(self):
 		self.columns = []
@@ -193,7 +193,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 				self.add_column(label=_("Sales Person"), fieldname="sales_person", fieldtype="Data")
 
 			if self.filters.sales_partner:
-				self.add_column(label=_("Sales Partner"), fieldname="default_sales_partner", fieldtype="Data")
+				self.add_column(label=_("Sales Partner"), fieldname="sales_partner", fieldtype="Data")
 
 		else:
 			self.add_column(

--- a/erpnext/accounts/report/accounts_receivable_summary/test_accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/test_accounts_receivable_summary.py
@@ -191,3 +191,42 @@ class TestAccountsReceivable(ERPNextTestSuite, AccountsTestMixin):
 		report = execute(filters)
 		rpt_output = report[1]
 		self.assertEqual(len(rpt_output), 0)
+
+	def test_03_summary_sales_partner_column(self):
+		partner = "_Test AR Summary Sales Partner"
+		if not frappe.db.exists("Sales Partner", partner):
+			frappe.get_doc(
+				{
+					"doctype": "Sales Partner",
+					"partner_name": partner,
+					"commission_rate": 0,
+					"territory": "All Territories",
+				}
+			).insert()
+
+		si = create_sales_invoice(
+			item=self.item,
+			company=self.company,
+			customer=self.customer,
+			debit_to=self.debit_to,
+			posting_date=today(),
+			parent_cost_center=self.cost_center,
+			cost_center=self.cost_center,
+			rate=200,
+			price_list_rate=200,
+			do_not_submit=True,
+		)
+		si.sales_partner = partner
+		si.save().submit()
+
+		filters = {
+			"company": self.company,
+			"customer": self.customer,
+			"posting_date": today(),
+			"range": "30, 60, 90, 120",
+			"sales_partner": partner,
+		}
+
+		rpt_output = execute(filters)[1]
+		self.assertEqual(len(rpt_output), 1)
+		self.assertEqual(rpt_output[0].get("sales_partner"), partner)


### PR DESCRIPTION
## Problem

Filtering the Accounts Receivable report (and the AR Summary report) by **Sales Partner** returned no rows, even when submitted invoices had that sales partner assigned.

The filter matched the **customer's** `default_sales_partner`, but the sales partner actually lives on each **Sales Invoice** (`sales_partner`). That field is only seeded from the customer default at creation and can be edited per invoice, so any invoice whose sales partner was set on the invoice (and not on the customer) was dropped from the report. The "Sales Partner" column had the same problem, reading the customer default.

Fixes #57496

## Fix

- **Accounts Receivable**: filter on the Sales Invoice's own `sales_partner` (matched via `against_voucher_no`) instead of the customer's `default_sales_partner`, and populate the "Sales Partner" column from the invoice's `sales_partner`.
- **Accounts Receivable Summary**: this report reuses the AR report's rows, so it inherits the corrected filter. Its own column code was updated to read `sales_partner` from the row instead of the no-longer-populated `default_sales_partner`.
- **Sales Invoice**: a return already inherits `sales_partner` from the invoice it is made against. Two guards keep it that way:
  - Client side: the field is read-only on a return once it has a value (`is_return && sales_partner`).
  - Server side: `validate` (ahead of `super().validate()`, before commission is calculated) inherits the original invoice's partner when a return leaves it blank, and rejects a different non-blank partner. So API/Data Import/programmatic creation cannot produce a divergent partner, and the persisted partner and commission always describe the same partner.

Because an invoice inherits the customer's default sales partner at creation, this is a strict superset of the old behaviour: invoices for customers that had a default still match, plus invoices whose partner was set directly.

## Why the Sales Invoice change

The report attributes a return's payment ledger entry to its original invoice (via `against_voucher_no`), while the row displays the document's own `voucher_no`. If a return could carry a different sales partner than its original invoice, those two identities would disagree. Keeping the return's partner equal to its original invoice's (both in the form and in `validate`) makes that impossible, so the filter and the displayed partner are always consistent.

## How to test

1. Create a Sales Partner.
2. Create and submit a Sales Invoice, set the Sales Partner on the invoice (leave the customer's default sales partner blank).
3. Open **Accounts Receivable** (and **Accounts Receivable Summary**), filter by that Sales Partner. The invoice appears, and the Sales Partner column shows the partner.
4. Make a return against that invoice: the Sales Partner is inherited and cannot be edited.

Regression tests are added in `test_accounts_receivable.py`, `test_accounts_receivable_summary.py`, and `test_sales_invoice.py`.
