### PR TITLE
fix: filter expense and income accounts by root type in Item Defaults of  the Item document

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -633,7 +633,7 @@ $.extend(erpnext.item, {
 			const row = locals[cdt][cdn];
 			return {
 				query: "erpnext.controllers.queries.get_expense_account",
-				filters: { company: row.company },
+				filters: { company: row.company, root_type: "Expense", is_group: 0 },
 			};
 		};
 
@@ -645,7 +645,7 @@ $.extend(erpnext.item, {
 			const row = locals[cdt][cdn];
 			return {
 				query: "erpnext.controllers.queries.get_income_account",
-				filters: { company: row.company },
+				filters: { company: row.company, root_type: "Income", is_group: 0 },
 			};
 		};
 

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -632,8 +632,11 @@ $.extend(erpnext.item, {
 		) {
 			const row = locals[cdt][cdn];
 			return {
-				query: "erpnext.controllers.queries.get_expense_account",
-				filters: { company: row.company, root_type: "Expense", is_group: 0 },
+				filters: {
+					company: row.company,
+					root_type: "Expense",
+					is_group: 0,
+				},
 			};
 		};
 
@@ -644,8 +647,11 @@ $.extend(erpnext.item, {
 		) {
 			const row = locals[cdt][cdn];
 			return {
-				query: "erpnext.controllers.queries.get_income_account",
-				filters: { company: row.company, root_type: "Income", is_group: 0 },
+				filters: {
+					company: row.company,
+					root_type: "Income",
+					is_group: 0,
+				},
 			};
 		};
 


### PR DESCRIPTION
In the Item Defaults child table of Item, the Default Expense Account and Default Income Account fields now filter accounts by root_type. Both fields also filter by is_group = 0 and are scoped to the row's company. 

Default Expense Account: filters by root_type = Expense
Default Income Account: filters by root_type = Income

no-docs