### PR TITLE
fix: prevent TimestampMismatchError resolving Dunning with multiple overdue installments

### DIFF
--- a/erpnext/accounts/doctype/dunning/dunning.py
+++ b/erpnext/accounts/doctype/dunning/dunning.py
@@ -275,6 +275,7 @@ def get_linked_dunnings_as_per_state(sales_invoice, state):
 		.join(overdue_payment)
 		.on(overdue_payment.parent == dunning.name)
 		.select(dunning.name)
+		.distinct()
 		.where(
 			(dunning.status == state)
 			& (dunning.docstatus != 2)

--- a/erpnext/accounts/doctype/dunning/test_dunning.py
+++ b/erpnext/accounts/doctype/dunning/test_dunning.py
@@ -123,6 +123,41 @@ class TestDunning(ERPNextTestSuite):
 		self.assertEqual(sales_invoice.status, "Overdue")
 		self.assertEqual(dunning.status, "Unresolved")
 
+	def test_payment_against_invoice_with_multiple_overdue_installments_in_dunning(self):
+		"""
+		When an invoice has more than one overdue installment, its Dunning holds one
+		Overdue Payment row per installment. Submitting a Payment Entry for the invoice
+		must resolve the Dunning without raising a TimestampMismatchError caused by the
+		same Dunning being loaded and saved more than once.
+		"""
+		create_payment_terms_template_for_dunning()
+		# Post far enough in the past that BOTH installments (5 and 10 credit days) are overdue.
+		sales_invoice = create_sales_invoice_against_cost_center(
+			posting_date=add_days(today(), -15),
+			qty=1,
+			rate=100,
+			do_not_submit=True,
+		)
+		sales_invoice.payment_terms_template = "_Test 50-50 for Dunning"
+		sales_invoice.submit()
+
+		dunning = create_dunning_from_sales_invoice(sales_invoice.name)
+		# Two overdue installments -> two overdue payment rows for the same invoice.
+		self.assertEqual(len(dunning.overdue_payments), 2)
+		dunning.submit()
+		self.assertEqual(dunning.status, "Unresolved")
+
+		# Pay the invoice in full. This previously raised TimestampMismatchError on the Dunning.
+		pe = get_payment_entry("Sales Invoice", sales_invoice.name)
+		pe.reference_no, pe.reference_date = "3", nowdate()
+		pe.insert()
+		pe.submit()
+
+		sales_invoice.reload()
+		dunning.reload()
+		self.assertEqual(sales_invoice.outstanding_amount, 0)
+		self.assertEqual(dunning.status, "Resolved")
+
 	def test_dunning_resolution_from_credit_note(self):
 		"""
 		Test that dunning is resolved when a credit note is issued against the original invoice.


### PR DESCRIPTION
## Problem

Fixes #57538

Submitting a **Payment Entry** for a Sales Invoice fails with `TimestampMismatchError` ("Document has been modified after you have opened it") when the invoice appears more than once in the **Overdue Payments** table of a submitted **Dunning** — the normal case for an invoice with a multi-installment payment schedule. The error is raised on the *Dunning* during Payment Entry submission, so it is confusing, and payments for such invoices cannot be posted at all.

## Root cause

`get_linked_dunnings_as_per_state` joins `Dunning` to its child `Overdue Payment` table **without `DISTINCT`**. An invoice with N overdue installments has N `Overdue Payment` rows in the same Dunning, so the query returns the **same Dunning name N times**.

`update_linked_dunnings` then loads that name into a **separate document object per duplicate row** and `.save()`s each one. The first save bumps the `modified` timestamp; the second (now stale) save raises `TimestampMismatchError`.

## Fix

Add `.distinct()` to the query so each linked Dunning is returned — and saved — exactly once. One-line fix, plus a regression test.

## How to reproduce (before this PR)

1. Payment Terms Template: 50% after 15 days, 50% after 30 days.
2. Sales Invoice (non-stock item, qty 1, rate 100) with that template, posting date ~60 days in the past → both installments overdue. Submit.
3. Create > Dunning → shows **two** overdue rows for the same invoice. Submit (Unresolved).
4. Create a Payment Entry for the full amount and submit → **fails** with `TimestampMismatchError`.

With this PR the Payment Entry submits and the Dunning becomes *Resolved*.

## Tests

Added `test_payment_against_invoice_with_multiple_overdue_installments_in_dunning` in `test_dunning.py`, which builds a two-installment overdue invoice + Dunning (two overdue rows) and asserts the full-amount Payment Entry submits and resolves the Dunning.