### PR TITLE
fix: use payment entry posting date for received amount exchange rate

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -3045,13 +3045,11 @@ def set_paid_amount_and_received_amount(
 			company_currency = frappe.get_cached_value("Company", doc.get("company"), "default_currency")
 			if bank and company_currency != bank.account_currency:
 				# doc currency can be different from bank currency
-				posting_date = doc.get("posting_date") or doc.get("transaction_date")
-				conversion_rate = get_exchange_rate(
-					bank.account_currency, party_account_currency, posting_date
-				)
+				conversion_rate = get_exchange_rate(bank.account_currency, party_account_currency)
 				received_amount = paid_amount / conversion_rate
 			else:
-				received_amount = paid_amount * doc.get("conversion_rate", 1)
+				conversion_rate = get_exchange_rate(doc.get("currency", company_currency), company_currency)
+				received_amount = paid_amount * conversion_rate
 
 		# if payment type is pay, then paid amount and received amount are swapped
 		if payment_type == "Pay":


### PR DESCRIPTION
`get_payment_entry` sets the new Payment Entry's `posting_date` to today, then computes `source_exchange_rate` and `target_exchange_rate` at that date. `set_paid_amount_and_received_amount` was instead seeding `received_amount` from the *source document's* posting date.

When the party account currency differs from the bank account currency, the two dates give different rates, so the Payment Entry opens with a non-zero `difference_amount` that has to be cleared manually even though nothing about the payment is actually unbalanced.

Both now use the same date, so the seeded `received_amount` is consistent with the exchange rates the Payment Entry derives for itself. The branch where the bank account is in company currency previously multiplied by the source document's stored `conversion_rate` (also historical) and now looks up the rate for the same date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
