### PR TITLE
fix: prevent duplicate shipping charges without cost center

### DIFF
--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
@@ -143,7 +143,7 @@ class ShippingRule(Document):
 		shipping_charge = {
 			"charge_type": "Actual",
 			"account_head": self.account,
-			"cost_center": self.cost_center,
+			"cost_center": self.cost_center or "",
 		}
 		if self.shipping_rule_type == "Selling":
 			# check if not applied on purchase

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -2068,6 +2068,30 @@ class TestSalesOrder(ERPNextTestSuite):
 		sales_order.save()
 		self.assertEqual(sales_order.taxes[0].tax_amount, 0)
 
+	def test_sales_order_with_shipping_rule_without_cost_center(self):
+		shipping_rule = frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"label": "Shipping Rule Without Cost Center - Sales Order Test",
+				"shipping_rule_type": "Selling",
+				"company": "_Test Company",
+				"account": "_Test Account Shipping Charges - _TC",
+				"cost_center": None,
+				"calculate_based_on": "Fixed",
+				"shipping_amount": 50,
+			}
+		)
+		sales_order = make_sales_order(do_not_save=True)
+
+		shipping_rule.apply(sales_order)
+		self.assertEqual(len(sales_order.taxes), 1)
+		self.assertEqual(sales_order.taxes[0].cost_center, "")
+
+		# Blank values from the client are deserialized as empty strings.
+		sales_order.taxes[0].cost_center = ""
+		shipping_rule.apply(sales_order)
+		self.assertEqual(len(sales_order.taxes), 1)
+
 	def test_sales_order_partial_advance_payment(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
 			create_payment_entry,


### PR DESCRIPTION
**Issue:**
When a Shipping Rule without a Cost Center is applied to a Sales Order, saving the document can add the shipping charge multiple times to the Sales Taxes and Charges table. The duplicate rows cannot be removed while the Shipping Rule remains selected. Clearing the Shipping Rule first allows the rows to be deleted. 

A blank Cost Center could be represented as None on the server and as an empty string ("") after client-side serialization. Shipping Rule uses exact field matching to locate an existing tax row, so this mismatch caused it to treat the existing shipping charge as a new row.

**Steps to Reproduce**

  1. Create a Shipping Rule without a Cost Center.
  2. Create a Sales Order.
  3. Apply the Shipping Rule.
  4. Save the Sales Order.
  5. Observe duplicate shipping charge rows in Sales Taxes and Charges.

**Ref:** [#75152](https://support.frappe.io/helpdesk/tickets/75152)

**Backport Needed for v16 & v15**