### PR TITLE
feat: status based bar colors in Work Order gantt view

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order_calendar.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order_calendar.js
@@ -46,3 +46,60 @@ frappe.views.calendar["Work Order"] = {
 	],
 	get_events_method: "frappe.desk.calendar.get_events",
 };
+
+const WORK_ORDER_GANTT_COLORS = {
+	Draft: "red",
+	Stopped: "red",
+	"Not Started": "red",
+	"In Process": "orange",
+	Completed: "green",
+	"Stock Reserved": "blue",
+	"Stock Partially Reserved": "orange",
+	Cancelled: "gray",
+};
+
+if (!frappe.views.GanttView.prototype._work_order_status_colors) {
+	frappe.views.GanttView.prototype._work_order_status_colors = true;
+
+	const prepare_tasks = frappe.views.GanttView.prototype.prepare_tasks;
+	frappe.views.GanttView.prototype.prepare_tasks = function () {
+		prepare_tasks.call(this);
+		if (this.doctype === "Work Order") {
+			set_work_order_bar_classes(this);
+		}
+	};
+
+	const set_colors = frappe.views.GanttView.prototype.set_colors;
+	frappe.views.GanttView.prototype.set_colors = function () {
+		set_colors.call(this);
+		if (this.doctype === "Work Order") {
+			set_work_order_bar_styles(this);
+		}
+	};
+}
+
+function set_work_order_bar_classes(view) {
+	view.tasks.forEach((task, idx) => {
+		const color = WORK_ORDER_GANTT_COLORS[view.data[idx].status];
+		if (color) {
+			task.custom_class = "wo-" + color;
+		}
+	});
+}
+
+function set_work_order_bar_styles(view) {
+	const style = [...new Set(Object.values(WORK_ORDER_GANTT_COLORS))]
+		.map(
+			(color) => `
+			.gantt .bar-wrapper.wo-${color} .bar {
+				fill: var(--${color}-300);
+			}
+			.gantt .bar-wrapper.wo-${color} .bar-progress {
+				fill: var(--${color}-300);
+			}
+		`
+		)
+		.join("");
+
+	view.$result.prepend(`<style>${style}</style>`);
+}


### PR DESCRIPTION
The Work Order gantt view rendered all bars in the default color, unlike the calendar view which colors events by status. The gantt view only supports colors from a hex color field on the record, which Work Order does not have.

This adds status-based bar colors to the Work Order gantt view, scoped entirely to the Work Order calendar config:

- Bars are classed by status using the same color map as the list view indicators.
- Colors use theme CSS variables (`--<color>-300`), so they adapt to dark mode automatically.
- `GanttView.prepare_tasks`/`set_colors` are extended once with a doctype guard, so other doctypes are unaffected.

| Status | Bar |
|---|---|
| Completed | green |
| In Process, Stock Partially Reserved | orange |
| Stock Reserved | blue |
| Draft, Stopped, Not Started | red |
| Cancelled | gray |

#no-docs