### PR TITLE
fix: update operating cost when propagating workstation hour rate to routing

### DIFF
--- a/erpnext/manufacturing/doctype/workstation/test_workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/test_workstation.py
@@ -80,7 +80,7 @@ class TestWorkstation(ERPNextTestSuite):
 
 		test_routing_operations = [
 			{"operation": "Test Operation A", "workstation": "_Test Workstation A", "time_in_mins": 60},
-			{"operation": "Test Operation B", "workstation": "_Test Workstation A", "time_in_mins": 60},
+			{"operation": "Test Operation B", "workstation": "_Test Workstation A", "time_in_mins": 30},
 		]
 		routing_doc = create_routing(routing_name="Routing Test", operations=test_routing_operations)
 		bom_doc = setup_bom(item_code="_Testing Item", routing=routing_doc.name, currency="INR")
@@ -109,6 +109,17 @@ class TestWorkstation(ERPNextTestSuite):
 		self.assertEqual(w1.hour_rate, 250)
 		self.assertEqual(bom_doc.operations[0].hour_rate, 250)
 		self.assertEqual(bom_doc.operations[1].hour_rate, 250)
+
+		# hour_rate propagation must also refresh operating_cost (hour_rate * time_in_mins / 60)
+		# on the Routing's BOM Operation rows; the 30-min op exercises the arithmetic.
+		for operation, expected_operating_cost in (("Test Operation A", 250), ("Test Operation B", 125)):
+			hour_rate, operating_cost = frappe.db.get_value(
+				"BOM Operation",
+				{"parent": routing_doc.name, "parenttype": "Routing", "operation": operation},
+				["hour_rate", "operating_cost"],
+			)
+			self.assertEqual(hour_rate, 250)
+			self.assertEqual(operating_cost, expected_operating_cost)
 
 
 def make_workstation(*args, **kwargs):

--- a/erpnext/manufacturing/doctype/workstation/workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/workstation.py
@@ -195,9 +195,10 @@ class Workstation(Document):
 
 		for bom_no in bom_list:
 			frappe.db.sql(
-				"""update `tabBOM Operation` set hour_rate = %s
+				"""update `tabBOM Operation`
+				set hour_rate = %s, operating_cost = %s * time_in_mins / 60
 				where parent = %s and workstation = %s""",
-				(self.hour_rate, bom_no[0], self.name),
+				(self.hour_rate, self.hour_rate, bom_no[0], self.name),
 			)
 
 	def validate_workstation_holiday(self, schedule_date, skip_holiday_list_check=False):


### PR DESCRIPTION
Manual backport of #57471 to `version-16-hotfix`