### PR TITLE
fix(manufacturing): update cost of BOMs created via BOM Creator (backport #57532)

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1003,7 +1003,7 @@ class BOM(WebsiteGenerator):
 
 		for d in self.get("items"):
 			old_rate = d.rate
-			if not self.bom_creator and (d.is_stock_item or d.is_phantom_item):
+			if d.is_stock_item or d.is_phantom_item:
 				d.rate = self.get_rm_rate(
 					{
 						"company": self.company,


### PR DESCRIPTION
Backport of #57532 to `version-16-hotfix`.

Closes #57464

`calculate_rm_cost` skipped the rate refresh whenever `bom_creator` was set, so neither the **Update Cost** button on BOM nor **Update latest price in all BOMs** in BOM Update Tool could refresh those BOMs. `create_bom` stamps `bom_creator` on every BOM it makes, so entire multi-level trees stayed frozen at their creation rates.

The guard replaced the removed `rm_cost_as_per == "Manual"` check in 0b63dbf, on the assumption that BOM Creator rows carry manually entered rates. They do not — `BOMCreator.before_save` recomputes every row from `rm_cost_as_per`, and "Manual" was dropped from that field in the same commit.