### PR TITLE
fix(setup): scope manufacturing warehouse filters to company

### DIFF
--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -70,6 +70,17 @@ frappe.ui.form.on("Company", {
 			};
 		});
 
+		["default_wip_warehouse", "default_fg_warehouse", "default_scrap_warehouse"].forEach((fieldname) => {
+			frm.set_query(fieldname, function (doc) {
+				return {
+					filters: {
+						company: doc.name,
+						is_group: 0,
+					},
+				};
+			});
+		});
+
 		frm.set_query("default_letter_head", function () {
 			return {
 				filters: {


### PR DESCRIPTION
Default WIP, Finished Goods and Scrap Warehouse fields on Company listed warehouses of every company. Filtered them by the current company and excluded group warehouses, matching the other warehouse fields on the form.