### PR TITLE
fix: guard scio row lookup in stock entry items_add

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -997,7 +997,10 @@ frappe.ui.form.on("Stock Entry Detail", {
 		}
 
 		if (frm.doc.purpose === "Receive from Customer") {
-			item.t_warehouse = frm.doc.items.find((item) => item.scio_detail).t_warehouse;
+			const scio_row = frm.doc.items.find((row) => row.scio_detail);
+			if (scio_row) {
+				item.t_warehouse = scio_row.t_warehouse;
+			}
 		}
 	},
 	set_basic_rate_manually(frm, cdt, cdn) {


### PR DESCRIPTION
**Issue:**

- When a new row is added to the Items table of a Stock Entry whose purpose is Receive from Customer, the client script tries to copy the target warehouse from an existing row — specifically, from the first row that is linked back to a Subcontracting Inward Order line. It searches for that row and immediately reads the warehouse off the result, without ever checking whether such a row was actually found.

- If no row in the table carries that link, the search comes back empty and reading the warehouse off it raises a TypeError. Because the failure happens inside the grid's row-add handler, the new row is left half-initialized, and the Items grid is stuck in a broken state — the user has to reload the form.

**Steps to Replicate:**

1. Create and submit a Subcontracting Inward Order with at least one received item that is a customer-provided item and has a required quantity.
2. From the order, create the raw-material receipt Stock Entry. It opens with the purpose Receive from Customer and prefilled item rows.
3. Set Default Target Warehouse on the header.
4. Delete every prefilled row (select all, delete).
5. Click Add row.

**Actual behaviour:**

Adding a row to the Items table of a Stock Entry with the purpose Receive from Customer, when no existing row is linked to a Subcontracting Inward Order line, throws in the browser:

- TypeError: Cannot read properties of undefined (reading 't_warehouse')

**Expected behaviour:** 

- Adding a row should work the same as under any other purpose. When an existing row carries a Subcontracting Inward Order link, the new row takes its target warehouse from that row, as designed. When no such row exists — an order that mapped to an empty items table, or one where the user cleared the prefilled rows — there is simply nothing to copy from, so the field is left for the user to fill.

- Either way, the handler should complete without throwing, so the rest of the chain runs and the row receives its usual warehouse, account, cost center, and serial/batch defaults.

**Backport Needed For V15 and V16**