### PR TITLE
fix(manufacturing): update cost of BOMs created via BOM Creator

### DIFF
--- a/erpnext/manufacturing/doctype/bom/services/costing.py
+++ b/erpnext/manufacturing/doctype/bom/services/costing.py
@@ -225,7 +225,7 @@ class BOMCostingService:
 
 		for d in self.doc.get("items"):
 			old_rate = d.rate
-			if not self.doc.bom_creator and (d.is_stock_item or d.is_phantom_item):
+			if d.is_stock_item or d.is_phantom_item:
 				d.rate = self.get_rm_rate(self._rm_rate_args(d), notify=False)
 
 			self._set_item_amounts(d)


### PR DESCRIPTION
Closes #57464

`calculate_rm_cost` skipped the rate refresh whenever `bom_creator` was set, so neither the **Update Cost** button on BOM nor **Update latest price in all BOMs** in BOM Update Tool could refresh those BOMs. `create_bom` stamps `bom_creator` on every BOM it makes, so entire multi-level trees stayed frozen at their creation rates.

The guard replaced the removed `rm_cost_as_per == "Manual"` check in 0b63dbf, on the assumption that BOM Creator rows carry manually entered rates. They don't — `BOMCreator.before_save` recomputes every row from `rm_cost_as_per`, and "Manual" was dropped from that field in the same commit.