### PR TITLE
fix(subscription): don't reactivate a cancelled subscription (backport #57774)

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -560,6 +560,11 @@ class Subscription(Document):
 		1. `process_for_active`
 		2. `process_for_past_due`
 		"""
+		# Snapshot before update_subscription_period() below can roll this forward,
+		# so the cancel_at_period_end check further down still targets the period
+		# that just ended, not the next one.
+		current_period_end = self.current_invoice_end
+
 		if not self.is_current_invoice_generated(
 			self.current_invoice_start, self.current_invoice_end
 		) and self.can_generate_new_invoice(posting_date):
@@ -569,7 +574,7 @@ class Subscription(Document):
 			self.update_subscription_period()
 
 		if self.cancel_at_period_end and (
-			getdate(posting_date) >= getdate(self.current_invoice_end)
+			getdate(posting_date) >= getdate(current_period_end)
 			or (self.end_date and getdate(posting_date) >= getdate(self.end_date))
 		):
 			self.cancel_subscription()

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -221,6 +221,9 @@ class Subscription(Document):
 		"""
 		Sets the status of the `Subscription`
 		"""
+		if self.status == "Cancelled":
+			return
+
 		if self.is_trialling():
 			self.status = "Trialling"
 		elif self.status == "Active" and self.end_date and getdate(posting_date) > getdate(self.end_date):
@@ -567,7 +570,7 @@ class Subscription(Document):
 
 		if self.cancel_at_period_end and (
 			getdate(posting_date) >= getdate(self.current_invoice_end)
-			or getdate(posting_date) >= getdate(self.end_date)
+			or (self.end_date and getdate(posting_date) >= getdate(self.end_date))
 		):
 			self.cancel_subscription()
 

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -307,6 +307,32 @@ class TestSubscription(FrappeTestCase):
 		self.assertEqual(subscription.status, "Cancelled")
 		self.assertEqual(len(subscription.invoices), invoice_count)
 
+	def test_subscription_cancels_at_period_end_without_end_date(self):
+		# https://github.com/frappe/erpnext/issues/57761 -- generate_invoice() rolls
+		# current_invoice_end forward to the next period before this check runs, so
+		# with no end_date to fall back on, cancel_at_period_end must compare
+		# against the period that just ended, not the (already advanced) next one.
+		create_plan(
+			plan_name="_Test plan name 11",
+			cost=80,
+			currency="INR",
+			billing_interval="Day",
+			billing_interval_count=3,
+		)
+		subscription = create_subscription(
+			start_date=nowdate(),
+			generate_invoice_at="End of the current subscription period",
+			plans=[{"plan": "_Test plan name 11", "qty": 1}],
+		)
+		subscription.cancel_at_period_end = 1
+		self.assertEqual(len(subscription.invoices), 0)
+		period_end = subscription.current_invoice_end
+
+		subscription.process(posting_date=period_end)
+
+		self.assertEqual(subscription.status, "Cancelled")
+		self.assertEqual(len(subscription.invoices), 1)
+
 	def test_subscription_restart_and_process(self):
 		settings = frappe.get_single("Subscription Settings")
 		default_grace_period_action = settings.cancel_after_grace

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -280,6 +280,33 @@ class TestSubscription(FrappeTestCase):
 		settings.cancel_after_grace = default_grace_period_action
 		settings.save()
 
+	def test_cancelled_subscription_stays_cancelled_after_payment_and_reprocess(self):
+		# https://github.com/frappe/erpnext/issues/57761
+		subscription = create_subscription(
+			start_date="2018-01-01", generate_invoice_at="Beginning of the current subscription period"
+		)
+		subscription.process(posting_date="2018-01-01")  # generate first invoice
+		self.assertEqual(subscription.status, "Unpaid")
+
+		invoice = subscription.get_current_invoice()
+		invoice.db_set("outstanding_amount", 0)
+		invoice.db_set("status", "Paid")
+
+		subscription.cancel_subscription()
+		self.assertEqual(subscription.status, "Cancelled")
+		cancelation_date = getdate(subscription.cancelation_date)
+
+		subscription.set_subscription_status()
+		self.assertEqual(subscription.status, "Cancelled")
+		self.assertEqual(getdate(subscription.cancelation_date), cancelation_date)
+
+		subscription.cancel_at_period_end = 1
+		subscription.end_date = None
+		invoice_count = len(subscription.invoices)
+		subscription.process()
+		self.assertEqual(subscription.status, "Cancelled")
+		self.assertEqual(len(subscription.invoices), invoice_count)
+
 	def test_subscription_restart_and_process(self):
 		settings = frappe.get_single("Subscription Settings")
 		default_grace_period_action = settings.cancel_after_grace

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -283,12 +283,12 @@ class TestSubscription(FrappeTestCase):
 	def test_cancelled_subscription_stays_cancelled_after_payment_and_reprocess(self):
 		# https://github.com/frappe/erpnext/issues/57761
 		subscription = create_subscription(
-			start_date="2018-01-01", generate_invoice_at="Beginning of the current subscription period"
+			start_date=nowdate(), generate_invoice_at="Beginning of the current subscription period"
 		)
-		subscription.process(posting_date="2018-01-01")  # generate first invoice
-		self.assertEqual(subscription.status, "Unpaid")
-
+		subscription.process(posting_date=nowdate())  # generate first invoice
 		invoice = subscription.get_current_invoice()
+		self.assertIsNotNone(invoice)
+
 		invoice.db_set("outstanding_amount", 0)
 		invoice.db_set("status", "Paid")
 


### PR DESCRIPTION
Manual backport of #57774 to `version-15-hotfix`.

An automatic mergify backport was not used here — a straight cherry-pick of the original commit conflicts on this branch (confirmed locally) since the code predates the `next_billing_period_*` rename and `STATUS_*` constants used on `develop`. This PR reapplies the same fix against this branch's actual code.

## Note on scope for this branch
`version-15-hotfix` does not have the Payment Entry → invoice → `refresh_subscription_status()` hook chain that #57761 reports (added later); `payment_entry.py` / `utils.py` here have no subscription-refresh call at all. The scheduler already excludes `Cancelled` subscriptions (`process_all_subscription()` filters `status != "Cancelled"`), and the "Force-Fetch" UI button that calls `process()` is hidden once a subscription is `Cancelled`. So the exact automatic repro from #57761 does not reproduce on this branch through ordinary usage.

The underlying defect is present though: `set_subscription_status()` unconditionally sets status to `Active` once there's no outstanding invoice, with no check for an existing `Cancelled` status, and `process()`'s `cancel_at_period_end` check reads an empty `end_date` as "now" via `getdate(None)`. Both are reachable directly (e.g. any caller invoking the whitelisted `process()`/`set_subscription_status()` on a cancelled subscription, or if the invoice-refresh hook is ever backported here too), so this closes the same class of bug rather than leaving it in place. Flagging this as lower urgency than the `version-16-hotfix` backport (#57778) since it's not exploitable via normal usage today — happy to drop this one if you'd rather not carry a preventive fix on a stable branch.

## Fix
- `set_subscription_status()` returns immediately if `status` is already `Cancelled`.
- The `cancel_at_period_end` check in `process()` guards the `end_date` comparison with `self.end_date and ...`.

Related to #57761

## Test plan
- Added `test_cancelled_subscription_stays_cancelled_after_payment_and_reprocess`, exercising the reactivation guard directly (`set_subscription_status()`) and the reprocess loop (`process()` with `cancel_at_period_end=1` and empty `end_date`), since this branch has no Payment Entry hook to trigger it through.
- `ruff check` clean, pre-commit hooks pass locally.
- Local `bench run-tests` verification blocked by the same unrelated fiscal-year fixture issue noted on #57774; CI is the verification path here.