### PR TITLE
fix: respect child warehouse account override in Stock and Account Value Comparison

### DIFF
--- a/erpnext/stock/doctype/warehouse/warehouse.py
+++ b/erpnext/stock/doctype/warehouse/warehouse.py
@@ -15,7 +15,7 @@ from frappe.utils.caching import request_cache
 from frappe.utils.nestedset import NestedSet
 from pypika.terms import ExistsCriterion
 
-from erpnext.stock import get_warehouse_account
+from erpnext.stock import get_warehouse_account, get_warehouse_account_map
 
 
 class Warehouse(NestedSet):
@@ -220,11 +220,19 @@ def get_child_warehouses(warehouse):
 
 def get_warehouses_based_on_account(account, company=None):
 	warehouses = []
+	warehouse_account_map = None
 	for d in frappe.get_all(
 		"Warehouse", fields=["name", "is_group"], filters={"account": account, "disabled": 0}
 	):
 		if d.is_group:
-			warehouses.extend(get_child_warehouses(d.name))
+			# Keep only children whose effective account matches; a child can override the group's account
+			if warehouse_account_map is None:
+				warehouse_account_map = get_warehouse_account_map(company)
+			warehouses.extend(
+				w
+				for w in get_child_warehouses(d.name)
+				if (warehouse_account_map.get(w) or {}).get("account") == account
+			)
 		else:
 			warehouses.append(d.name)
 


### PR DESCRIPTION
The Stock and Account Value Comparison report resolves the stock-side warehouses for an account via `get_warehouses_based_on_account`. When the account is set on a **group** warehouse, it previously pulled in **all** descendants regardless of their own account — so a child that overrides the group's account (e.g. a Goods-in-Transit warehouse under an inventory group) was wrongly counted under the parent account. Both legs of an in-transit transfer then fell under the same account and cancelled to `0` on the stock side, while GL correctly split them across two accounts — surfacing a phantom difference.

The fix includes a descendant of a matched group only if its **effective** account equals the target:

- Child account not set → inherits the parent group's account → they "agree" → included.
- Child account set and equal to the parent's → agree → included.
- Child account set but different (e.g. `TKT Transit` = `2-2002`) → disagree → excluded.

https://support.frappe.io/helpdesk/tickets/74917?view=VIEW-HD+Ticket-70178
