### PR TITLE
fix: sync open PR/DN form timestamp after Quality Inspection submit

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -262,6 +262,29 @@ class QualityInspection(Document):
 					self.modified,
 				)
 
+				self.notify_reference_update()
+
+	def notify_reference_update(self):
+		"""Push a realtime `doc_update` for the linked reference document.
+
+		Submitting/cancelling a Quality Inspection bumps the reference (e.g. Purchase
+		Receipt / Delivery Note) `modified` timestamp via a raw db write above. A form
+		still open in the browser keeps the old timestamp and would fail the timestamp
+		conflict check on the next save/submit. Mirroring `Document.notify_update`, this
+		lets an open, unedited form silently reload and sync the timestamp instead.
+		"""
+		frappe.publish_realtime(
+			"doc_update",
+			{
+				"modified": self.modified,
+				"doctype": self.reference_type,
+				"name": self.reference_name,
+			},
+			doctype=self.reference_type,
+			docname=self.reference_name,
+			after_commit=True,
+		)
+
 	def inspect_and_set_status(self):
 		for reading in self.readings:
 			if not reading.manual_inspection:  # dont auto set status if manual


### PR DESCRIPTION
## Problem

When an item requires Quality Inspection, the workflow on a Purchase Receipt / Delivery Note is:

1. Save the PR/DN (QI is required before submit).
2. Create and submit a Quality Inspection for the item.
3. Go back to the still-open PR/DN and submit it.

On QI submit, `QualityInspection.update_qc_reference()` writes the QI link onto the reference child row and then bumps the **parent** PR/DN's `modified` timestamp via a raw `frappe.db.set_value(...)`. That raw write emits **no** realtime event, so a PR/DN form still open in the browser keeps its old `modified` timestamp.

As a result, when the user returns to that unedited form and tries to save/submit, the server-side timestamp conflict check fails:

> (Purchase Receipt) has been modified after you have opened it (`<old>`, `<new>`). Please refresh to get the latest document.

The user is forced to manually refresh every single time a QI is submitted in between — painful when multiple items each need their own QI.

## Fix

After bumping the reference document's `modified`, publish a `doc_update` realtime event for it, mirroring `Document.notify_update()`:

```python
frappe.publish_realtime(
    "doc_update",
    {"modified": self.modified, "doctype": self.reference_type, "name": self.reference_name},
    doctype=self.reference_type,
    docname=self.reference_name,
    after_commit=True,
)
```

The client already handles this event (`frappe/public/js/frappe/model/model.js`): for an open form that is **not dirty**, it silently calls `debounced_reload_doc()` to sync the timestamp, and only shows the conflict message when there are genuine unsaved edits. So the open, unedited PR/DN reloads itself and submits cleanly without a manual refresh. This runs on QI submit, cancel, and trash.

## Steps to reproduce

1. Enable "Inspection Required before Purchase/Delivery" on an Item.
2. Create a Purchase Receipt (or Delivery Note) with that item and save it.
3. From the PR/DN, create a Quality Inspection for the item and submit it.
4. Switch back to the still-open PR/DN (do not refresh) and Save/Submit.
5. Before: "document has been modified after you have opened it" error. After: form silently syncs and submits.

> Re-raised against `develop` after #57649 was auto-closed by Mergify for targeting a stable branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)