### PR TITLE
fix: preserve UOM conversion factor precision in transactions

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -466,7 +466,7 @@ class BuyingController(SubcontractingController):
 					self.precision("item_tax_amount", item),
 				)
 
-				self.round_floats_in(item)
+				self.round_floats_in(item, do_not_round_fields=["conversion_factor"])
 				if flt(item.conversion_factor) == 0.0:
 					item.conversion_factor = (
 						get_conversion_factor(item.item_code, item.uom).get("conversion_factor") or 1.0

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -225,7 +225,12 @@ class calculate_taxes_and_totals:
 		if self.doc.get("is_consolidated") or self.discount_amount_applied:
 			return
 
-		do_not_round_fields = ["valuation_rate", "incoming_rate", "sales_incoming_rate"]
+		do_not_round_fields = [
+			"valuation_rate",
+			"incoming_rate",
+			"sales_incoming_rate",
+			"conversion_factor",
+		]
 		for item in self.doc.items:
 			self.doc.round_floats_in(item, do_not_round_fields=do_not_round_fields)
 			self.calculate_item_rate(item)

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -143,11 +143,26 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		}
 	}
 
+	get_item_fields_to_round() {
+		const [item] = this.frm.doc.items || [];
+		if (!item) {
+			return [];
+		}
+
+		const do_not_round_fields = ["conversion_factor"];
+		return frappe.meta
+			.get_fieldnames(item.doctype, item.parent, {
+				fieldtype: ["in", ["Currency", "Float"]],
+			})
+			.filter((fieldname) => !do_not_round_fields.includes(fieldname));
+	}
+
 	calculate_item_values() {
 		var me = this;
 		if (!this.discount_amount_applied) {
+			const fields_to_round = this.get_item_fields_to_round();
 			for (const item of this.frm.doc.items || []) {
-				frappe.model.round_floats_in(item);
+				frappe.model.round_floats_in(item, fields_to_round);
 				item.net_rate = item.rate;
 				item.qty = item.qty === undefined ? (me.frm.doc.is_return ? -1 : 1) : item.qty;
 

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -849,6 +849,28 @@ class TestMaterialRequest(ERPNextTestSuite):
 		mr = frappe.get_doc("Material Request", mr.name)
 		self.assertEqual(mr.per_ordered, 100)
 
+	def test_fractional_conversion_factor_for_purchase(self):
+		item = create_item("_Test Fractional Conversion Item", stock_uom="Kg", is_purchase_item=1)
+		conversion_factor = 0.453592292
+
+		mr = make_material_request(
+			item_code=item.name,
+			qty=1000,
+			uom="Pound",
+			conversion_factor=conversion_factor,
+		)
+		mr.reload()
+
+		self.assertEqual(mr.items[0].conversion_factor, conversion_factor)
+
+		po = make_purchase_order(mr.name)
+		po.supplier = "_Test Supplier"
+		po.insert()
+		po.reload()
+
+		self.assertEqual(po.items[0].conversion_factor, conversion_factor)
+		self.assertEqual(po.items[0].stock_qty, mr.items[0].stock_qty)
+
 	def test_customer_provided_parts_mr(self):
 		create_item("CUST-0987", is_customer_provided_item=1, customer="_Test Customer", is_purchase_item=0)
 		existing_requested_qty = self._get_requested_qty("_Test Customer", "_Test Warehouse - _TC")


### PR DESCRIPTION
Item rows round every `Float` field to the site Float Precision (3 by default), and `conversion_factor` was one of them. It is a ratio, not a rate — `UOM Conversion Factor.value` is stored at precision 9.

Material Request has no `currency` field, so it never runs `calculate_taxes_and_totals` and keeps the full factor. Every doc mapped from it does run it, so the factor is truncated on the way out:

| | conversion_factor | qty | stock_qty |
|---|---|---|---|
| Material Request | 0.453592292 | 2138.484 Pound | 970 Kg |
| Purchase Order | 0.454 | 2138.484 Pound | 970.872 Kg |

`stock_qty` is recomputed as `qty * conversion_factor`, so it drifts from what was requested and the Material Request never closes cleanly. An item whose purchase UOM differs from its stock UOM hits this with no UOM Conversion Detail row of its own — `get_conversion_factor` falls back to the global `UOM Conversion Factor`, which is where the 9-digit value comes from. Factors below the site precision round to zero outright.

Excludes `conversion_factor` from the rounded fields on both the server and the client.