### PR TITLE
fix(accounts): net Add and Deduct tax rows in Purchase Register

### DIFF
--- a/erpnext/accounts/report/purchase_register/purchase_register.py
+++ b/erpnext/accounts/report/purchase_register/purchase_register.py
@@ -553,8 +553,8 @@ def get_invoice_tax_map(invoice_list, invoice_expense_map, expense_accounts, inc
 			else:
 				invoice_expense_map[d.parent][d.account_head] = flt(d.tax_amount)
 		else:
-			invoice_tax_map.setdefault(d.parent, frappe._dict()).setdefault(d.account_head, [])
-			invoice_tax_map[d.parent][d.account_head] = flt(d.tax_amount)
+			invoice_tax_map.setdefault(d.parent, frappe._dict()).setdefault(d.account_head, 0.0)
+			invoice_tax_map[d.parent][d.account_head] += flt(d.tax_amount)
 
 	return invoice_expense_map, invoice_tax_map
 

--- a/erpnext/accounts/report/purchase_register/test_purchase_register.py
+++ b/erpnext/accounts/report/purchase_register/test_purchase_register.py
@@ -47,6 +47,41 @@ class TestPurchaseRegister(ERPNextTestSuite):
 
 		self.assertEqual(labels, sorted([lower, upper], key=str.casefold))
 
+	def test_add_and_deduct_rows_on_one_account_are_netted(self):
+		"""An account head carrying both an Add and a Deduct row must report their net.
+
+		The tax query groups by (parent, account_head, add_deduct_tax), so such an account comes
+		back as two rows. Only one of them survived into the report.
+		"""
+		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import (
+			make_purchase_invoice as make_pi,
+		)
+
+		company = "_Test Company"
+		tax_account = "_Test Account VAT - _TC"
+
+		pi = make_pi(company=company, do_not_save=True)
+		for add_deduct, amount in (("Add", 10), ("Deduct", 4)):
+			pi.append(
+				"taxes",
+				{
+					"charge_type": "Actual",
+					"account_head": tax_account,
+					"description": "VAT",
+					"category": "Total",
+					"add_deduct_tax": add_deduct,
+					"tax_amount": amount,
+					"cost_center": "Main - _TC",
+				},
+			)
+		pi.save()
+		pi.submit()
+
+		filters = frappe._dict(company=company, from_date=add_months(today(), -1), to_date=today())
+		row = next(r for r in execute(filters)[1] if r.get("voucher_no") == pi.name)
+
+		self.assertEqual(flt(row.get(frappe.scrub(tax_account))), 6.0)
+
 	def test_purchase_register_ignores_tax_rows_from_other_doctype(self):
 		filters = frappe._dict(company="_Test Company 6", from_date=add_months(today(), -1), to_date=today())
 


### PR DESCRIPTION
Stacked on #57710.

`get_invoice_tax_map` groups the tax query by `(parent, account_head, add_deduct_tax)`, so an account head carrying both an Add and a Deduct row on one invoice comes back as two rows. The consumer assigned rather than accumulated, so whichever row the engine returned last won and the other was dropped — and that is unordered, so the reported tax could be either the addition or the negated deduction.

An invoice with +10 Add and -4 Deduct on one account reported **-4.0** instead of **6.0**.

Now accumulates, matching what the sibling expense-account branch three lines above already does. The Deduct row is already negated by the query's `CASE`, so the sum is the net. Also drops a `setdefault` to `[]` that the next line immediately overwrote.

Pre-existing and identical on both engines — surfaced by the GROUP BY re-audit (#56241) because the `add_deduct_tax` grouping is what makes the two rows appear.