### PR TITLE
fix: guard against None row in get_stock_balance_for

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -1547,7 +1547,7 @@ def get_stock_balance_for(
 			)
 			serial_nos = "\n".join(d.serial_no for d in serial_no_details if d.batch_no == batch_no)
 
-		if row.use_serial_batch_fields and row.batch_no and (qty or row.current_qty):
+		if row and row.use_serial_batch_fields and row.batch_no and (qty or row.current_qty):
 			rate = get_incoming_rate(
 				frappe._dict(
 					{


### PR DESCRIPTION
Description:

- get_stock_balance_for() accepts an optional row parameter (row=None by default), but one of its three row accesses dereferenced it unconditionally:
  if row.use_serial_batch_fields and row.batch_no and (qty or row.current_qty):
- The other two row accesses in the same function already guard against None (row.X if row else default) — this one didn't.
- For a batch-tracked item, calling the function with batch_no set but row omitted (e.g. a direct API call, or any caller that doesn't have a form row to pass) raises AttributeError: 'NoneType' object has no attribute 'use_serial_batch_fields' instead of returning a stock balance.