### PR TITLE
fix(accounts): skip party dashboard without invoice permission

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -865,9 +865,11 @@ def validate_account_party_type(self):
 
 
 def get_dashboard_info(party_type, party, loyalty_program=None):
-	current_fiscal_year = get_fiscal_year(nowdate(), as_dict=True)
-
 	doctype = "Sales Invoice" if party_type == "Customer" else "Purchase Invoice"
+	if not frappe.has_permission(doctype, "read"):
+		return None
+
+	current_fiscal_year = get_fiscal_year(nowdate(), as_dict=True)
 
 	companies = frappe.get_list(
 		doctype, filters={"docstatus": 1, party_type.lower(): party}, distinct=1, fields=["company"]


### PR DESCRIPTION
**Issue:**
Users with access to Customer or Supplier encountered a permission error when opening the document if they lacked read access to Sales Invoice or Purchase Invoice. This happened because get_dashboard_info queried the related invoice DocType without checking permissions. The change now verifies read access before running dashboard queries and returns None when permission is unavailable, allowing the party document to load normally.

**Ref:** [#75290](https://support.frappe.io/helpdesk/tickets/75290)

**Before:**
<img width="1439" height="658" alt="image" src="https://github.com/user-attachments/assets/429da6cd-b824-4c1f-8a0b-f9f63d4fa018" />


**After:**
<img width="1360" height="575" alt="image" src="https://github.com/user-attachments/assets/38db7783-8142-4ab0-927a-ae9f3fd536a4" />


**Backport Needed for v16 & v15**