### PR TITLE
fix(banking): fetch company list from DB instead of boot

### DIFF
--- a/banking/src/components/features/BankReconciliation/CompanySelector.tsx
+++ b/banking/src/components/features/BankReconciliation/CompanySelector.tsx
@@ -20,12 +20,13 @@ import { cn } from "@/lib/utils"
 import _ from "@/lib/translate"
 import { selectedBankAccountAtom } from "./bankRecAtoms"
 import { useFrappeGetDocList } from "frappe-react-sdk"
+import ErrorBanner from "@/components/ui/error-banner"
 
 const CompanySelector = ({ onChange }: { onChange?: (company: string) => void }) => {
     const [open, setOpen] = useState(false)
     const [searchQuery, setSearchQuery] = useState("")
 
-    const { data: companies } = useFrappeGetDocList("Company", {
+    const { data: companies, error } = useFrappeGetDocList("Company", {
         limit: 0,
         fields: ["name"],
     }, 'company_list', {
@@ -48,6 +49,10 @@ const CompanySelector = ({ onChange }: { onChange?: (company: string) => void })
             setSelectedBankAccount(null)
             onChange?.(company)
         }
+    }
+
+    if (error) {
+        return <ErrorBanner error={error} />
     }
 
     return (<Popover open={open} onOpenChange={setOpen}>

--- a/banking/src/components/features/BankReconciliation/CompanySelector.tsx
+++ b/banking/src/components/features/BankReconciliation/CompanySelector.tsx
@@ -19,13 +19,21 @@ import {
 import { cn } from "@/lib/utils"
 import _ from "@/lib/translate"
 import { selectedBankAccountAtom } from "./bankRecAtoms"
+import { useFrappeGetDocList } from "frappe-react-sdk"
 
 const CompanySelector = ({ onChange }: { onChange?: (company: string) => void }) => {
     const [open, setOpen] = useState(false)
     const [searchQuery, setSearchQuery] = useState("")
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const options = window.frappe?.boot?.docs?.filter((doc: Record<string, any>) => doc.doctype === ":Company").map((company: Record<string, any>) => company.name) || []
+    const { data: companies } = useFrappeGetDocList("Company", {
+        limit: 0,
+        fields: ["name"],
+    }, 'company_list', {
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+    })
+
+    const options = companies?.map((company: { name: string }) => company.name) || []
 
     const setSelectedCompany = useSetAtom(selectedCompanyAtom)
     const setSelectedBankAccount = useSetAtom(selectedBankAccountAtom)

--- a/banking/src/hooks/useCurrentCompany.ts
+++ b/banking/src/hooks/useCurrentCompany.ts
@@ -1,7 +1,9 @@
 import { useAtomValue } from "jotai"
 import { atomWithStorage } from "jotai/utils"
 
-export const selectedCompanyAtom = atomWithStorage<string>('bank-rec-selected-company', window.frappe?.boot?.user?.defaults?.company || '')
+export const selectedCompanyAtom = atomWithStorage<string>('bank-rec-selected-company', window.frappe?.boot?.user?.defaults?.company || '', undefined, {
+    getOnInit: true,
+})
 
 export const useCurrentCompany = () => {
     const selectedCompany = useAtomValue(selectedCompanyAtom)


### PR DESCRIPTION
Don't use company list from boot - the user sees all company as options in the picker - even ones they do not have access to.

`no-docs`