### PR TITLE
fix: disabled item attribute blocks unrelated edits to existing variants

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -860,7 +860,17 @@ class Item(Document):
 				frappe.throw(_("Item {0} is not a template item.").format(frappe.bold(self.variant_of)))
 
 			if based_on == "Item Attribute":
+				previous_doc = self.get_doc_before_save()
+				saved_attributes = (
+					{(row.attribute, row.attribute_value) for row in previous_doc.attributes}
+					if previous_doc
+					else set()
+				)
+
 				for d in self.attributes:
+					if (d.attribute, d.attribute_value) in saved_attributes:
+						continue
+
 					if not frappe.db.exists(
 						"Item Variant Attribute", {"attribute": d.attribute, "parent": self.variant_of}
 					):

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -423,6 +423,24 @@ class TestItem(ERPNextTestSuite):
 
 		self.assertRaises(InvalidItemAttributeValueError, attribute.save)
 
+	def test_disabled_attribute_blocks_only_attribute_changes(self):
+		frappe.delete_doc_if_exists("Item", "_Test Variant Item-L", force=1)
+
+		variant = create_variant("_Test Variant Item", {"Test Size": "Large"})
+		variant.save()
+
+		attribute = frappe.get_doc("Item Attribute", "Test Size")
+		attribute.disabled = 1
+		attribute.save()
+
+		variant.reload()
+		variant.description = "Edited after the attribute was disabled"
+		variant.save()
+
+		variant.reload()
+		variant.attributes[0].attribute_value = "Small"
+		self.assertRaises(frappe.ValidationError, variant.save)
+
 	def test_rename_attribute_value_updates_variants(self):
 		frappe.delete_doc_if_exists("Item", "_Test Variant Item-L", force=1)
 


### PR DESCRIPTION
Disabling an Item Attribute writes `disabled = 1` into every Item Variant Attribute row, including the rows on the template. `validate_variant` runs on every save and walks the whole attribute table, so any later save of an existing variant re-checks its untouched rows against the now-disabled template row and throws `Attribute {0} is disabled.` — even when the edit never touched the attributes.

`update_variants` hits the same wall, so a single template save fails once an attribute is disabled.

The flag is meant to keep an attribute out of new variants, not to freeze the variants that already use it — `item.js` only reads it to drop the attribute from the variant creation dialog.

Fix: skip attribute rows that are unchanged since the last save. New and edited rows are still validated, so a disabled attribute still cannot be added to an existing variant. The same guard covers the sibling checks for attributes and values the template no longer offers.

### Steps to reproduce
1. Create a template item with an Item Attribute and make a variant from it.
2. Disable the Item Attribute.
3. Edit any field on the variant (say the description) and save.

Before: `Attribute <Name> is disabled.` After: saves; changing an attribute value still throws.