### PR TITLE
fix: allow reserving stock from work order dialog

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/services/reservation.py
+++ b/erpnext/manufacturing/doctype/work_order/services/reservation.py
@@ -546,10 +546,10 @@ class WorkOrderStockReservation:
 
 @frappe.whitelist()
 def make_stock_reservation_entries(
-	doc: str | Document, items: str | list | None = None, is_transfer: bool = True, notify: bool = False
+	doc: str | dict, items: str | list | None = None, is_transfer: bool = True, notify: bool = False
 ):
 	"""Whitelisted entry point: verify Work Order write access, then reserve stock."""
-	if isinstance(doc, str):
+	if isinstance(doc, str | dict):
 		doc = parse_json(doc)
 		doc = frappe.get_doc("Work Order", doc.get("name"))
 

--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -1199,7 +1199,7 @@ class StockReservation:
 
 			self.available_qty_to_reserve = self.get_available_qty_to_reserve(item_code, warehouse)
 			if not self.available_qty_to_reserve:
-				self.throw_stock_not_exists_error(item.idx, item_code, warehouse)
+				self.throw_stock_not_exists_error(item.get("idx"), item_code, warehouse)
 
 			self.qty_to_be_reserved = (
 				qty if self.available_qty_to_reserve >= qty else self.available_qty_to_reserve
@@ -1259,13 +1259,16 @@ class StockReservation:
 			)
 
 	def throw_stock_not_exists_error(self, idx, item_code, warehouse):
-		frappe.msgprint(
-			_("Row #{0}: Stock not available to reserve for the Item {1} in Warehouse {2}.").format(
+		if idx:
+			msg = _("Row #{0}: Stock not available to reserve for the Item {1} in Warehouse {2}.").format(
 				idx, frappe.bold(item_code), frappe.bold(warehouse)
-			),
-			title=_("Stock Reservation"),
-			indicator="orange",
-		)
+			)
+		else:
+			msg = _("Stock not available to reserve for the Item {0} in Warehouse {1}.").format(
+				frappe.bold(item_code), frappe.bold(warehouse)
+			)
+
+		frappe.msgprint(msg, title=_("Stock Reservation"), indicator="orange")
 
 	def get_available_qty_to_reserve(self, item_code, warehouse, ignore_sre=None):
 		available_qty = get_stock_balance(item_code, warehouse)


### PR DESCRIPTION
Fixes the Reserve Stock dialog on Work Orders: accept the dict payload (was throwing FrappeTypeError) and drop the "Row #None" prefix when no row context is available.

ref #57599