### PR TITLE
fix(stock): label item default warehouse fallback as Stock Settings

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -101,12 +101,7 @@ def get_item_group_defaults(item, company):
 
 @frappe.whitelist()
 def get_company_resolved_defaults(company: str) -> dict:
-	"""
-	Returns effective default values for a company by checking:
-	1. Company document
-	2. Stock Settings (for warehouse fallback)
-	3. Accounts Settings (for deferred account fallbacks)
-	"""
+	"""Effective defaults for a company: Company document, plus Stock Settings for the warehouse."""
 	if not company:
 		return {}
 

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -26,6 +26,10 @@ const virtual_field_map = {
 	deferred_revenue_account: "vf_deferred_revenue_account",
 };
 
+const fallback_source_map = {
+	default_warehouse: "Stock Settings",
+};
+
 frappe.ui.form.on("Item", {
 	valuation_method(frm) {
 		if (!frm.is_new() && frm.doc.valuation_method === "Moving Average") {
@@ -620,7 +624,10 @@ $.extend(erpnext.item, {
 			}
 			const base = $label.data("base-label");
 
-			$label.text(from_company[real_field] ? `${base} (Company)` : `${base} (Item Group)`);
+			const source = from_company[real_field]
+				? __(fallback_source_map[real_field] || "Company")
+				: __("Item Group");
+			$label.text(`${base} (${source})`);
 		});
 	},
 


### PR DESCRIPTION
The side-by-side defaults view in the Item Defaults grid labels every non-Item Group fallback as `(Company)`. Company has no `default_warehouse` field — `get_company_resolved_defaults` reads it from the Stock Settings singleton, so the warehouse row was pointing users at the wrong place to change it.

Labels it `(Stock Settings)` instead, via a per-field override map that defaults to Company.

Also drops a stale docstring line claiming an Accounts Settings fallback for deferred accounts that the function never did.