### PR TITLE
fix: skip stock expense GL entries for non-stock items

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -356,7 +356,14 @@ class BuyingController(SubcontractingController):
 		if self.doctype == "Purchase Invoice" and not self.update_stock:
 			return
 
+		stock_items = self.get_stock_items()
+
 		for row in self.items:
+			# A service item holds no stock value, so there is nothing to book against it - and it
+			# must not make the expense accounts mandatory either.
+			if row.item_code not in stock_items:
+				continue
+
 			details = self.get_validated_purchase_expense_details(row.item_code)
 			if not details:
 				continue
@@ -364,6 +371,10 @@ class BuyingController(SubcontractingController):
 			amount = flt(row.valuation_rate * row.stock_qty, row.precision("base_amount"))
 			if row.landed_cost_voucher_amount:
 				amount -= flt(row.landed_cost_voucher_amount, row.precision("base_amount"))
+
+			if not amount:
+				# GL Entry rejects a row with neither a debit nor a credit.
+				continue
 
 			self.add_gl_entry(
 				gl_entries=gl_entries,

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -897,6 +897,12 @@ class StockController(AccountsController):
 			self.append_expenses_added_to_stock_pair(gl_list, item_code, amount, item_row)
 
 	def append_expenses_added_to_stock_pair(self, gl_list, item_code, amount, item_row):
+		# A service item holds no stock value, so there is nothing to book against it - and it must
+		# not make the expense accounts mandatory either. A zero pair would be rejected by GL Entry
+		# anyway, which needs a debit or a credit on every row.
+		if not amount or not frappe.get_cached_value("Item", item_code, "is_stock_item"):
+			return
+
 		fields = ("expenses_added_to_stock_account", "expenses_added_to_stock_contra_account")
 		details = get_expenses_added_to_stock_accounts(item_code, self.company)
 

--- a/erpnext/stock/tests/test_expenses_added_to_stock.py
+++ b/erpnext/stock/tests/test_expenses_added_to_stock.py
@@ -174,3 +174,38 @@ class TestExpensesAddedToStock(ERPNextTestSuite):
 			rate=100,
 			company=COMPANY,
 		)
+
+	def test_service_item_books_nothing_on_purchase_invoice_with_update_stock(self):
+		"""A service item carries no stock value, so booking it produced a GL row with neither a
+		debit nor a credit, which GL Entry rejects outright."""
+		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
+
+		service_item = make_item(properties={"is_stock_item": 0}).name
+
+		pi = make_purchase_invoice(
+			company=COMPANY,
+			warehouse=WAREHOUSE,
+			item_code=service_item,
+			qty=1,
+			rate=500,
+			update_stock=1,
+			expense_account="Expenses - TCP1",
+			cost_center="Main - TCP1",
+		)
+
+		self.assertEqual(pi.docstatus, 1)
+
+		_balances, debits, credits = self.get_gl_balances("Purchase Invoice", pi.name)
+		self.assertEqual(debits[self.eats_account], 0)
+		self.assertEqual(credits[self.eats_contra_account], 0)
+
+		booked = frappe.get_all(
+			"GL Entry",
+			filters={
+				"voucher_type": "Purchase Invoice",
+				"voucher_no": pi.name,
+				"is_cancelled": 0,
+				"account": self.purchase_expense_account,
+			},
+		)
+		self.assertFalse(booked)

--- a/erpnext/stock/tests/test_expenses_added_to_stock.py
+++ b/erpnext/stock/tests/test_expenses_added_to_stock.py
@@ -189,7 +189,7 @@ class TestExpensesAddedToStock(ERPNextTestSuite):
 			qty=1,
 			rate=500,
 			update_stock=1,
-			expense_account="Expenses - TCP1",
+			expense_account="Cost of Goods Sold - TCP1",
 			cost_center="Main - TCP1",
 		)
 


### PR DESCRIPTION
Service items were booked to the stock expense accounts, producing a GL row with neither a
debit nor a credit. `GLEntry.check_mandatory` rejects that, so submitting fails:

```
frappe.exceptions.ValidationError: Purchase Invoice ACC-PINV-2026-00031:
Either debit or credit amount is required for Purchase Expense Account - F
```

### Cause
`set_gl_entry_for_purchase_expense` iterated every row on the voucher. A service item has no
`valuation_rate`, so `amount = flt(row.valuation_rate * row.stock_qty, ...)` is `0` and the pair was
still appended. Reproduced with a Purchase Invoice that has **Update Stock** ticked and a service
item (`Maintain Stock` off), with the expense accounts configured on the Company.

### Fix
- `set_gl_entry_for_purchase_expense`: resolve stock items once via the existing `get_stock_items()`
  (one cached bulk query, no lookup inside the loop) and skip anything not in it, plus a zero-amount
  guard. The skip sits **before** `get_validated_purchase_expense_details`, so a service item no
  longer makes those accounts mandatory either - a services-only invoice will not demand them.
- `append_expenses_added_to_stock_pair`: same guard at the single choke point shared by the
  Stock Entry / Stock Reconciliation and Purchase Receipt paths, so one check covers all of them.

### Tests
Adds `test_service_item_books_nothing_on_purchase_invoice_with_update_stock`, reproducing the
reported case: service item + Update Stock on a Purchase Invoice, asserting it submits and books
nothing to either account.

### Note
Fixed-asset items are now skipped for Purchase Expense too, since they carry `is_stock_item = 0`.
That looks consistent with the feature's intent - the Purchase Receipt Expenses Added To Stock path
already excludes fixed assets explicitly - but calling it out as it goes slightly beyond the
service-item case.

Same fix for `develop` is in the companion PR (the guard lives in `base_stock_gl_composer.py` there).
