### PR TITLE
fix(purchase): reject purchase returns where every item has zero quan…

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -160,10 +160,21 @@ def validate_returned_items(doc):
 				):
 					frappe.throw(_("Warehouse is mandatory"))
 
-			items_returned = True
+			if doc.doctype in ("Purchase Invoice", "Purchase Receipt", "Subcontracting Receipt"):
+				if flt(d.qty) < 0 or flt(d.get("received_qty")) < 0:
+					items_returned = True
+			else:
+				items_returned = True
 
 		elif d.item_name:
-			items_returned = True
+			if doc.doctype in ("Purchase Invoice", "Purchase Receipt", "Subcontracting Receipt"):
+				# No item_code here means no linked Item, so there's no accepted/rejected
+				# split to speak of - received_qty isn't a meaningful independent signal.
+				# Only a negative qty (i.e. a real negative billing amount) counts.
+				if flt(d.qty) < 0:
+					items_returned = True
+			else:
+				items_returned = True
 
 	if not items_returned:
 		frappe.throw(_("At least one item should be entered with negative quantity in return document"))

--- a/erpnext/controllers/tests/test_sales_and_purchase_return.py
+++ b/erpnext/controllers/tests/test_sales_and_purchase_return.py
@@ -37,3 +37,44 @@ class TestSalesAndPurchaseReturn(ERPNextTestSuite):
 
 		self.assertEqual(return_dn.is_return, 1)
 		self.assertEqual(return_dn.items[0].qty, -5)
+
+	def test_purchase_invoice_zero_qty_return_is_rejected(self):
+		# A return with every item at qty 0 moves no stock and no value, so it must be
+		# rejected the same way a return with no items at all would be.
+		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
+
+		pi = make_purchase_invoice(qty=10)
+		self.addCleanup(self._cancel_and_delete, "Purchase Invoice", pi.name)
+
+		return_pi = make_purchase_invoice(
+			is_return=1,
+			return_against=pi.name,
+			qty=0,
+			do_not_save=True,
+		)
+
+		self.assertRaises(frappe.ValidationError, return_pi.save)
+
+	def test_purchase_invoice_item_name_only_zero_qty_return_is_rejected(self):
+		# Item Code is not mandatory on Purchase Invoice Item - a row can have only an
+		# item_name (e.g. a free-text/non-stock line). Such rows fall through to the
+		# item_name-only branch, which must also reject an all-zero-qty return instead
+		# of unconditionally treating the row as returned.
+		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
+
+		pi = make_purchase_invoice(item_name="_Test Item", qty=10, do_not_submit=True)
+		pi.items[0].item_code = ""
+		pi.save()
+		pi.submit()
+		self.addCleanup(self._cancel_and_delete, "Purchase Invoice", pi.name)
+
+		return_pi = make_purchase_invoice(
+			item_name="_Test Item",
+			is_return=1,
+			return_against=pi.name,
+			qty=0,
+			do_not_save=True,
+		)
+		return_pi.items[0].item_code = ""
+
+		self.assertRaises(frappe.ValidationError, return_pi.save)


### PR DESCRIPTION
**Issue:**
- Purchase return validation allows zero-quantity return documents

**Description:**
- When creating a return (Purchase Receipt / Purchase Invoice / Subcontracting Receipt) against an already-submitted purchase document, ERPNext allows the return to be submitted even if every item row has quantity = 0. This produces a valid, submitted return document that moves zero stock and zero value—a completely no-op transaction—while still consuming a document number and appearing linked to the original document in reports and the Connections view.
This is not blocked once, either—it can be repeated an unlimited number of times against the same original document, since a zero-qty return contributes nothing to the already returned running total, so each subsequent zero-qty return attempt is evaluated as if nothing had been returned yet.

**Before:**

[purchase before.webm](https://github.com/user-attachments/assets/74bae988-7c0b-4ae4-b3b5-4dd12483fb28)

**After:**

[purchase after.webm](https://github.com/user-attachments/assets/470677b1-b614-4fe0-bca3-c753425809c9)


**Steps to Replicate:**
1. Create a Purchase Receipt (or Purchase Invoice / Subcontracting Receipt) with at least one item, qty = 10. Submit it.
2. From that document, use Create → Return / Debit Note (or Return, depending on the document type) to generate a return document.
3. In the return document, change the item's Qty to 0 (instead of leaving it negative).
4. Save and Submit.

**Expected result:** ERPNext should reject the document with an error such as: At least one item should be entered with negative quantity in return document.

**Actual result:** The return document saves and submits successfully with no error, despite qty = 0.
(Optional, to confirm the "unlimited repeats" aspect) Repeat steps 2–4 again against the same original Purchase Receipt (or Purchase Invoice / Subcontracting Receipt). It succeeds again and can be repeated indefinitely.

**Backport Needed For V15 and V16**