### PR TITLE
feat: add Due Upto filter to receivable/payable reports

### DIFF
--- a/erpnext/accounts/report/accounts_payable/accounts_payable.js
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.js
@@ -18,6 +18,11 @@ frappe.query_reports["Accounts Payable"] = {
 			default: frappe.datetime.get_today(),
 		},
 		{
+			fieldname: "due_upto",
+			label: __("Due Upto"),
+			fieldtype: "Date",
+		},
+		{
 			fieldname: "finance_book",
 			label: __("Finance Book"),
 			fieldtype: "Link",

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -20,6 +20,11 @@ frappe.query_reports["Accounts Receivable"] = {
 			default: frappe.datetime.get_today(),
 		},
 		{
+			fieldname: "due_upto",
+			label: __("Due Upto"),
+			fieldtype: "Date",
+		},
+		{
 			fieldname: "finance_book",
 			label: __("Finance Book"),
 			fieldtype: "Link",

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -403,6 +403,15 @@ class ReceivablePayableReport:
 		self.set_party_details(row)
 		self.set_ageing(row)
 
+		# cutoff filters invoices only; leave payments, credit/debit notes and journals untouched
+		if (
+			self.filters.get("due_upto")
+			and self.is_invoice(row)
+			and row.due_date
+			and getdate(row.due_date) > getdate(self.filters.due_upto)
+		):
+			return
+
 		if self.filters.get("group_by_party"):
 			self.update_sub_total_row(row, row.party)
 			if self.previous_party and (self.previous_party != row.party):


### PR DESCRIPTION
Adds an optional **Due Upto** date filter to the Accounts Receivable and Accounts Payable reports to further filter outstanding rows by due date.

<img width="964" height="359" alt="Screenshot 2026-08-01 at 10 29 20 PM" src="https://github.com/user-attachments/assets/36b787a6-69a8-4777-a70b-c4f565df4c70" />

no-docs
