### PR TITLE
fix: enforce object-level permission on depreciation posting

### DIFF
--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -81,7 +81,7 @@ def post_depreciation_entries(date=None):
 			)
 
 		try:
-			make_depreciation_entry(
+			_make_depreciation_entry(
 				asset_depr_schedule_name,
 				date,
 				sch_start_idx,
@@ -139,7 +139,7 @@ def get_depreciable_asset_depr_schedules_data(date):
 def make_depreciation_entry_for_all_asset_depr_schedules(asset_doc, date=None):
 	for row in asset_doc.get("finance_books"):
 		asset_depr_schedule_name = get_asset_depr_schedule_name(asset_doc.name, "Active", row.finance_book)
-		make_depreciation_entry(asset_depr_schedule_name, date)
+		_make_depreciation_entry(asset_depr_schedule_name, date)
 
 
 def get_acc_frozen_upto():
@@ -186,6 +186,30 @@ def get_depreciation_cost_center_and_depreciation_series_for_company():
 
 @frappe.whitelist()
 def make_depreciation_entry(
+	asset_depr_schedule_name,
+	date=None,
+	sch_start_idx=None,
+	sch_end_idx=None,
+	credit_and_debit_accounts=None,
+	depreciation_cost_center_and_depreciation_series=None,
+	accounting_dimensions=None,
+):
+	asset_depr_schedule_doc = frappe.get_doc("Asset Depreciation Schedule", asset_depr_schedule_name)
+	frappe.has_permission("Asset Depreciation Schedule", "write", asset_depr_schedule_doc, throw=True)
+	frappe.has_permission("Asset", "write", asset_depr_schedule_doc.asset, throw=True)
+
+	return _make_depreciation_entry(
+		asset_depr_schedule_name,
+		date,
+		sch_start_idx,
+		sch_end_idx,
+		credit_and_debit_accounts,
+		depreciation_cost_center_and_depreciation_series,
+		accounting_dimensions,
+	)
+
+
+def _make_depreciation_entry(
 	asset_depr_schedule_name,
 	date=None,
 	sch_start_idx=None,


### PR DESCRIPTION
`make_depreciation_entry` only checked generic Journal Entry permission, so any user with Journal Entry access could post depreciation entries for an Asset Depreciation Schedule / Asset they cannot manage. The whitelisted endpoint now checks `write` permission on the specific schedule and asset. Internal callers (scheduler, asset disposal) use `_make_depreciation_entry`, so their behaviour is unchanged.