### PR TITLE
fix: stop swallowing exceptions silently in six places

### DIFF
--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.py
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.py
@@ -331,7 +331,7 @@ def add_bank_account(data, bank_account):
 				bank_account_loc = loc
 
 	for row in data[1:]:
-		if bank_account_loc:
+		if bank_account_loc is not None:
 			row[bank_account_loc] = bank_account
 		else:
 			row.append(bank_account)

--- a/erpnext/accounts/doctype/bank_transaction_rule/bank_transaction_rule.py
+++ b/erpnext/accounts/doctype/bank_transaction_rule/bank_transaction_rule.py
@@ -157,12 +157,9 @@ class BankTransactionRule(Document):
 		"""
 		Delete the matched rule from the bank transaction
 		"""
-		try:
-			frappe.db.set_value(
-				"Bank Transaction", {"matched_transaction_rule": self.name}, "matched_transaction_rule", None
-			)
-		except Exception:
-			pass
+		frappe.db.set_value(
+			"Bank Transaction", {"matched_transaction_rule": self.name}, "matched_transaction_rule", None
+		)
 
 	def after_delete(self):
 		"""

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -459,6 +459,11 @@ class PaymentRequest(Document):
 			else:
 				return True
 		except Exception:
+			frappe.log_error(
+				title=f"Payment Gateway validation failed: {self.payment_gateway}",
+				reference_doctype=self.doctype,
+				reference_name=self.name,
+			)
 			return False
 
 	def set_payment_request_url(self):

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -89,7 +89,11 @@ def filter_pricing_rule_based_on_condition(pricing_rules, doc=None):
 					if frappe.safe_eval(pricing_rule.condition, None, doc.as_dict()):
 						filtered_pricing_rules.append(pricing_rule)
 				except Exception:
-					pass
+					frappe.log_error(
+						title=f"Pricing Rule condition failed to evaluate: {pricing_rule.name}",
+						reference_doctype="Pricing Rule",
+						reference_name=pricing_rule.name,
+					)
 			else:
 				filtered_pricing_rules.append(pricing_rule)
 	else:

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -403,12 +403,7 @@ def get_recipients_and_cc(customer, doc):
 			if doc.primary_mandatory and clist.primary_email:
 				for email in clist.primary_email.split(","):
 					recipients.append(email.strip())
-	cc = []
-	if doc.cc_to != "":
-		try:
-			cc = [frappe.get_value("User", user.cc, "email") for user in doc.cc_to]
-		except Exception:
-			pass
+	cc = [email for user in doc.cc_to if (email := frappe.get_value("User", user.cc, "email"))]
 
 	return recipients, cc
 

--- a/erpnext/buying/doctype/request_for_quotation/mapper.py
+++ b/erpnext/buying/doctype/request_for_quotation/mapper.py
@@ -64,27 +64,24 @@ def create_supplier_quotation(doc: str | Document | dict):
 	):
 		frappe.throw(_("Not Permitted"), frappe.PermissionError)
 
-	try:
-		sq_doc = frappe.get_doc(
-			{
-				"doctype": "Supplier Quotation",
-				"supplier": doc.get("supplier"),
-				"terms": doc.get("terms"),
-				"company": doc.get("company"),
-				"currency": doc.get("currency")
-				or get_party_account_currency("Supplier", doc.get("supplier"), doc.get("company")),
-				"buying_price_list": doc.get("buying_price_list")
-				or frappe.db.get_single_value("Buying Settings", "buying_price_list"),
-			}
-		)
-		add_items(sq_doc, doc.get("supplier"), doc.get("items"))
-		sq_doc.flags.ignore_permissions = True
-		sq_doc.run_method("set_missing_values")
-		sq_doc.save()
-		frappe.msgprint(_("Supplier Quotation {0} Created").format(sq_doc.name))
-		return sq_doc.name
-	except Exception:
-		return None
+	sq_doc = frappe.get_doc(
+		{
+			"doctype": "Supplier Quotation",
+			"supplier": doc.get("supplier"),
+			"terms": doc.get("terms"),
+			"company": doc.get("company"),
+			"currency": doc.get("currency")
+			or get_party_account_currency("Supplier", doc.get("supplier"), doc.get("company")),
+			"buying_price_list": doc.get("buying_price_list")
+			or frappe.db.get_single_value("Buying Settings", "buying_price_list"),
+		}
+	)
+	add_items(sq_doc, doc.get("supplier"), doc.get("items"))
+	sq_doc.flags.ignore_permissions = True
+	sq_doc.run_method("set_missing_values")
+	sq_doc.save()
+	frappe.msgprint(_("Supplier Quotation {0} Created").format(sq_doc.name))
+	return sq_doc.name
 
 
 def add_items(sq_doc, supplier, items):


### PR DESCRIPTION
Fixes a batch of reported `except Exception: pass` / `return None` sites.

Not all of them wanted a `frappe.log_error()` — three were better off with the handler deleted:

| Issue | Site | Fix |
|---|---|---|
| #57421 | Pricing Rule condition | log — a broken condition silently dropped the rule |
| #57426 | Payment Request gateway validation | log — no payment URL, no clue why |
| #57424 | Supplier Quotation from RFQ portal | let it raise; `return None` gave the supplier a submit button that does nothing, and it also swallowed mandatory-field validation |
| #57423 | Bank Transaction Rule `on_trash` | dropped the `try/except`; a failed write already aborts the delete, so catching it only hides the cause (and on Postgres the handler itself can't touch the DB) |
| #57425 | Statement of Accounts CC | handler was unreachable — `frappe.get_value` returns `None` for a missing user, it doesn't raise. Dropped it, and filtered out users with no email so `None` stops reaching the cc list |
| #56280 | Bank Statement Import | real bug: `if bank_account_loc:` is false at column 0, so the column got appended instead of filled |

Error Log entries use `reference_doctype`/`reference_name` and let `log_error` pick up the traceback itself.
