### PR TITLE
ci: fall back to develop when frappe has no matching branch

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -6,7 +6,18 @@ cd ~ || exit
 
 githubbranch=${GITHUB_BASE_REF:-${GITHUB_REF##*/}}
 frappeuser=${FRAPPE_USER:-"frappe"}
-frappecommitish=${FRAPPE_BRANCH:-$githubbranch}
+frappecommitish=${FRAPPE_BRANCH:-}
+
+# A stacked pull request targets another erpnext branch, which has no counterpart in frappe.
+# Fall back to develop so the bench is still installed. An explicit FRAPPE_BRANCH is trusted as
+# given, since it can be a commit sha rather than a branch.
+if [ -z "$frappecommitish" ]; then
+    frappecommitish=$githubbranch
+    if ! git ls-remote --exit-code --heads "https://github.com/${frappeuser}/frappe" "$frappecommitish" >/dev/null 2>&1; then
+        echo "frappe has no branch ${frappecommitish}, falling back to develop"
+        frappecommitish=develop
+    fi
+fi
 db_host=${DB_HOST:-"127.0.0.1"}
 db_user_host=${DB_USER_HOST:-"localhost"}
 wkhtmltox_deb=${WKHTMLTOX_DEB:-"/tmp/wkhtmltox.deb"}

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -13,9 +13,18 @@ frappecommitish=${FRAPPE_BRANCH:-}
 # given, since it can be a commit sha rather than a branch.
 if [ -z "$frappecommitish" ]; then
     frappecommitish=$githubbranch
-    if ! git ls-remote --exit-code --heads "https://github.com/${frappeuser}/frappe" "$frappecommitish" >/dev/null 2>&1; then
+
+    # git ls-remote --exit-code reports 2 for a branch that is not there and 128 for a remote it
+    # could not reach. Only the first one is proof of absence; keep the branch on anything else so
+    # a flaky probe cannot install an unrelated frappe.
+    probe=0
+    git ls-remote --exit-code --heads "https://github.com/${frappeuser}/frappe" "$frappecommitish" >/dev/null 2>&1 || probe=$?
+
+    if [ "$probe" -eq 2 ]; then
         echo "frappe has no branch ${frappecommitish}, falling back to develop"
         frappecommitish=develop
+    elif [ "$probe" -ne 0 ]; then
+        echo "could not reach frappe to check for branch ${frappecommitish} (git ls-remote exited ${probe}), keeping it"
     fi
 fi
 db_host=${DB_HOST:-"127.0.0.1"}


### PR DESCRIPTION
`install.sh` picks the frappe branch to clone from the pull request's base branch:

```bash
githubbranch=${GITHUB_BASE_REF:-${GITHUB_REF##*/}}
frappecommitish=${FRAPPE_BRANCH:-$githubbranch}
```

A stacked pull request targets another erpnext branch, so the fetch fails with `fatal: couldn't find remote ref <erpnext branch>`. No bench is installed, and every job that needs one fails with it — `Build & reinstall (setup)`, then `Patch Test` on `cd frappe-bench: No such file or directory`.

Falls back to `develop` when the base branch has no counterpart in frappe. An explicit `FRAPPE_BRANCH` is left alone, since `server-tests-mariadb.yml` passes a commit sha through it, which `git ls-remote --heads` would not match.

Branches that do exist in frappe (`develop`, `version-15`, …) are unaffected — verified with `git ls-remote` against frappe/frappe.

Seen on #57685, #57686 and #57687.
