### PR TITLE
fix(projects): read the Timesheet label from the employee field

### DIFF
--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -453,6 +453,17 @@ class TestTimesheet(ERPNextTestSuite):
 		rate = get_timesheet_detail_rate(detail.name, timesheet.currency)
 		self.assertEqual(rate, detail.billing_amount)
 
+	def test_title_follows_employee(self):
+		first = make_employee("_test_timesheet_title_one@example.com", company="_Test Company")
+		second = make_employee("_test_timesheet_title_two@example.com", company="_Test Company")
+
+		timesheet = make_timesheet(first, simulate=True, do_not_submit=True)
+		self.assertEqual(timesheet.get_title(), frappe.db.get_value("Employee", first, "employee_name"))
+
+		timesheet.employee = second
+		timesheet.save()
+		self.assertEqual(timesheet.get_title(), frappe.db.get_value("Employee", second, "employee_name"))
+
 	@staticmethod
 	def _delete_if_exists(doctype, name):
 		if frappe.db.exists(doctype, name):

--- a/erpnext/projects/doctype/timesheet/timesheet.json
+++ b/erpnext/projects/doctype/timesheet/timesheet.json
@@ -49,7 +49,6 @@
  "fields": [
   {
    "allow_on_submit": 1,
-   "default": "{employee_name}",
    "fieldname": "title",
    "fieldtype": "Data",
    "hidden": 1,
@@ -315,7 +314,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-04-08 12:43:30.658074",
+ "modified": "2026-07-30 11:04:12.882140",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Timesheet",
@@ -409,5 +408,5 @@
  "sort_field": "creation",
  "sort_order": "ASC",
  "states": [],
- "title_field": "title"
+ "title_field": "employee_name"
 }

--- a/erpnext/stock/doctype/material_request/material_request.json
+++ b/erpnext/stock/doctype/material_request/material_request.json
@@ -68,7 +68,6 @@
   },
   {
    "allow_on_submit": 1,
-   "default": "{material_request_type}",
    "fieldname": "title",
    "fieldtype": "Data",
    "hidden": 1,
@@ -377,7 +376,7 @@
  "idx": 70,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-09 17:15:30.124509",
+ "modified": "2026-07-30 11:04:31.517204",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Material Request",


### PR DESCRIPTION
Follow-up to #57524, which dropped the `{...}` title defaults that were never rendered. Two doctypes still carried one.

**Timesheet** — the only place the mechanism was live. `title_field` was `title`, so `set_title_field()` seeded it from `{employee_name}` on insert. A `default` renders once, so reassigning a draft leaves the label on the previous employee, and the field is `hidden` so it can't be corrected from the form:

```
insert    -> employee_name: Alpha | title: 'Alpha'
re-assign -> employee_name: Beta  | title: 'Alpha'
```

`title_field` now points at `employee_name`, so the label reads the live field instead of a copy that drifts. No backfill needed; existing stored titles simply stop being displayed.

**Material Request** — `{material_request_type}` is dead code. `set_title()` runs in `validate` and always fills `title` first, so `set_title_field()` never renders it, and `create_new.js` skips defaults for the field `title_field` names. Titles stay `"<type> Request for <items>"`.

No erpnext doctype ships a `{...}` default on `title` after this. The guard in `test_init.py` is left as-is so the pattern stays available to future doctypes.
