### PR TITLE
fix(subscription): don't reactivate a cancelled subscription

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -278,6 +278,9 @@ class Subscription(Document):
 		"""
 		Sets the status of the `Subscription`
 		"""
+		if self.status == STATUS_CANCELLED:
+			return
+
 		self._set_current_invoice_dates()
 		if self.is_trialling():
 			self.status = STATUS_TRIALING
@@ -673,7 +676,7 @@ class Subscription(Document):
 
 		if self.cancel_at_period_end and (
 			getdate(posting_date) >= getdate(self.next_billing_period_end)
-			or getdate(posting_date) >= getdate(self.end_date)
+			or (self.end_date and getdate(posting_date) >= getdate(self.end_date))
 		):
 			self.cancel_subscription()
 

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -779,6 +779,41 @@ class TestSubscription(ERPNextTestSuite):
 		subscription.reload()
 		self.assertEqual(subscription.status, "Active")
 
+	def test_cancelled_subscription_stays_cancelled_after_payment_and_reprocess(self):
+		# https://github.com/frappe/erpnext/issues/57761
+		# An intentionally cancelled subscription must not be resurrected by settling
+		# an invoice issued before cancellation, and an empty end_date must not be
+		# read as "now" by the cancel_at_period_end check on reprocessing.
+		subscription = create_subscription(
+			start_date=nowdate(),
+			generate_invoice_at="Prepaid (bill at period start)",
+			submit_invoice=1,
+			cancel_at_period_end=1,
+		)
+		subscription.process(posting_date=nowdate())
+		invoice = subscription.get_current_invoice()
+		self.assertGreater(invoice.outstanding_amount, 0)
+
+		subscription.cancel_subscription()
+		self.assertEqual(subscription.status, "Cancelled")
+		cancelation_date = subscription.cancelation_date
+		self.assertIsNotNone(cancelation_date)
+
+		payment_entry = get_payment_entry(invoice.doctype, invoice.name, bank_account="_Test Bank - _TC")
+		payment_entry.reference_no = "12345"
+		payment_entry.reference_date = nowdate()
+		payment_entry.submit()
+
+		subscription.reload()
+		self.assertEqual(subscription.status, "Cancelled")
+		self.assertEqual(subscription.cancelation_date, cancelation_date)
+
+		invoice_count = len(subscription.invoices)
+		subscription.process()
+		subscription.reload()
+		self.assertEqual(subscription.status, "Cancelled")
+		self.assertEqual(len(subscription.invoices), invoice_count)
+
 	def test_first_invoice_generated_on_create_for_prepaid(self):
 		subscription = create_subscription(
 			start_date=nowdate(),

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -781,9 +781,6 @@ class TestSubscription(ERPNextTestSuite):
 
 	def test_cancelled_subscription_stays_cancelled_after_payment_and_reprocess(self):
 		# https://github.com/frappe/erpnext/issues/57761
-		# An intentionally cancelled subscription must not be resurrected by settling
-		# an invoice issued before cancellation, and an empty end_date must not be
-		# read as "now" by the cancel_at_period_end check on reprocessing.
 		subscription = create_subscription(
 			start_date=nowdate(),
 			generate_invoice_at="Prepaid (bill at period start)",
@@ -796,7 +793,7 @@ class TestSubscription(ERPNextTestSuite):
 
 		subscription.cancel_subscription()
 		self.assertEqual(subscription.status, "Cancelled")
-		cancelation_date = subscription.cancelation_date
+		cancelation_date = getdate(subscription.cancelation_date)
 		self.assertIsNotNone(cancelation_date)
 
 		payment_entry = get_payment_entry(invoice.doctype, invoice.name, bank_account="_Test Bank - _TC")
@@ -806,7 +803,7 @@ class TestSubscription(ERPNextTestSuite):
 
 		subscription.reload()
 		self.assertEqual(subscription.status, "Cancelled")
-		self.assertEqual(subscription.cancelation_date, cancelation_date)
+		self.assertEqual(getdate(subscription.cancelation_date), cancelation_date)
 
 		invoice_count = len(subscription.invoices)
 		subscription.process()


### PR DESCRIPTION
## What

`Subscription.set_subscription_status()` unconditionally moved status to `Active` whenever there was no outstanding invoice, with no check for whether the subscription had been intentionally cancelled. Settling an invoice that was issued *before* cancellation (e.g. via a Payment Entry, which triggers a status refresh through `PaymentEntry.trigger_invoice_update_for_subscriptions()`) flipped a `Cancelled` subscription back to `Active`, while `cancelation_date` stayed populated.

Separately, `process()`'s `cancel_at_period_end` check compared `posting_date` against `getdate(self.end_date)`. Since `getdate(None)` returns today, a `Subscription` with `cancel_at_period_end = 1` and an empty `end_date` was treated as "cancel now" on every scheduler run.

Combined, these two bugs let a cancelled subscription silently toggle `Cancelled → Active` and generate another invoice at the next period boundary, even though the user had explicitly cancelled it.

### Fix
- `set_subscription_status()` now returns immediately if `status` is already `Cancelled`, so only an explicit `restart_subscription()` call can move it out of that state.
- The `cancel_at_period_end` check in `process()` now guards the `end_date` comparison with `self.end_date and ...`, so an empty `end_date` is no longer read as "now".

### Fixes
Fixes #57761

### Related (same code paths, not fixed by this PR)
- #54079 — `set_subscription_status()` not reflecting status correctly when prior invoices are cancelled/credited/refunded
- #48941 — `cancel_at_period_end` auto-cancel flow raising an error on prorated invoices

## Test plan
- [x] Added `test_cancelled_subscription_stays_cancelled_after_payment_and_reprocess` in `test_subscription.py`, replaying the issue's repro: cancel a subscription, fully settle its pre-cancellation invoice via Payment Entry, then reprocess it.
- [x] Verified red/green manually via a rollback-wrapped console script against a real site (the local dev site's `bench run-tests` is blocked by an unrelated fiscal-year fixture collision in test bootstrap): before the fix, status flipped to `Active` after payment and stayed there after reprocessing; after the fix, status stays `Cancelled` and no extra invoice is generated.
- [x] `ruff check` clean, pre-commit hooks pass.