### PR TITLE
feat: auto-fill subscription accounting dimensions from plan with item fallback

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.js
+++ b/erpnext/accounts/doctype/subscription/subscription.js
@@ -110,6 +110,32 @@ frappe.ui.form.on("Subscription", {
 	},
 });
 
+frappe.ui.form.on("Subscription Plan Detail", {
+	plan: function (frm, cdt, cdn) {
+		const row = locals[cdt][cdn];
+		if (!row.plan) return;
+		const requested_plan = row.plan;
+
+		frappe.call({
+			method: "erpnext.accounts.doctype.subscription.subscription.get_plan_dimensions",
+			args: {
+				plan: requested_plan,
+				company: frm.doc.company,
+				party_type: frm.doc.party_type,
+			},
+			callback: function (r) {
+				if (!r.message || locals[cdt]?.[cdn]?.plan !== requested_plan) return;
+				// Only fill dimensions left empty, so a manual entry or an earlier plan is never overwritten.
+				for (const [dimension, value] of Object.entries(r.message)) {
+					if (frm.fields_dict[dimension] && !frm.doc[dimension]) {
+						frm.set_value(dimension, value);
+					}
+				}
+			},
+		});
+	},
+});
+
 // Status -> colour and label for the calendar heatmap. Keys are Title-case to
 // match the value frappe-charts shows in its hover tooltip.
 const HEATMAP_COLORS = {

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -26,6 +26,7 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
 )
 from erpnext.accounts.doctype.subscription_plan.subscription_plan import get_plan_rate
+from erpnext.stock.doctype.item.item import get_item_defaults
 
 
 class InvoiceCancelled(frappe.ValidationError):
@@ -979,6 +980,39 @@ def get_prorata_factor(
 	diff = flt(date_diff(nowdate(), period_start) + 1)
 	plan_days = flt(date_diff(period_end, period_start) + 1)
 	return diff / plan_days
+
+
+@frappe.whitelist()
+def get_plan_dimensions(
+	plan: str, company: str | None = None, party_type: str | None = None
+) -> dict[str, str]:
+	"""Resolve a plan's accounting dimensions, falling back to the plan item's company defaults."""
+	plan_doc = frappe.get_cached_doc("Subscription Plan", plan)
+
+	dimensions = {}
+	for dimension in ["cost_center", *get_accounting_dimensions()]:
+		value = plan_doc.get(dimension) or get_item_dimension(plan_doc.item, dimension, company, party_type)
+		if value:
+			dimensions[dimension] = value
+
+	return dimensions
+
+
+def get_item_dimension(
+	item_code: str, dimension: str, company: str | None, party_type: str | None
+) -> str | None:
+	if not company:
+		return None
+
+	item_defaults = get_item_defaults(item_code, company)
+	if dimension != "cost_center":
+		return item_defaults.get(dimension)
+
+	selling = item_defaults.get("selling_cost_center")
+	buying = item_defaults.get("buying_cost_center")
+	if party_type == PARTY_SUPPLIER:
+		return buying or selling
+	return selling or buying
 
 
 def process_all(subscription: list, posting_date: DateTimeLikeObject | None = None) -> None:

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -18,7 +18,12 @@ from frappe.utils.data import (
 )
 
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
-from erpnext.accounts.doctype.subscription.subscription import Subscription, get_prorata_factor, process_all
+from erpnext.accounts.doctype.subscription.subscription import (
+	Subscription,
+	get_plan_dimensions,
+	get_prorata_factor,
+	process_all,
+)
 from erpnext.accounts.utils import update_subscription_on_invoice_update
 from erpnext.tests.utils import ERPNextTestSuite
 
@@ -950,6 +955,47 @@ class TestSubscription(ERPNextTestSuite):
 		subscription.reload()
 		cells = {cell["date"]: cell for cell in subscription.get_billing_heatmap()}
 		self.assertEqual(cells[str(getdate(invoice.from_date))]["status"], "refunded")
+
+	def test_plan_dimensions_resolve_from_plan_then_item(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		# Plan-level cost center takes precedence.
+		create_plan(plan_name="_Test Sub Plan CC", cost=100, currency="INR")
+		frappe.db.set_value(
+			"Subscription Plan", "_Test Sub Plan CC", "cost_center", "_Test Cost Center - _TC"
+		)
+		self.assertEqual(
+			get_plan_dimensions("_Test Sub Plan CC", "_Test Company", "Customer").get("cost_center"),
+			"_Test Cost Center - _TC",
+		)
+
+		# No plan cost center: fall back to the item's company default (selling vs buying by party type).
+		item = make_item(
+			"_Test Sub Dimension Item",
+			{
+				"is_stock_item": 0,
+				"item_defaults": [
+					{
+						"company": "_Test Company",
+						"selling_cost_center": "_Test Cost Center - _TC",
+						"buying_cost_center": "_Test Cost Center 2 - _TC",
+					}
+				],
+			},
+		)
+		create_plan(plan_name="_Test Sub Plan No CC", cost=100, currency="INR", item=item.name)
+
+		self.assertEqual(
+			get_plan_dimensions("_Test Sub Plan No CC", "_Test Company", "Customer").get("cost_center"),
+			"_Test Cost Center - _TC",
+		)
+		self.assertEqual(
+			get_plan_dimensions("_Test Sub Plan No CC", "_Test Company", "Supplier").get("cost_center"),
+			"_Test Cost Center 2 - _TC",
+		)
+
+		# Without a company the item fallback is skipped.
+		self.assertNotIn("cost_center", get_plan_dimensions("_Test Sub Plan No CC"))
 
 
 def make_full_credit_note(invoice_name):


### PR DESCRIPTION
Fixes #57132

## What

When a plan is selected in the Subscription's Plans table, the Subscription's Accounting Dimensions (cost center and any custom accounting dimensions) now auto-fill. Each dimension is taken from the Subscription Plan first. If the plan has no value, it falls back to the plan's item, using the item's default for the Subscription's company: selling cost center for a Customer, buying cost center for a Supplier.

Only empty dimension fields are filled, so a manual entry or a value set by an earlier plan is never overwritten.

## Why

Subscription Plans and Items already carry accounting dimensions, but the Subscription did not pull them in. Users had to set the cost center by hand even when the plan or its item already had one for the company.

## How to test

1. Set a cost center on a Subscription Plan, or set selling/buying cost center defaults on the plan's Item for a company.
2. Create a Subscription, set the company and party, and add that plan in the Plans table.
3. The cost center (and any custom accounting dimensions) fill in from the plan, falling back to the item's company default when the plan has none.

A unit test covers plan precedence and the item fallback for both customer and supplier.

no-docs
