### PR TITLE
fix(manufacturing): reach the whole configurator from tree toolbar actions

### DIFF
--- a/erpnext/public/js/bom_configurator/bom_configurator.bundle.js
+++ b/erpnext/public/js/bom_configurator/bom_configurator.bundle.js
@@ -32,18 +32,7 @@ class BOMConfigurator {
 	}
 
 	bind_events() {
-		frappe.views.trees["BOM Configurator"].events = {
-			frm: this.frm,
-			add_item: this.add_item,
-			add_sub_assembly: this.add_sub_assembly,
-			set_query_for_workstation: this.set_query_for_workstation,
-			get_sub_assembly_modal_fields: this.get_sub_assembly_modal_fields,
-			convert_to_sub_assembly: this.convert_to_sub_assembly,
-			delete_node: this.delete_node,
-			edit_bom: this.edit_bom,
-			load_tree: this.load_tree,
-			set_default_qty: this.set_default_qty,
-		};
+		frappe.views.trees["BOM Configurator"].events = this;
 	}
 
 	tree_options() {


### PR DESCRIPTION
The BOM Creator tree copied its toolbar handlers onto `view.events` as unbound functions, so `this` inside them was that object literal, not the `BOMConfigurator`. They worked only because the literal also carried `frm`, and broke the moment a handler called a method the literal did not list.

`get_item_code` — added when the tree started keying nodes on the row name — is not in the list, so Add Raw Material, Add Sub Assembly and Convert to Sub Assembly all died on `this.get_item_code is not a function`.

Assign the instance instead of the hand-maintained whitelist.

Verified in the browser: all three actions add to the tree and recompute costs, and the pre-filled item on Convert to Sub Assembly is correct again.

Fixes #57773