### PR TITLE
fix: don't overwrite payment schedule discount from payment term master

### DIFF
--- a/erpnext/accounts/doctype/payment_schedule/payment_schedule.json
+++ b/erpnext/accounts/doctype/payment_schedule/payment_schedule.json
@@ -124,6 +124,7 @@
   {
    "default": "Percentage",
    "fetch_from": "payment_term.discount_type",
+   "fetch_if_empty": 1,
    "fieldname": "discount_type",
    "fieldtype": "Select",
    "label": "Discount Type",
@@ -131,6 +132,7 @@
   },
   {
    "fetch_from": "payment_term.discount",
+   "fetch_if_empty": 1,
    "fieldname": "discount",
    "fieldtype": "Float",
    "label": "Discount"


### PR DESCRIPTION
**Issue:** The discount is not getting fetched according to the Payment Schedule. The issue is reproducible on the local site.

**Steps to Reproduce:**

1. Create a Payment Term (100 % Payment 30 Days); do not mention the discount.
2. Create a Payment Terms Template (30 Days 100%) and add the Payment Term and mention the discount.
3. Mention the Payment Terms Template in Customer Master(Big Basket).
4. When creating a Sales Invoice, the system initially displays the discount amount. However, after saving the document, the discount is automatically removed.

**Before:**

[Screencast from 2026-07-29 23-03-23.webm](https://github.com/user-attachments/assets/8da412c4-4116-42d6-9ceb-c638ede46998)


**After:**

[Screencast from 2026-07-29 22-27-35.webm](https://github.com/user-attachments/assets/a348aa92-ae08-4a60-88c9-0ae838d1bccb)


