### PR TITLE
 fix: do not copy Blanket Order naming series to the mapped order

### DIFF
--- a/erpnext/manufacturing/doctype/blanket_order/blanket_order.py
+++ b/erpnext/manufacturing/doctype/blanket_order/blanket_order.py
@@ -149,7 +149,11 @@ def make_order(source_name: str):
 		"Blanket Order",
 		source_name,
 		{
-			"Blanket Order": {"doctype": doctype, "postprocess": update_doc},
+			"Blanket Order": {
+				"doctype": doctype,
+				"field_no_map": ["naming_series"],
+				"postprocess": update_doc,
+			},
 			"Blanket Order Item": {
 				"doctype": doctype + " Item",
 				"field_map": {"rate": "blanket_order_rate", "parent": "blanket_order"},

--- a/erpnext/manufacturing/doctype/blanket_order/test_blanket_order.py
+++ b/erpnext/manufacturing/doctype/blanket_order/test_blanket_order.py
@@ -25,6 +25,7 @@ class TestBlanketOrder(ERPNextTestSuite):
 		so.submit()
 
 		self.assertEqual(so.doctype, "Sales Order")
+		self.assertNotEqual(so.naming_series, bo.naming_series)
 		self.assertEqual(len(so.get("items")), len(bo.get("items")))
 
 		# check the rate, quantity and updation for the ordered quantity
@@ -50,6 +51,7 @@ class TestBlanketOrder(ERPNextTestSuite):
 		po.submit()
 
 		self.assertEqual(po.doctype, "Purchase Order")
+		self.assertNotEqual(po.naming_series, bo.naming_series)
 		self.assertEqual(len(po.get("items")), len(bo.get("items")))
 
 		# check the rate, quantity and updation for the ordered quantity


### PR DESCRIPTION
**Issue:**

When a Sales Order, Purchase Order, or Quotation is created from a Blanket Order, the new document does not use its own naming series. It inherits the Blanket Order's series (`MFG-BLR-.YYYY.-`), so a Sales Order is named `MFG-BLR-2026-00003` instead of `SAL-ORD-2026-00001`.


**Steps to replicate:**

1. Create and submit a **Blanket Order** with Order Type **Selling** — it gets a name like
   `MFG-BLR-2026-00001`.
2. From that Blanket Order, click **Create > Sales Order**.
3. Set a Delivery Date and a quantity, then **Save**.
4. Check the name of the new Sales Order and its **Naming Series** field.
5. Repeat with a **Purchasing** Blanket Order and **Create > Purchase Order**.

**Expected result**

| Created from Blanket Order | Expected name |
| --- | --- |
| Sales Order | `SAL-ORD-2026-00001` |
| Purchase Order | `PUR-ORD-2026-00001` |

Each document uses its own naming series and counter.

**Actual result**

| Created from Blanket Order | Actual name | Naming Series field |
| --- | --- | --- |
| Sales Order | `MFG-BLR-2026-00003` | `MFG-BLR-.YYYY.-` |
| Purchase Order | `MFG-BLR-2026-00004` | `MFG-BLR-.YYYY.-` |


**Backport Needed For V15 and V16**