### PR TITLE
test: isolate the disabled item attribute test fixtures

### DIFF
--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -424,12 +424,33 @@ class TestItem(ERPNextTestSuite):
 		self.assertRaises(InvalidItemAttributeValueError, attribute.save)
 
 	def test_disabled_attribute_blocks_only_attribute_changes(self):
-		frappe.delete_doc_if_exists("Item", "_Test Variant Item-L", force=1)
+		frappe.delete_doc_if_exists("Item", "_Test Disabled Attribute Template-L", force=1)
+		frappe.delete_doc_if_exists("Item", "_Test Disabled Attribute Template", force=1)
+		frappe.delete_doc_if_exists("Item Attribute", "_Test Disabled Size", force=1)
 
-		variant = create_variant("_Test Variant Item", {"Test Size": "Large"})
+		attribute = frappe.get_doc(
+			{
+				"doctype": "Item Attribute",
+				"attribute_name": "_Test Disabled Size",
+				"item_attribute_values": [
+					{"attribute_value": "Large", "abbr": "L"},
+					{"attribute_value": "Small", "abbr": "S"},
+				],
+			}
+		).insert()
+
+		template = make_item(
+			"_Test Disabled Attribute Template",
+			{
+				"has_variants": 1,
+				"variant_based_on": "Item Attribute",
+				"attributes": [{"attribute": attribute.name}],
+			},
+		)
+
+		variant = create_variant(template.name, {attribute.name: "Large"})
 		variant.save()
 
-		attribute = frappe.get_doc("Item Attribute", "Test Size")
 		attribute.disabled = 1
 		attribute.save()
 


### PR DESCRIPTION
Follow-up to #57747.

`test_disabled_attribute_blocks_only_attribute_changes` disabled the shared `Test Size` Item Attribute. On `develop` that is invisible because `ERPNextTestSuite.tearDown` rolls back after every test. On `version-15` `FrappeTestCase` only rolls back once per class, so the flag stayed visible for the rest of `TestItem` and broke the seven tests that build a variant from `Test Size` — see the backport in #57749.

Build a dedicated Item Attribute and template instead. Nothing the test writes is reachable from another test on either branch, so no cleanup is needed.

The same commit is on the backport branch for #57749.