### PR TITLE
fix(subcontracting): stop the Subcontracting Receipt title from going stale

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
@@ -7,7 +7,6 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "title",
   "naming_series",
   "supplier",
   "supplier_name",
@@ -63,6 +62,7 @@
   "total_additional_costs",
   "tab_other_info",
   "more_info",
+  "title",
   "amended_from",
   "range",
   "column_break4",
@@ -91,10 +91,8 @@
  "fields": [
   {
    "allow_on_submit": 1,
-   "default": "{supplier_name}",
    "fieldname": "title",
    "fieldtype": "Data",
-   "hidden": 1,
    "label": "Title",
    "no_copy": 1,
    "print_hide": 1
@@ -679,7 +677,7 @@
  "in_create": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-02-27 17:59:44.107193",
+ "modified": "2026-07-28 13:04:52.771908",
  "modified_by": "Administrator",
  "module": "Subcontracting",
  "name": "Subcontracting Receipt",
@@ -747,6 +745,6 @@
  "sort_order": "DESC",
  "states": [],
  "timeline_field": "supplier",
- "title_field": "title",
+ "title_field": "supplier_name",
  "track_changes": 1
 }

--- a/erpnext/tests/test_init.py
+++ b/erpnext/tests/test_init.py
@@ -44,3 +44,20 @@ class TestInit(ERPNextTestSuite):
 		from frappe.tests.test_patches import check_patch_files
 
 		check_patch_files("erpnext")
+
+	def test_no_unrendered_title_templates(self):
+		import frappe
+
+		modules = frappe.get_all("Module Def", filters={"app_name": "erpnext"}, pluck="name")
+		for doctype in frappe.get_all("DocType", filters={"module": ("in", modules)}, pluck="name"):
+			meta = frappe.get_meta(doctype)
+			field = meta.get_field("title")
+			if not field or not field.default or "{" not in field.default:
+				continue
+
+			self.assertEqual(
+				meta.title_field,
+				"title",
+				f"{doctype}: title default {field.default!r} is stored verbatim because "
+				"Document.set_title_field() only renders it when title_field is 'title'",
+			)


### PR DESCRIPTION
Follow-up to #57493, which fixed Subcontracting Order and Subcontracting Inward Order but left out Subcontracting Receipt.

Subcontracting Receipt's `title_field` is `"title"`, so `Document.set_title_field()` does render its `{supplier_name}` template — but only once, on insert. It never re-runs on update, so the title goes stale the moment the supplier changes. Same loose end that #53710 closed for Purchase Invoice.

Point `title_field` at `supplier_name` like Purchase Receipt, and give the `title` field the same shape #57493 gave its siblings. No data patch: existing rows already hold a rendered name.

Also adds a guard for the whole bug class — a `{...}` default on a `title` field is only ever rendered when `title_field` is `"title"`. Run against the pre-#57493 tree it flags exactly Subcontracting Order and Subcontracting Inward Order.

Reported in #57448.
