### PR TITLE
fix: removing the purchase invoice check while cancelling the purchase invoice

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -438,16 +438,6 @@ class PurchaseReceipt(BuyingController):
 		super().on_cancel()
 
 		self.check_for_on_hold_or_closed_status("Purchase Order", "purchase_order")
-		# Check if Purchase Invoice has been submitted against current Purchase Order
-		submitted = frappe.get_all(
-			"Purchase Invoice Item",
-			filters={"purchase_receipt": self.name, "docstatus": 1},
-			fields=["parent"],
-			as_list=True,
-			limit=1,
-		)
-		if submitted:
-			frappe.throw(_("Purchase Invoice {0} is already submitted").format(submitted[0][0]))
 
 		self.update_prevdoc_status()
 		self.update_billing_status()


### PR DESCRIPTION
The submitted Purchase Invoice is preventing the cancellation of the Purchase Receipt,  since the framework requires all linked submitted documents to be cancelled first. Since the Purchase Invoice is linked to the Purchase Receipt, it must be cancelled before the Purchase Receipt can be cancelled.