### PR TITLE
fix(opportunity): add validation for positive item quantities

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -133,6 +133,7 @@ class Opportunity(TransactionBase, CRMNote):
 		self.validate_uom_is_integer("uom", "qty")
 		self.validate_cust_name()
 		self.map_fields()
+		self.validate_qty()
 		self.set_exchange_rate()
 
 		if not self.title:
@@ -142,6 +143,15 @@ class Opportunity(TransactionBase, CRMNote):
 
 	def on_update(self):
 		self.update_prospect()
+
+	def validate_qty(self):
+		for item in self.items:
+			if item.qty <= 0:
+				frappe.throw(
+					_("Row #{0}: Quantity must be greater than 0 for Item {1}").format(
+						item.idx, item.item_code
+					)
+				)
 
 	def map_fields(self):
 		for field in self.meta.get_valid_columns():

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -146,7 +146,7 @@ class Opportunity(TransactionBase, CRMNote):
 
 	def validate_qty(self):
 		for item in self.items:
-			if item.qty <= 0:
+			if flt(item.qty) <= 0:
 				frappe.throw(
 					_("Row #{0}: Quantity must be greater than 0 for Item {1}").format(
 						item.idx, item.item_code


### PR DESCRIPTION
**Issue:**
Opportunity allows users to add items with zero (0) or negative quantities. This can result in invalid opportunity data and inconsistent downstream business processes.

**Description:**
Added server-side validation to the Opportunity doctype to ensure that all item quantities are greater than zero before the document can be saved.
If any item has a quantity less than or equal to zero, the system throws a validation error and prevents the document from being saved.

**Steps to Reproduce:**
1. Go to CRM → Opportunity.
2. Create a new Opportunity.
3. Add an item to the Items table.
4. Enter a quantity of 0 or a negative value (e.g., -5).
5. Click Save.

**Before:**

[oppu_before.webm](https://github.com/user-attachments/assets/f7876ff5-2200-411c-ac1f-9e86044a7b78)


**After:**

[opportunity after.webm](https://github.com/user-attachments/assets/2b048fc7-61c1-4a38-a467-42abaa4faf0f)


**Current Behavior:**
The Opportunity is saved successfully with an invalid item quantity.

**Expected Behavior:**
The system should prevent saving the Opportunity and display a validation message indicating that the item quantity must be greater than zero.

Backport Needed For V16 and V15