### PR TITLE
Fix/allow zero qty in blanket order

### DIFF
--- a/erpnext/manufacturing/doctype/blanket_order/blanket_order.py
+++ b/erpnext/manufacturing/doctype/blanket_order/blanket_order.py
@@ -119,9 +119,21 @@ class BlanketOrder(Document):
 			d.db_set("ordered_qty", item_ordered_qty.get(d.item_code, 0))
 
 	def validate_item_qty(self):
+		allow_zero_qty = self.is_zero_qty_allowed()
+
 		for d in self.items:
-			if flt(d.qty) <= 0:
+			if flt(d.qty) < 0:
+				frappe.throw(_("Row {0}: Quantity cannot be negative.").format(d.idx))
+
+			if not flt(d.qty) and not allow_zero_qty:
 				frappe.throw(_("Row {0}: Quantity must be greater than zero.").format(d.idx))
+
+	def is_zero_qty_allowed(self):
+		"""Zero qty is allowed only if unit price items are permitted in the order it maps to."""
+		if self.blanket_order_type == "Selling":
+			return frappe.db.get_single_value("Selling Settings", "allow_zero_qty_in_sales_order")
+
+		return frappe.db.get_single_value("Buying Settings", "allow_zero_qty_in_purchase_order")
 
 
 @frappe.whitelist()

--- a/erpnext/manufacturing/doctype/blanket_order/test_blanket_order.py
+++ b/erpnext/manufacturing/doctype/blanket_order/test_blanket_order.py
@@ -182,6 +182,21 @@ class TestBlanketOrder(ERPNextTestSuite):
 		with self.assertRaises(frappe.ValidationError):
 			bo.insert()
 
+	@ERPNextTestSuite.change_settings("Selling Settings", {"allow_zero_qty_in_sales_order": 1})
+	def test_selling_blanket_order_zero_quantity_when_allowed(self):
+		bo = make_blanket_order(blanket_order_type="Selling", quantity=0)
+		self.assertEqual(bo.items[0].qty, 0)
+
+	@ERPNextTestSuite.change_settings("Buying Settings", {"allow_zero_qty_in_purchase_order": 1})
+	def test_purchasing_blanket_order_zero_quantity_when_allowed(self):
+		bo = make_blanket_order(blanket_order_type="Purchasing", quantity=0)
+		self.assertEqual(bo.items[0].qty, 0)
+
+	def test_blanket_order_negative_quantity(self):
+		self.assertRaises(
+			frappe.ValidationError, make_blanket_order, blanket_order_type="Selling", quantity=-10
+		)
+
 
 def make_blanket_order(**args):
 	args = frappe._dict(args)
@@ -201,7 +216,7 @@ def make_blanket_order(**args):
 		"items",
 		{
 			"item_code": args.item_code or "_Test Item",
-			"qty": args.quantity or 1000,
+			"qty": 1000 if args.quantity is None else args.quantity,
 			"rate": args.rate or 100,
 		},
 	)


### PR DESCRIPTION
**Description:**

- A Blanket Order cannot be saved with an item of quantity 0, even when zero quantity is enabled in Selling Settings / Buying Settings. This blocks unit price items — agreements where only the rate is fixed, and the quantity is not known upfront, which is a normal use of a Blanket Order.

- Zero quantity works in Sales Order, Quotation, Purchase Order, Request for Quotation and Supplier Quotation once the corresponding setting is enabled. Blanket Order is the only document that still rejects it.

**Steps to replicate:**

1. Go to **Selling Settings** and enable **Allow Zero Quantity in Sales Order**.
2. Create a new **Blanket Order**.
3. Set Order Type as **Selling**, select a Customer, and set the From Date and To Date.
4. In the Items table, add an item with **Quantity = 0** and a Rate (e.g. 100).
5. Click **Save**.

**Expected result:**

The Blanket Order is saved and submitted, since zero quantity is allowed by the setting.

**Actual result:**

Saving fails with the error:

> Row 1: Quantity must be greater than zero.

The same happens for Order Type **Purchasing** after enabling **Allow Zero Quantity in Purchase Order** in Buying Settings.

**Backport Needed For V15 and V16**
