### PR TITLE
ci(patch): fall back to develop when the base ref has no frappe branch

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -171,11 +171,17 @@ jobs:
           update_to_version 16 3.14
 
           echo "Updating to latest version"
-          # a stacked PR's base is an erpnext feature branch with no counterpart in frappe,
-          # so fall back to the repository's default branch
           base_ref="${GITHUB_BASE_REF:-${GITHUB_REF##*/}}"
-          git -C "apps/frappe" fetch --depth 1 upstream "$base_ref" \
-            || git -C "apps/frappe" fetch --depth 1 upstream develop
+          ls_remote_status=0
+          git -C "apps/frappe" ls-remote --exit-code --heads upstream "$base_ref" >/dev/null \
+            || ls_remote_status=$?
+          if [ "$ls_remote_status" -eq 2 ]; then
+            echo "frappe has no '$base_ref' branch; falling back to develop"
+            base_ref=develop
+          elif [ "$ls_remote_status" -ne 0 ]; then
+            exit "$ls_remote_status"
+          fi
+          git -C "apps/frappe" fetch --depth 1 upstream "$base_ref"
           git -C "apps/frappe" checkout -q -f FETCH_HEAD
           git -C "apps/erpnext" checkout -q -f "$GITHUB_SHA"
 

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -176,10 +176,10 @@ jobs:
             frappe_ref="refs/heads/$GITHUB_BASE_REF"
             fallback_to_develop=1
           elif [ "${GITHUB_REF_TYPE:-}" = "branch" ]; then
-            frappe_ref="refs/heads/$GITHUB_REF_NAME"
+            frappe_ref="$GITHUB_REF"
             fallback_to_develop=1
           elif [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
-            frappe_ref="refs/tags/$GITHUB_REF_NAME"
+            frappe_ref="$GITHUB_REF"
           else
             echo "Unsupported GitHub ref type: '${GITHUB_REF_TYPE:-unset}'"
             exit 1

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -171,17 +171,30 @@ jobs:
           update_to_version 16 3.14
 
           echo "Updating to latest version"
-          base_ref="${GITHUB_BASE_REF:-${GITHUB_REF##*/}}"
+          fallback_to_develop=0
+          if [ -n "${GITHUB_BASE_REF:-}" ]; then
+            frappe_ref="refs/heads/$GITHUB_BASE_REF"
+            fallback_to_develop=1
+          elif [ "${GITHUB_REF_TYPE:-}" = "branch" ]; then
+            frappe_ref="refs/heads/$GITHUB_REF_NAME"
+            fallback_to_develop=1
+          elif [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+            frappe_ref="refs/tags/$GITHUB_REF_NAME"
+          else
+            echo "Unsupported GitHub ref type: '${GITHUB_REF_TYPE:-unset}'"
+            exit 1
+          fi
+
           ls_remote_status=0
-          git -C "apps/frappe" ls-remote --exit-code --heads upstream "$base_ref" >/dev/null \
+          git -C "apps/frappe" ls-remote --exit-code upstream "$frappe_ref" >/dev/null \
             || ls_remote_status=$?
-          if [ "$ls_remote_status" -eq 2 ]; then
-            echo "frappe has no '$base_ref' branch; falling back to develop"
-            base_ref=develop
+          if [ "$ls_remote_status" -eq 2 ] && [ "$fallback_to_develop" -eq 1 ]; then
+            echo "frappe has no '$frappe_ref'; falling back to develop"
+            frappe_ref=refs/heads/develop
           elif [ "$ls_remote_status" -ne 0 ]; then
             exit "$ls_remote_status"
           fi
-          git -C "apps/frappe" fetch --depth 1 upstream "$base_ref"
+          git -C "apps/frappe" fetch --depth 1 upstream "$frappe_ref"
           git -C "apps/frappe" checkout -q -f FETCH_HEAD
           git -C "apps/erpnext" checkout -q -f "$GITHUB_SHA"
 

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -171,7 +171,11 @@ jobs:
           update_to_version 16 3.14
 
           echo "Updating to latest version"
-          git -C "apps/frappe" fetch --depth 1 upstream "${GITHUB_BASE_REF:-${GITHUB_REF##*/}}"
+          # a stacked PR's base is an erpnext feature branch with no counterpart in frappe,
+          # so fall back to the repository's default branch
+          base_ref="${GITHUB_BASE_REF:-${GITHUB_REF##*/}}"
+          git -C "apps/frappe" fetch --depth 1 upstream "$base_ref" \
+            || git -C "apps/frappe" fetch --depth 1 upstream develop
           git -C "apps/frappe" checkout -q -f FETCH_HEAD
           git -C "apps/erpnext" checkout -q -f "$GITHUB_SHA"
 


### PR DESCRIPTION
The Patch Test fetches the **frappe** repo using this **erpnext** PR's base branch name:

```bash
git -C "apps/frappe" fetch --depth 1 upstream "${GITHUB_BASE_REF:-${GITHUB_REF##*/}}"
```

For an ordinary PR that is `develop`, which exists in `frappe/frappe`. For a stacked PR the base is an erpnext feature branch with no counterpart there, so the fetch fails and the step exits 128 before a single patch runs:

```
fatal: couldn't find remote ref pg-audit/bom-amount-per-line
```

This affects **every** stacked PR. It has been latent rather than absent: earlier stacks passed only because their Patch Test ran while they still targeted `develop`, before being retargeted onto the layer below.

Demonstrated cleanly by stack #57713, where the only variable is the base branch:

| PR | Base | Patch Test |
|---|---|---|
| #57708 | `develop` | pass (8m24s) |
| #57709 | feature branch | fail — `couldn't find remote ref pg-audit/bom-amount-per-line` |
| #57710 | feature branch | fail — `couldn't find remote ref pg-audit/bom-stock-analysis-double-count` |
| #57711 | feature branch | fail — `couldn't find remote ref pg-audit/disassembly-coherent-source-row` |

Falls back to `develop` when the base ref does not resolve. Ordinary PRs and version-branch PRs are unaffected — their base exists in frappe, so the first fetch succeeds and the fallback never runs.

Kept out of stack #57713 deliberately: that stack is query fixes, this is shared CI.