### PR TITLE
fix(sales): reject sales returns where every item has zero quantity

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -160,7 +160,14 @@ def validate_returned_items(doc):
 				):
 					frappe.throw(_("Warehouse is mandatory"))
 
-			if doc.doctype in ("Purchase Invoice", "Purchase Receipt", "Subcontracting Receipt"):
+			if doc.doctype in (
+				"Purchase Invoice",
+				"Purchase Receipt",
+				"Subcontracting Receipt",
+				"Sales Invoice",
+				"Delivery Note",
+				"POS Invoice",
+			):
 				if flt(d.qty) < 0 or flt(d.get("received_qty")) < 0:
 					items_returned = True
 			else:

--- a/erpnext/controllers/tests/test_sales_and_purchase_return.py
+++ b/erpnext/controllers/tests/test_sales_and_purchase_return.py
@@ -78,3 +78,35 @@ class TestSalesAndPurchaseReturn(ERPNextTestSuite):
 		return_pi.items[0].item_code = ""
 
 		self.assertRaises(frappe.ValidationError, return_pi.save)
+
+	def test_delivery_note_zero_qty_return_is_rejected(self):
+		# A return with every item at qty 0 moves no stock and no value, so it must be
+		# rejected the same way a return with no items at all would be.
+		from erpnext.stock.doctype.delivery_note.mapper import make_sales_return
+		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
+		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+		se = make_stock_entry(item_code="_Test Item", target="_Test Warehouse - _TC", qty=20, basic_rate=100)
+		self.addCleanup(self._cancel_and_delete, "Stock Entry", se.name)
+
+		dn = create_delivery_note(qty=5)
+		self.addCleanup(self._cancel_and_delete, "Delivery Note", dn.name)
+
+		return_dn = make_sales_return(dn.name)
+		return_dn.items[0].qty = 0
+
+		self.assertRaises(frappe.ValidationError, return_dn.insert)
+
+	def test_sales_invoice_zero_qty_return_is_rejected(self):
+		# Same rule for a standalone (non stock-affecting) Sales Invoice return: qty 0 on
+		# every row must be rejected, not silently accepted as a no-op credit note.
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+		from erpnext.controllers.sales_and_purchase_return import make_return_doc
+
+		si = create_sales_invoice(qty=10)
+		self.addCleanup(self._cancel_and_delete, "Sales Invoice", si.name)
+
+		return_si = make_return_doc(si.doctype, si.name)
+		return_si.items[0].qty = 0
+
+		self.assertRaises(frappe.ValidationError, return_si.save)


### PR DESCRIPTION
**Issue:**
- Sales return validation allows zero-quantity return documents

**Description:**
- When creating a return (Sales Invoice / Delivery Note / POS Invoice) against an already-submitted sales document, ERPNext allows the return to be submitted even if every item row has quantity = 0. This creates a valid, submitted return document that moves zero stock and zero value—a completely no-op transaction—while still consuming a document number and appearing linked to the original document in reports and the Connections view.
This is not blocked once, either—it can be repeated an unlimited number of times against the same original document, since a zero-qty return contributes nothing to the already-returned running total; each subsequent zero-qty return attempt is evaluated as if nothing had been returned yet.


**Steps to Replicate:**
1. Create a Delivery Note (or Sales Invoice) with at least one item, qty = 10. Submit it.
2. From that document, use Create → Return / Credit Note to generate a return document.
3. In the return document, change the item's Qty to 0 (instead of leaving it negative).
4. Save and Submit.

Before:

[sales before.webm](https://github.com/user-attachments/assets/304038aa-fe90-4dbb-9640-ec4d9523fe9d)

After:

[sales after.webm](https://github.com/user-attachments/assets/2095ae09-a4e0-4dbd-a2c9-c64e8639ed0d)


**Expected result**: ERPNext should reject the document with an error such as:
At least one item should be entered with negative quantity in return document.

**Actual result**: The return document saves and submits successfully with no errors, even when qty = 0.
(Optional, to confirm the "unlimited repeats" aspect) Repeat steps 2–4 against the same original Delivery Note (or Sales Invoice). It succeeds again and can be repeated indefinitely.

**Backport Needed for V15 and V16**

