### PR TITLE
fix: validate Blanket Order item quantity is greater than zero

### DIFF
--- a/erpnext/manufacturing/doctype/blanket_order/blanket_order.py
+++ b/erpnext/manufacturing/doctype/blanket_order/blanket_order.py
@@ -120,8 +120,8 @@ class BlanketOrder(Document):
 
 	def validate_item_qty(self):
 		for d in self.items:
-			if flt(d.qty) < 0:
-				frappe.throw(_("Row {0}: Quantity cannot be negative.").format(d.idx))
+			if flt(d.qty) <= 0:
+				frappe.throw(_("Row {0}: Quantity must be greater than zero.").format(d.idx))
 
 
 @frappe.whitelist()

--- a/erpnext/manufacturing/doctype/blanket_order/test_blanket_order.py
+++ b/erpnext/manufacturing/doctype/blanket_order/test_blanket_order.py
@@ -162,6 +162,26 @@ class TestBlanketOrder(ERPNextTestSuite):
 		bo = make_blanket_order(blanket_order_type="Purchasing", supplier=supplier, item_code=item_code)
 		self.assertEqual(bo.items[0].party_item_code, "SUPP-PART-1")
 
+	def test_blanket_order_zero_quantity(self):
+		bo = frappe.new_doc("Blanket Order")
+		bo.blanket_order_type = "Selling"
+		bo.company = "_Test Company"
+		bo.customer = "_Test Customer"
+		bo.from_date = today()
+		bo.to_date = add_months(today(), 12)
+
+		bo.append(
+			"items",
+			{
+				"item_code": "_Test Item",
+				"qty": 0,
+				"rate": 100,
+			},
+		)
+
+		with self.assertRaises(frappe.ValidationError):
+			bo.insert()
+
 
 def make_blanket_order(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
**Issue:**
Blanket Order allows items with a quantity of 0.

**Description:**
Currently, the Blanket Order DocType only validates that item quantities are not negative (qty < 0). As a result, users can create and submit a Blanket Order with an item quantity of 0.
A Blanket Order represents a long-term purchasing or selling commitment. Allowing an item with zero quantity creates an invalid agreement because there is no committed quantity to fulfill. This can also lead to inconsistent downstream behavior when creating Purchase Orders or Sales Orders against the Blanket Order.
The validation should require the item quantity to be greater than zero.

**Steps to Reproduce:**
1. Go to Manufacturing → Blanket Order.
2. Create a new Blanket Order.
3. Select either Selling or Purchasing.
4. Fill in the mandatory fields (Company, Customer/Supplier, From Date, To Date).
5. Add an item.
6. Set the item Quantity to 0.
7. Save and Submit the Blanket Order.

**Before:**

[blanket before.webm](https://github.com/user-attachments/assets/eddde51e-4092-45b6-a572-e1bc138cb4dc)



**After:**

[blankeet after.webm](https://github.com/user-attachments/assets/a31e0815-ea2e-4fae-8eb1-eba4be1a911f)


**Current Behavior:**
The Blanket Order is created successfully even though the item quantity is 0.

**Expected Behavior:**
The system should prevent the Blanket Order from being saved or submitted.
A validation error should be shown indicating that the item quantity must be greater than zero.


Backport Needed For V15 and V16