### PR TITLE
test(postgres): DO NOT MERGE - probe whether MAX() over text agrees across engines

### DIFF
--- a/erpnext/tests/test_text_collation_parity.py
+++ b/erpnext/tests/test_text_collation_parity.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+def max_of(values):
+	rows = " UNION ALL ".join(f"SELECT {frappe.db.escape(value)} AS v" for value in values)
+	return frappe.db.sql(f"SELECT MAX(v) FROM ({rows}) t")[0][0]
+
+
+class TestTextCollationParity(ERPNextTestSuite):
+	"""Does MAX() over text pick the same value on MariaDB and PostgreSQL?
+
+	The PostgreSQL parity effort wrapped many descriptive text columns in Max() to satisfy strict
+	GROUP BY, on the reasoning that Max() returns the value MariaDB picked arbitrarily. Where the
+	column genuinely varies within its group that reasoning does not hold: Max() over text is a
+	sort, and the two engines sort text by different rules.
+
+	These expectations are MariaDB's (utf8mb4 case-insensitive collation: case folded, punctuation
+	and spaces significant). A failure on the PostgreSQL job means the Max()-over-varying-text
+	sites are a live parity gap, not only a row-coherence one.
+	"""
+
+	def test_case_is_folded_not_byte_ordered(self):
+		self.assertEqual(max_of(["apple", "Banana", "cherry"]), "cherry")
+		self.assertEqual(max_of(["abc", "ABD"]), "ABD")
+
+	def test_punctuation_and_space_are_significant(self):
+		# glibc en_US.UTF-8 ignores punctuation at the primary level and would answer "ITEM-C";
+		# MariaDB compares '-' (0x2D) against 'B' (0x42) and answers "ITEMB"
+		self.assertEqual(max_of(["ITEM-C", "ITEMB"]), "ITEMB")
+		self.assertEqual(max_of(["Stores - TC", "StoresbTC"]), "StoresbTC")


### PR DESCRIPTION
**Do not merge.** This exists only to make CI answer a question raised by a re-audit of the GROUP BY changes from #56241. Close it once the Postgres job has reported.

## The question

The parity effort wrapped a large number of descriptive text columns in `Max()` to satisfy Postgres' strict GROUP BY, justified in comments as *"Max() returns the value MySQL picked arbitrarily"*.

Where the column is functionally dependent on the group key that is exactly true and `Max()` is a no-op — which covers most of the sites. Where the column **genuinely varies** within its group it is not true twice over: MySQL picked a row arbitrarily rather than the maximum, and `Max()` over text is a *sort*, which the two engines do differently.

MariaDB's `utf8mb4` collations fold case but treat punctuation and spaces as significant. glibc's `en_US.UTF-8` — what the Linux CI Postgres runs — ignores punctuation at the primary level. So:

| values | MariaDB | glibc Postgres |
|---|---|---|
| `ITEM-C`, `ITEMB` | `ITEMB` | `ITEM-C` |

## What this PR does

Adds `erpnext/tests/test_text_collation_parity.py`, asserting **MariaDB's** answers.

- Passes locally on macOS (BSD/ICU collation, which happens to agree with MariaDB on these cases).
- **If the Postgres job fails it**, the `Max()`-over-varying-text sites are a live cross-engine parity gap, not merely the row-coherence problem they were already known to be — and the fix is to stop sorting: take a representative row, as #57710 does for the disassembly query.
- If it passes, the concern is closed and only the coherence issue remains.

Either result is useful. Neither belongs on `develop`.