### PR TITLE
fix(stock): handle multi-item opening balance in Stock Ledger report

### DIFF
--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -6,8 +6,10 @@ import copy
 
 import frappe
 from frappe import _
-from frappe.query_builder.functions import Sum
+from frappe.query_builder.functions import IfNull, Sum
 from frappe.utils import cint, flt, get_datetime
+from pypika import Order
+from pypika.analytics import RowNumber
 
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
 from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
@@ -52,14 +54,15 @@ def execute(filters=None):
 
 	data = []
 	conversion_factors = []
-	if opening_row:
-		data.append(opening_row)
+	opening_rows = opening_row if isinstance(opening_row, list) else ([opening_row] if opening_row else [])
+	for row in opening_rows:
+		data.append(row)
 		conversion_factors.append(0)
 
 	actual_qty = stock_value = 0
-	if opening_row:
-		actual_qty = opening_row.get("qty_after_transaction")
-		stock_value = opening_row.get("stock_value")
+	if opening_rows:
+		actual_qty = opening_rows[0].get("qty_after_transaction", 0)
+		stock_value = opening_rows[0].get("stock_value", 0)
 
 	available_serial_nos = {}
 
@@ -692,43 +695,120 @@ def get_opening_balance(filters, columns, sl_entries, inv_dimension_wise_value=N
 	if not (filters.item_code and filters.warehouse and filters.from_date):
 		return
 
-	from erpnext.stock.stock_ledger import get_previous_sle
+	item_codes = filters.item_code
+	if isinstance(item_codes, str):
+		item_codes = [item_codes]
 
-	project = None
-	if filters.get("project") and not frappe.get_all(
-		"Inventory Dimension", filters={"reference_document": "Project"}
-	):
-		project = filters.get("project")
+	warehouses = get_matching_warehouses(filters.warehouse)
+	if not warehouses:
+		return
 
-	last_entry = get_previous_sle(
-		{
-			"item_code": filters.item_code,
-			"warehouse_condition": get_warehouse_condition(filters.warehouse),
-			"posting_date": filters.from_date,
-			"posting_time": "00:00:00",
-			"project": project,
-		},
-		for_report=True,
+	sle_doctype = frappe.qb.DocType("Stock Ledger Entry")
+	sr_doctype = frappe.qb.DocType("Stock Reconciliation")
+
+	opening_reco_query = (
+		frappe.qb.from_(sle_doctype)
+		.inner_join(sr_doctype)
+		.on(sle_doctype.voucher_no == sr_doctype.name)
+		.select(sle_doctype.voucher_no)
+		.where(sle_doctype.docstatus < 2)
+		.where(sle_doctype.is_cancelled == 0)
+		.where(sle_doctype.item_code.isin(item_codes))
+		.where(sle_doctype.warehouse.isin(warehouses))
+		.where(sle_doctype.voucher_type == "Stock Reconciliation")
+		.where(sle_doctype.posting_date == filters.from_date)
+		.where(sr_doctype.purpose == "Opening Stock")
 	)
 
-	# check if any SLEs are actually Opening Stock Reconciliation
-	for sle in list(sl_entries):
-		if (
-			sle.get("voucher_type") == "Stock Reconciliation"
-			and sle.posting_date == filters.from_date
-			and frappe.db.get_value("Stock Reconciliation", sle.voucher_no, "purpose") == "Opening Stock"
-		):
-			last_entry = sle
-			sl_entries.remove(sle)
+	opening_reco_vouchers = set(opening_reco_query.run(pluck=True))
 
-	row = {
+	if opening_reco_vouchers:
+		sl_entries[:] = [sle for sle in sl_entries if sle.get("voucher_no") not in opening_reco_vouchers]
+
+	sle_cond = (sle_doctype.posting_date < filters.from_date) | (
+		(sle_doctype.posting_date == filters.from_date) & (sle_doctype.posting_time == "00:00:00")
+	)
+	if opening_reco_vouchers:
+		sle_cond = sle_cond | (
+			(sle_doctype.posting_date == filters.from_date)
+			& (sle_doctype.voucher_no.isin(list(opening_reco_vouchers)))
+		)
+
+	subq = (
+		frappe.qb.from_(sle_doctype)
+		.select(
+			sle_doctype.qty_after_transaction,
+			sle_doctype.stock_value,
+			RowNumber()
+			.over(sle_doctype.item_code, sle_doctype.warehouse)
+			.orderby(sle_doctype.posting_datetime, sle_doctype.creation, sle_doctype.name, order=Order.desc)
+			.as_("rn"),
+		)
+		.where(sle_doctype.docstatus < 2)
+		.where(sle_doctype.is_cancelled == 0)
+		.where(sle_doctype.item_code.isin(item_codes))
+		.where(sle_doctype.warehouse.isin(warehouses))
+		.where(sle_cond)
+	)
+
+	for field in ["voucher_no", "project", "company"]:
+		if filters.get(field):
+			subq = subq.where(sle_doctype[field] == filters.get(field))
+
+	inventory_dimension_fields = get_inventory_dimension_fields()
+	if inventory_dimension_fields:
+		for fieldname in inventory_dimension_fields:
+			if filters.get(fieldname):
+				subq = subq.where(sle_doctype[fieldname].isin(filters.get(fieldname)))
+
+	query = (
+		frappe.qb.from_(subq)
+		.select(
+			IfNull(Sum(subq.qty_after_transaction), 0.0).as_("total_qty"),
+			IfNull(Sum(subq.stock_value), 0.0).as_("total_stock_value"),
+		)
+		.where(subq.rn == 1)
+	)
+
+	res = query.run(as_dict=True)
+
+	total_qty = flt(res[0].total_qty) if res else 0.0
+	total_stock_value = flt(res[0].total_stock_value) if res else 0.0
+	valuation_rate = flt(total_stock_value / total_qty) if total_qty else 0.0
+
+	return {
 		"item_code": _("'Opening'"),
-		"qty_after_transaction": last_entry.get("qty_after_transaction", 0),
-		"valuation_rate": last_entry.get("valuation_rate", 0),
-		"stock_value": last_entry.get("stock_value", 0),
+		"qty_after_transaction": total_qty,
+		"valuation_rate": valuation_rate,
+		"stock_value": total_stock_value,
 	}
 
-	return row
+
+def get_matching_warehouses(warehouses):
+	if not warehouses:
+		return []
+
+	if isinstance(warehouses, str):
+		warehouses = [warehouses]
+
+	warehouse_details = frappe.get_all(
+		"Warehouse",
+		filters={"name": ("in", warehouses)},
+		fields=["lft", "rgt"],
+	)
+
+	if not warehouse_details:
+		return warehouses
+
+	wh = frappe.qb.DocType("Warehouse")
+	cond = None
+	for d in warehouse_details:
+		c = (wh.lft >= d.lft) & (wh.rgt <= d.rgt)
+		cond = c if cond is None else (cond | c)
+
+	matching = (frappe.qb.from_(wh).select(wh.name).where(cond)).run(pluck=True)
+
+	return matching if matching else warehouses
 
 
 def get_warehouse_condition(warehouses):
@@ -784,7 +864,15 @@ def get_opening_balance_for_inv_dimension(filters, inv_dimension_wise_value):
 	if not filters.item_code or not filters.warehouse or not filters.from_date:
 		return
 
-	if len(filters.get("item_code")) > 1 or len(filters.get("warehouse")) > 1:
+	item_codes = filters.get("item_code")
+	if isinstance(item_codes, str):
+		item_codes = [item_codes]
+
+	warehouses = filters.get("warehouse")
+	if isinstance(warehouses, str):
+		warehouses = [warehouses]
+
+	if len(item_codes) > 1 or len(warehouses) > 1:
 		return
 
 	sl_doctype = frappe.qb.DocType("Stock Ledger Entry")
@@ -804,17 +892,11 @@ def get_opening_balance_for_inv_dimension(filters, inv_dimension_wise_value):
 		)
 	)
 
-	if filters.get("item_code"):
-		if isinstance(filters.item_code, list | tuple):
-			query = query.where(sl_doctype.item_code.isin(filters.item_code))
-		else:
-			query = query.where(sl_doctype.item_code == filters.item_code)
+	if item_codes:
+		query = query.where(sl_doctype.item_code.isin(item_codes))
 
-	if filters.get("warehouse"):
-		if isinstance(filters.warehouse, list | tuple):
-			query = query.where(sl_doctype.warehouse.isin(filters.warehouse))
-		else:
-			query = query.where(sl_doctype.warehouse == filters.warehouse)
+	if warehouses:
+		query = query.where(sl_doctype.warehouse.isin(warehouses))
 
 	for key, value in inv_dimension_wise_value.items():
 		if isinstance(value, list | tuple):

--- a/erpnext/stock/report/stock_ledger/test_stock_ledger_report.py
+++ b/erpnext/stock/report/stock_ledger/test_stock_ledger_report.py
@@ -87,3 +87,250 @@ class TestStockLedgerReport(ERPNextTestSuite):
 		rows = self.run_report(item_a)
 		item_codes = {row["item_code"] for row in rows if row.get("voucher_no")}
 		self.assertEqual(item_codes, {item_a})
+
+	def test_multi_item_opening_balance_with_and_without_transactions(self):
+		item_a = "_Test Item"
+		item_b = "_Test Item 2"
+		self.make_movements(
+			item_a,
+			[
+				{
+					"qty": 10,
+					"to_warehouse": WAREHOUSE,
+					"basic_rate": 100,
+					"posting_date": add_days(today(), -10),
+				}
+			],
+		)
+		self.make_movements(
+			item_b,
+			[{"qty": 5, "to_warehouse": WAREHOUSE, "basic_rate": 50, "posting_date": add_days(today(), -10)}],
+		)
+		self.make_movements(
+			item_a,
+			[{"qty": 2, "from_warehouse": WAREHOUSE, "posting_date": today()}],
+		)
+
+		filters = frappe._dict(
+			company="_Test Company",
+			from_date=add_days(today(), -5),
+			to_date=today(),
+			item_code=[item_a, item_b],
+			warehouse=WAREHOUSE,
+		)
+		columns, rows = execute(filters)
+
+		opening_rows = [row for row in rows if row.get("item_code") == "'Opening'"]
+		self.assertEqual(len(opening_rows), 1)
+		self.assertEqual(opening_rows[0]["qty_after_transaction"], 15)
+
+	def test_multi_warehouse_opening_balance_aggregation(self):
+		item = "_Test Item"
+		warehouse_1 = "Stores - _TC"
+		warehouse_2 = "Finished Goods - _TC"
+
+		self.make_movements(
+			item,
+			[
+				{
+					"qty": 10,
+					"to_warehouse": warehouse_1,
+					"basic_rate": 100,
+					"posting_date": add_days(today(), -10),
+				},
+				{
+					"qty": 20,
+					"to_warehouse": warehouse_2,
+					"basic_rate": 100,
+					"posting_date": add_days(today(), -10),
+				},
+			],
+		)
+
+		filters = frappe._dict(
+			company="_Test Company",
+			from_date=add_days(today(), -5),
+			to_date=today(),
+			item_code=[item],
+			warehouse=[warehouse_1, warehouse_2],
+		)
+		columns, rows = execute(filters)
+
+		opening_rows = [row for row in rows if row.get("item_code") == "'Opening'"]
+		self.assertEqual(len(opening_rows), 1)
+		self.assertEqual(opening_rows[0]["qty_after_transaction"], 30)
+
+	def test_opening_stock_reconciliation_on_from_date_non_midnight_time(self):
+		from erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation import (
+			create_stock_reconciliation,
+		)
+
+		item = "_Test Item"
+		from_date = today()
+
+		sr = create_stock_reconciliation(
+			item_code=item,
+			warehouse=WAREHOUSE,
+			qty=25,
+			rate=100,
+			posting_date=from_date,
+			posting_time="10:30:00",
+			purpose="Opening Stock",
+			do_not_submit=False,
+		)
+
+		filters = frappe._dict(
+			company="_Test Company",
+			from_date=from_date,
+			to_date=from_date,
+			item_code=[item],
+			warehouse=WAREHOUSE,
+		)
+		columns, rows = execute(filters)
+
+		opening_rows = [row for row in rows if row.get("item_code") == "'Opening'"]
+		self.assertEqual(len(opening_rows), 1)
+		self.assertEqual(opening_rows[0]["qty_after_transaction"], 25)
+
+		# Ensure the Opening Stock Reconciliation is not duplicated in detail transaction rows
+		reco_rows = [row for row in rows if row.get("voucher_no") == sr.name]
+		self.assertEqual(len(reco_rows), 0)
+
+	def test_backdated_sle_independent_maxima_handling(self):
+		item = "_Test Item"
+		# Entry 1: Later posting date (2026-07-20), created first
+		self.make_movements(
+			item,
+			[
+				{
+					"qty": 10,
+					"to_warehouse": WAREHOUSE,
+					"basic_rate": 100,
+					"posting_date": add_days(today(), -10),
+				}
+			],
+		)
+		# Entry 2: Backdated posting date (2026-07-15), created LATER
+		self.make_movements(
+			item,
+			[
+				{
+					"qty": 5,
+					"to_warehouse": WAREHOUSE,
+					"basic_rate": 100,
+					"posting_date": add_days(today(), -15),
+				}
+			],
+		)
+
+		filters = frappe._dict(
+			company="_Test Company",
+			from_date=add_days(today(), -5),
+			to_date=today(),
+			item_code=[item],
+			warehouse=WAREHOUSE,
+		)
+		columns, rows = execute(filters)
+
+		opening_rows = [row for row in rows if row.get("item_code") == "'Opening'"]
+		self.assertEqual(len(opening_rows), 1)
+		# Should correctly pick the latest posting date entry (15 Qty) despite backdated creation order
+		self.assertEqual(opening_rows[0]["qty_after_transaction"], 15)
+
+	def test_filtered_opening_balance_does_not_pick_excluded_creation_entry(self):
+		item = "_Test Item"
+		posting_date = add_days(today(), -10)
+		posting_time = "09:00:00"
+
+		included_entry = make_stock_entry(
+			item_code=item,
+			qty=10,
+			to_warehouse=WAREHOUSE,
+			basic_rate=100,
+			posting_date=posting_date,
+			posting_time=posting_time,
+		)
+		make_stock_entry(
+			item_code=item,
+			qty=50,
+			to_warehouse=WAREHOUSE,
+			basic_rate=100,
+			posting_date=posting_date,
+			posting_time=posting_time,
+		)
+
+		filters = frappe._dict(
+			company="_Test Company",
+			from_date=add_days(today(), -5),
+			to_date=today(),
+			item_code=[item],
+			warehouse=WAREHOUSE,
+			voucher_no=included_entry.name,
+		)
+		columns, rows = execute(filters)
+
+		opening_rows = [row for row in rows if row.get("item_code") == "'Opening'"]
+		self.assertEqual(len(opening_rows), 1)
+		self.assertEqual(opening_rows[0]["qty_after_transaction"], 10)
+
+	def test_tied_creation_terminal_sle_is_not_summed_twice(self):
+		item = "_Test Item"
+		posting_date = add_days(today(), -10)
+		posting_time = "09:00:00"
+
+		stock_entry_1 = make_stock_entry(
+			item_code=item,
+			qty=10,
+			to_warehouse=WAREHOUSE,
+			basic_rate=100,
+			posting_date=posting_date,
+			posting_time=posting_time,
+		)
+		stock_entry_2 = make_stock_entry(
+			item_code=item,
+			qty=5,
+			to_warehouse=WAREHOUSE,
+			basic_rate=100,
+			posting_date=posting_date,
+			posting_time=posting_time,
+		)
+
+		sle_rows = frappe.get_all(
+			"Stock Ledger Entry",
+			filters={
+				"voucher_type": "Stock Entry",
+				"voucher_no": ("in", [stock_entry_1.name, stock_entry_2.name]),
+				"item_code": item,
+				"warehouse": WAREHOUSE,
+				"is_cancelled": 0,
+			},
+			fields=["name", "qty_after_transaction"],
+			order_by="name desc",
+		)
+		self.assertEqual(len(sle_rows), 2)
+
+		for sle in sle_rows:
+			frappe.db.set_value(
+				"Stock Ledger Entry",
+				sle.name,
+				"creation",
+				"2026-01-01 00:00:00.000000",
+				update_modified=False,
+			)
+
+		filters = frappe._dict(
+			company="_Test Company",
+			from_date=add_days(today(), -5),
+			to_date=today(),
+			item_code=[item],
+			warehouse=WAREHOUSE,
+		)
+		columns, rows = execute(filters)
+
+		opening_rows = [row for row in rows if row.get("item_code") == "'Opening'"]
+		self.assertEqual(len(opening_rows), 1)
+		self.assertEqual(opening_rows[0]["qty_after_transaction"], sle_rows[0].qty_after_transaction)
+		self.assertNotEqual(
+			opening_rows[0]["qty_after_transaction"],
+			sum(sle.qty_after_transaction for sle in sle_rows),
+		)


### PR DESCRIPTION
**Issue:**
**Stock Ledger report shows a wrong "Opening" row when more than one item is selected**

When you pick several items in the Items filter, the "Opening" row at the top of the report doesn't add up the opening stock of all of them. It only picks up the opening stock of one item, so the number shown is much lower than it should be. Because every Balance Qty and Balance Value below it is calculated from that opening figure, the entire report ends up wrong, even though the individual entries in between are correct. Running the report for each item one at a time gives the right numbers, which makes the multi item view look inconsistent.

**Steps to Reproduce:** 
Receive Item A (10 qty) and Item B (5 qty) into a warehouse 10 days ago, issue 2 of Item A today, then run Stock Ledger with from_date = today - 5, to_date = today and both items selected. Opening shows 10 (or 5) instead of 15.

**Ref:** [#74766](https://support.frappe.io/helpdesk/tickets/74766)

**Before:**
<img width="1280" height="400" alt="image" src="https://github.com/user-attachments/assets/2d019a93-c808-455b-b593-83685fae3f73" />

**After:**
<img width="1280" height="353" alt="image" src="https://github.com/user-attachments/assets/cba44aa8-622d-4e4c-a789-79a95d671d94" />


**Backport Needed for v16 and v15**