### PR TITLE
fix(accounts): fetch deferred invoice docs on non-empty `sales_docs` or `purchase_docs` in repost accounting ledger

### DIFF
--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -467,19 +467,24 @@ def get_child_docs(doc: list) -> list:
 
 
 def validate_docs_for_deferred_accounting(sales_docs, purchase_docs):
-	docs_with_deferred_revenue = frappe.db.get_all(
-		"Sales Invoice Item",
-		filters={"parent": ["in", sales_docs], "docstatus": 1, "enable_deferred_revenue": True},
-		fields=["parent"],
-		as_list=1,
-	)
+	docs_with_deferred_revenue = ()
+	docs_with_deferred_expense = ()
 
-	docs_with_deferred_expense = frappe.db.get_all(
-		"Purchase Invoice Item",
-		filters={"parent": ["in", purchase_docs], "docstatus": 1, "enable_deferred_expense": 1},
-		fields=["parent"],
-		as_list=1,
-	)
+	if sales_docs:
+		docs_with_deferred_revenue = frappe.db.get_all(
+			"Sales Invoice Item",
+			filters={"parent": ["in", sales_docs], "docstatus": 1, "enable_deferred_revenue": True},
+			fields=["parent"],
+			as_list=1,
+		)
+
+	if purchase_docs:
+		docs_with_deferred_expense = frappe.db.get_all(
+			"Purchase Invoice Item",
+			filters={"parent": ["in", purchase_docs], "docstatus": 1, "enable_deferred_expense": 1},
+			fields=["parent"],
+			as_list=1,
+		)
 
 	if docs_with_deferred_revenue or docs_with_deferred_expense:
 		frappe.throw(


### PR DESCRIPTION
On saving a Repost Accounting Ledger without any Purchase Invoice or Sales Invoice, a `QueryTimeoutError` is encountered due to the difference in the query between `develop` and stable versions (Framework Issue).

SQL Query on `develop`:
```sql
SELECT `parent` FROM `tabPurchase Invoice Item` WHERE ((((1=0) AND (`docstatus`=1))) AND (`enable_deferred_expense`=1)) ORDER BY `creation` DESC
```

SQL Query on `version-16` and `version-15`:
```sql
SELECT `parent` FROM `tabPurchase Invoice Item` WHERE (IFNULL(`parent`,'') IN ('') OR IFNULL(`parent`,'') IS NULL) AND `docstatus`=1 AND `enable_deferred_expense`=1 ORDER BY `creation` DESC
```