### PR TITLE
fix: stop storing "{supplier_name}" / "{customer_name}" as the document title

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -171,14 +171,12 @@
   },
   {
    "allow_on_submit": 1,
-   "default": "{supplier_name}",
    "fieldname": "title",
    "fieldtype": "Data",
    "hidden": 1,
    "label": "Title",
    "no_copy": 1,
-   "print_hide": 1,
-   "reqd": 1
+   "print_hide": 1
   },
   {
    "fieldname": "naming_series",
@@ -1309,7 +1307,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-31 17:19:40.816883",
+ "modified": "2026-07-28 12:20:11.284370",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order",

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -162,7 +162,7 @@ class PurchaseOrder(BuyingController):
 		taxes_and_charges_deducted: DF.Currency
 		tc_name: DF.Link | None
 		terms: DF.TextEditor | None
-		title: DF.Data
+		title: DF.Data | None
 		to_date: DF.Date | None
 		total: DF.Currency
 		total_net_weight: DF.Float

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -444,3 +444,4 @@ erpnext.patches.v16_0.crm_settings_handle_allowed_users_for_frappe_crm
 erpnext.patches.v16_0.backfill_pick_list_transferred_qty
 erpnext.patches.v16_0.access_control_for_project_users
 erpnext.patches.v16_0.rename_ar_ap_ageing_filter
+erpnext.patches.v15_0.fix_titles

--- a/erpnext/patches/v15_0/fix_titles.py
+++ b/erpnext/patches/v15_0/fix_titles.py
@@ -1,0 +1,20 @@
+import frappe
+
+
+def execute():
+	"""
+	These doctypes point `title_field` at the party name field, so their `title`
+	default was never rendered and got stored as the literal template string.
+	"""
+
+	for doctype, source_field in (
+		("Purchase Order", "supplier_name"),
+		("Subcontracting Order", "supplier_name"),
+		("Sales Order", "customer_name"),
+	):
+		table = frappe.qb.DocType(doctype)
+		(
+			frappe.qb.update(table)
+			.set(table.title, table[source_field])
+			.where(table.title == f"{{{source_field}}}")
+		).run()

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -187,7 +187,6 @@
   },
   {
    "allow_on_submit": 1,
-   "default": "{customer_name}",
    "fieldname": "title",
    "fieldtype": "Data",
    "hidden": 1,
@@ -1680,7 +1679,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-06 15:33:49.059029",
+ "modified": "2026-07-28 12:20:44.130918",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.json
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.json
@@ -66,7 +66,6 @@
  "fields": [
   {
    "allow_on_submit": 1,
-   "default": "{supplier_name}",
    "fieldname": "title",
    "fieldtype": "Data",
    "hidden": 1,
@@ -465,7 +464,7 @@
  "icon": "fa fa-file-text",
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-06 15:21:49.924146",
+ "modified": "2026-07-28 12:21:09.663812",
  "modified_by": "Administrator",
  "module": "Subcontracting",
  "name": "Subcontracting Order",

--- a/erpnext/tests/test_init.py
+++ b/erpnext/tests/test_init.py
@@ -49,3 +49,18 @@ class TestInit(unittest.TestCase):
 		from frappe.tests.test_patches import check_patch_files
 
 		check_patch_files("erpnext")
+
+	def test_no_unrendered_title_templates(self):
+		modules = frappe.get_all("Module Def", filters={"app_name": "erpnext"}, pluck="name")
+		for doctype in frappe.get_all("DocType", filters={"module": ("in", modules)}, pluck="name"):
+			meta = frappe.get_meta(doctype)
+			field = meta.get_field("title")
+			if not field or not field.default or "{" not in field.default:
+				continue
+
+			self.assertEqual(
+				meta.title_field,
+				"title",
+				f"{doctype}: title default {field.default!r} is stored verbatim because "
+				"Document.set_title_field() only renders it when title_field is 'title'",
+			)


### PR DESCRIPTION
Purchase Order, Sales Order and Subcontracting Order point `title_field` at the party name field while their `title` field still carries a `{supplier_name}` / `{customer_name}` default. `Document.set_title_field()` only renders that template when `title_field` is exactly `"title"`, and both `frappe.model.create_new` and `create_new.js` skip a default only for the field `title_field` names — so the placeholder is written verbatim to every new record, server-side and client-side alike.

```
Purchase Order   title_field='supplier_name'  new_doc.title='{supplier_name}'
Sales Order      title_field='customer_name'  new_doc.title='{customer_name}'
```

On Purchase Order the field is also `reqd`, so it is a mandatory field guaranteed to hold junk. Both broke in 242579b77c5 (Oct 2020).

Drop the dead defaults — and Purchase Order's `reqd`, which would otherwise make an always-empty field mandatory — and backfill the affected rows. Purchase Invoice, Purchase Receipt and Supplier Quotation keep `title_field: "title"` here and do render correctly, so they are deliberately left alone; switching them would be a UX change rather than a fix.

Also adds a guard for the whole bug class — a `{...}` default on a `title` field is only ever rendered when `title_field` is `"title"`. It flags exactly these three doctypes before the fix.

Reported in #57448. develop equivalent: #57493 and #57522.
