### PR TITLE
refactor(job_card): make the completion dialog say what it asks for

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -242,10 +242,11 @@ frappe.ui.form.on("Job Card", {
 		const fields = [
 			{
 				fieldtype: "Float",
-				label: __("Qty to Manufacture"),
+				label: __("Qty to Manufacture in this Cycle"),
 				fieldname: "for_quantity",
 				reqd: 1,
 				default: pending_qty,
+				description: __("Completed, Pending and Process Loss quantities must add up to this."),
 				change() {
 					const dialog = frm.job_completion_dialog;
 					dialog.set_value("completed_qty", dialog.get_value("for_quantity"));
@@ -285,6 +286,7 @@ frappe.ui.form.on("Job Card", {
 				label: __("Pending Quantity"),
 				fieldname: "pending_qty",
 				default: 0.0,
+				description: __("Qty left for a later cycle or for another job card."),
 				change() {
 					const dialog = frm.job_completion_dialog;
 					const process_loss_qty =
@@ -311,6 +313,7 @@ frappe.ui.form.on("Job Card", {
 				fieldtype: "Float",
 				label: __("Process Loss Quantity"),
 				fieldname: "process_loss_qty",
+				description: __("Qty scrapped in this cycle, nobody will produce it."),
 				onchange() {
 					const dialog = frm.job_completion_dialog;
 					const remaining =
@@ -392,9 +395,8 @@ frappe.ui.form.on("Job Card", {
 					},
 				});
 			},
-			__("Enter Value"),
-			__("Update"),
-			__("Set Finished Good Quantity")
+			__("Complete Job"),
+			__("Update")
 		);
 	},
 

--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -420,46 +420,6 @@ frappe.ui.form.on("Job Card", {
 		});
 	},
 
-	make_finished_good(frm) {
-		const fields = [
-			{
-				fieldtype: "Float",
-				label: __("Completed Quantity"),
-				fieldname: "qty",
-				reqd: 1,
-				default: frm.doc.for_quantity - frm.doc.manufactured_qty,
-			},
-			{
-				fieldtype: "Datetime",
-				label: __("End Time"),
-				fieldname: "end_time",
-				default: frappe.datetime.now_datetime(),
-			},
-		];
-
-		frappe.prompt(
-			fields,
-			(data) => {
-				if (data.qty <= 0) {
-					frappe.throw(__("Quantity should be greater than 0"));
-				}
-
-				frm.call({
-					method: "make_finished_good",
-					doc: frm.doc,
-					args: { qty: data.qty, end_time: data.end_time },
-					callback(r) {
-						const doc = frappe.model.sync(r.message);
-						frappe.set_route("Form", doc[0].doctype, doc[0].name);
-					},
-				});
-			},
-			__("Enter Value"),
-			__("Update"),
-			__("Set Finished Good Quantity")
-		);
-	},
-
 	setup_quality_inspection(frm) {
 		const quality_inspection_field = frm.get_docfield("quality_inspection");
 		quality_inspection_field.get_route_options_for_new_doc = function (frm) {

--- a/erpnext/public/js/shop_floor/shop_floor.js
+++ b/erpnext/public/js/shop_floor/shop_floor.js
@@ -789,10 +789,11 @@ class ShopFloor {
 		const fields = [
 			{
 				fieldtype: "Float",
-				label: __("Qty to Manufacture"),
+				label: __("Qty to Manufacture in this Cycle"),
 				fieldname: "for_quantity",
 				reqd: 1,
 				default: pending,
+				description: __("Completed, Pending and Process Loss quantities must add up to this."),
 				change() {
 					const d = me.session_dialog;
 					d.set_value("completed_qty", d.get_value("for_quantity"));
@@ -832,6 +833,7 @@ class ShopFloor {
 				label: __("Pending Quantity"),
 				fieldname: "pending_qty",
 				default: 0.0,
+				description: __("Qty left for a later cycle or for another job card."),
 				change() {
 					const d = me.session_dialog;
 					const pl =
@@ -858,6 +860,7 @@ class ShopFloor {
 				label: __("Process Loss Quantity"),
 				fieldname: "process_loss_qty",
 				default: 0.0,
+				description: __("Qty scrapped in this cycle, nobody will produce it."),
 				change() {
 					const d = me.session_dialog;
 					const remaining =


### PR DESCRIPTION
The completion dialog was hard to read:

- its qty shared the **Qty to Manufacture** label with the field on the form while it means the current cycle only
- its title fell back to the generic **Enter Value**, because `frappe.prompt` takes four arguments and it was passed five
- nothing on it said the three quantities have to add up

Names the cycle in the label, titles the dialog after the button that opens it, and describes the split on the fields. Same wording in the shop floor dialog.

Also drops the unused `make_finished_good` handler — nothing triggered it and Job Card has no such method.
