### PR TITLE
fix: prevent duplicate shipping charges without cost center

### DIFF
--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
@@ -163,8 +163,6 @@ class ShippingRule(Document):
 
 		shipping_charge_filters = shipping_charge.copy()
 		if not self.cost_center:
-			# Blank Link values can be None on the server or an empty string from the client.
-			# Child-table defaults can also resolve a blank value to the company default.
 			shipping_charge_filters["cost_center"] = (
 				"in",
 				(None, "", erpnext.get_default_cost_center(doc.company)),

--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
@@ -161,7 +161,16 @@ class ShippingRule(Document):
 			)
 			shipping_charge["add_deduct_tax"] = "Add"
 
-		existing_shipping_charge = doc.get("taxes", filters=shipping_charge)
+		shipping_charge_filters = shipping_charge.copy()
+		if not self.cost_center:
+			# Blank Link values can be None on the server or an empty string from the client.
+			# Child-table defaults can also resolve a blank value to the company default.
+			shipping_charge_filters["cost_center"] = (
+				"in",
+				(None, "", erpnext.get_default_cost_center(doc.company)),
+			)
+
+		existing_shipping_charge = doc.get("taxes", filters=shipping_charge_filters)
 		if existing_shipping_charge:
 			# take the last record found
 			existing_shipping_charge[-1].tax_amount = shipping_amount

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -2068,6 +2068,41 @@ class TestSalesOrder(ERPNextTestSuite):
 		sales_order.save()
 		self.assertEqual(sales_order.taxes[0].tax_amount, 0)
 
+	def test_sales_order_with_shipping_rule_without_cost_center(self):
+		from erpnext import get_default_cost_center
+
+		shipping_rule = frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"label": "Shipping Rule Without Cost Center - Sales Order Test",
+				"shipping_rule_type": "Selling",
+				"company": "_Test Company",
+				"account": "_Test Account Shipping Charges - _TC",
+				"calculate_based_on": "Fixed",
+				"shipping_amount": 50,
+			}
+		).insert()
+		sales_order = make_sales_order(do_not_save=True)
+		sales_order.shipping_rule = shipping_rule.name
+		company_cost_center = get_default_cost_center(sales_order.company)
+
+		shipping_rule.apply(sales_order)
+		self.assertEqual(len(sales_order.taxes), 1)
+		self.assertIsNone(sales_order.taxes[0].cost_center)
+
+		for cost_center in (None, "", company_cost_center):
+			sales_order.taxes[0].cost_center = cost_center
+			shipping_rule.apply(sales_order)
+			self.assertEqual(len(sales_order.taxes), 1)
+			self.assertEqual(sales_order.taxes[0].cost_center, cost_center)
+
+		sales_order.taxes[0].cost_center = ""
+		sales_order.save()
+		sales_order.reload()
+		shipping_rule.apply(sales_order)
+		self.assertEqual(len(sales_order.taxes), 1)
+		self.assertEqual(sales_order.taxes[0].cost_center, "")
+
 	def test_sales_order_partial_advance_payment(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
 			create_payment_entry,


### PR DESCRIPTION
## Summary

- prevent duplicate shipping-charge rows when a Shipping Rule has no Cost Center
- treat server-side `None`, client-side empty strings, and an already-applied company default as the same blank-rule match
- preserve the existing Cost Center value instead of normalizing or changing document behavior
- add regression coverage for applying, saving, reloading, and reapplying the rule

## Root cause

Blank Link values can be represented as `None` on the server and as an empty string after client serialization. Shipping Rule used exact field matching to locate an existing tax row, so the representation mismatch caused it to append another row.

## Impact

Applying or saving a Shipping Rule without a Cost Center no longer duplicates its shipping charge. Existing Cost Center behavior remains unchanged: this fix only broadens lookup equivalence and does not rewrite the stored value.

## Validation

- `test_sales_order_with_shipping_rule_without_cost_center`
- `test_sales_order_with_shipping_rule`
- repository pre-commit hooks, including Ruff and PostgreSQL compatibility checks
