### PR TITLE
feat: stock validations in Period Closing Voucher and snapshot-seeded batch valuation (backport #57811)

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -18,6 +18,9 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 )
 from erpnext.accounts.utils import get_account_currency, get_fiscal_year
 from erpnext.controllers.accounts_controller import AccountsController
+from erpnext.stock.doctype.stock_closing_entry.stock_closing_entry import (
+	SCOPE_FIELDS as STOCK_CLOSING_SCOPE_FIELDS,
+)
 from erpnext.stock.utils import get_stock_value_on
 
 
@@ -204,11 +207,7 @@ class PeriodClosingVoucher(AccountsController):
 		return flt(balance[0][0]) if balance else 0.0
 
 	def validate_stock_closing_entry(self):
-		status = frappe.db.get_value(
-			"Stock Closing Entry",
-			{"company": self.company, "to_date": self.period_end_date, "docstatus": 1},
-			"status",
-		)
+		status = frappe.db.get_value("Stock Closing Entry", self.get_stock_closing_entry_filters(), "status")
 
 		if status == "Completed":
 			return
@@ -223,10 +222,20 @@ class PeriodClosingVoucher(AccountsController):
 
 		frappe.throw(
 			_(
-				"Create a Stock Closing Entry with To Date as {0} before submitting the Period Closing Voucher."
+				"Create a Stock Closing Entry for the entire company with To Date as {0} before submitting the Period Closing Voucher."
 			).format(frappe.bold(formatdate(self.period_end_date))),
 			title=_("Stock Closing Entry Required"),
 		)
+
+	def get_stock_closing_entry_filters(self):
+		filters = {"company": self.company, "to_date": self.period_end_date, "docstatus": 1}
+
+		meta = frappe.get_meta("Stock Closing Entry")
+		for fieldname in STOCK_CLOSING_SCOPE_FIELDS:
+			if meta.has_field(fieldname):
+				filters[fieldname] = ("is", "not set")
+
+		return filters
 
 	def on_submit(self):
 		self.db_set("gle_processing_status", "In Progress")

--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -7,8 +7,9 @@ import copy
 import frappe
 from frappe import _
 from frappe.query_builder.functions import Sum
-from frappe.utils import add_days, flt, formatdate, getdate
+from frappe.utils import add_days, flt, fmt_money, formatdate, getdate
 
+from erpnext import is_perpetual_inventory_enabled
 from erpnext.accounts.doctype.account_closing_balance.account_closing_balance import (
 	make_closing_entries,
 )
@@ -17,6 +18,7 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 )
 from erpnext.accounts.utils import get_account_currency, get_fiscal_year
 from erpnext.controllers.accounts_controller import AccountsController
+from erpnext.stock.utils import get_stock_value_on
 
 
 class PeriodClosingVoucher(AccountsController):
@@ -129,6 +131,102 @@ class PeriodClosingVoucher(AccountsController):
 		company_currency = frappe.get_cached_value("Company", self.company, "default_currency")
 		if account_currency != company_currency:
 			frappe.throw(_("Currency of the Closing Account must be {0}").format(company_currency))
+
+	def before_submit(self):
+		if not self.has_stock_transactions():
+			return
+
+		self.validate_stock_accounts_balance()
+		self.validate_stock_closing_entry()
+
+	def has_stock_transactions(self):
+		if not is_perpetual_inventory_enabled(self.company):
+			return False
+
+		return bool(
+			frappe.db.exists(
+				"Stock Ledger Entry",
+				{
+					"company": self.company,
+					"is_cancelled": 0,
+					"posting_date": ("<=", self.period_end_date),
+				},
+			)
+		)
+
+	def validate_stock_accounts_balance(self):
+		precision = frappe.get_precision("GL Entry", "debit")
+		account_balance = flt(self.get_stock_accounts_balance(), precision)
+		stock_value = flt(
+			get_stock_value_on(posting_date=self.period_end_date, company=self.company), precision
+		)
+
+		if account_balance == stock_value:
+			return
+
+		currency = frappe.get_cached_value("Company", self.company, "default_currency")
+		frappe.throw(
+			_(
+				"The closing balance {0} of the Stock Asset accounts does not match the closing value {1} of the Stock Balance report as on {2}. Resolve the difference using the Stock Ledger Variance report before closing the period."
+			).format(
+				frappe.bold(fmt_money(account_balance, currency=currency)),
+				frappe.bold(fmt_money(stock_value, currency=currency)),
+				frappe.bold(formatdate(self.period_end_date)),
+			),
+			title=_("Stock Value Mismatch"),
+		)
+
+	def get_stock_accounts_balance(self):
+		gle = frappe.qb.DocType("GL Entry")
+		account = frappe.qb.DocType("Account")
+
+		stock_accounts = (
+			frappe.qb.from_(account)
+			.select(account.name)
+			.where(
+				(account.account_type == "Stock")
+				& (account.company == self.company)
+				& (account.is_group == 0)
+			)
+		)
+
+		balance = (
+			frappe.qb.from_(gle)
+			.select(Sum(gle.debit - gle.credit))
+			.where(
+				(gle.company == self.company)
+				& (gle.is_cancelled == 0)
+				& (gle.posting_date <= self.period_end_date)
+				& gle.account.isin(stock_accounts)
+			)
+		).run()
+
+		return flt(balance[0][0]) if balance else 0.0
+
+	def validate_stock_closing_entry(self):
+		status = frappe.db.get_value(
+			"Stock Closing Entry",
+			{"company": self.company, "to_date": self.period_end_date, "docstatus": 1},
+			"status",
+		)
+
+		if status == "Completed":
+			return
+
+		if status:
+			frappe.throw(
+				_(
+					"The Stock Closing Entry for {0} is not completed yet. Wait for it to complete before submitting the Period Closing Voucher."
+				).format(frappe.bold(formatdate(self.period_end_date))),
+				title=_("Stock Closing Entry In Progress"),
+			)
+
+		frappe.throw(
+			_(
+				"Create a Stock Closing Entry with To Date as {0} before submitting the Period Closing Voucher."
+			).format(frappe.bold(formatdate(self.period_end_date))),
+			title=_("Stock Closing Entry Required"),
+		)
 
 	def on_submit(self):
 		self.db_set("gle_processing_status", "In Progress")

--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -6,8 +6,8 @@ import copy
 
 import frappe
 from frappe import _
-from frappe.query_builder.functions import Sum
-from frappe.utils import add_days, flt, fmt_money, formatdate, getdate
+from frappe.query_builder.functions import Max, Sum
+from frappe.utils import add_days, flt, fmt_money, formatdate, get_link_to_form, getdate
 
 from erpnext import is_perpetual_inventory_enabled
 from erpnext.accounts.doctype.account_closing_balance.account_closing_balance import (
@@ -18,9 +18,7 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 )
 from erpnext.accounts.utils import get_account_currency, get_fiscal_year
 from erpnext.controllers.accounts_controller import AccountsController
-from erpnext.stock.doctype.stock_closing_entry.stock_closing_entry import (
-	SCOPE_FIELDS as STOCK_CLOSING_SCOPE_FIELDS,
-)
+from erpnext.stock.doctype.stock_closing_entry.stock_closing_entry import apply_unscoped_filters
 from erpnext.stock.utils import get_stock_value_on
 
 
@@ -207,12 +205,24 @@ class PeriodClosingVoucher(AccountsController):
 		return flt(balance[0][0]) if balance else 0.0
 
 	def validate_stock_closing_entry(self):
-		status = frappe.db.get_value("Stock Closing Entry", self.get_stock_closing_entry_filters(), "status")
+		closing_entry = frappe.db.get_value(
+			"Stock Closing Entry",
+			apply_unscoped_filters(
+				{"company": self.company, "to_date": self.period_end_date, "docstatus": 1}
+			),
+			["name", "status", "modified"],
+			as_dict=True,
+		)
 
-		if status == "Completed":
-			return
+		if not closing_entry:
+			frappe.throw(
+				_(
+					"Create a Stock Closing Entry for the entire company with To Date as {0} before submitting the Period Closing Voucher."
+				).format(frappe.bold(formatdate(self.period_end_date))),
+				title=_("Stock Closing Entry Required"),
+			)
 
-		if status:
+		if closing_entry.status != "Completed":
 			frappe.throw(
 				_(
 					"The Stock Closing Entry for {0} is not completed yet. Wait for it to complete before submitting the Period Closing Voucher."
@@ -220,22 +230,23 @@ class PeriodClosingVoucher(AccountsController):
 				title=_("Stock Closing Entry In Progress"),
 			)
 
-		frappe.throw(
-			_(
-				"Create a Stock Closing Entry for the entire company with To Date as {0} before submitting the Period Closing Voucher."
-			).format(frappe.bold(formatdate(self.period_end_date))),
-			title=_("Stock Closing Entry Required"),
-		)
+		self.validate_stock_closing_entry_is_fresh(closing_entry)
 
-	def get_stock_closing_entry_filters(self):
-		filters = {"company": self.company, "to_date": self.period_end_date, "docstatus": 1}
+	def validate_stock_closing_entry_is_fresh(self, closing_entry):
+		sle = frappe.qb.DocType("Stock Ledger Entry")
+		last_change = (
+			frappe.qb.from_(sle)
+			.select(Max(sle.modified))
+			.where((sle.company == self.company) & (sle.posting_date <= self.period_end_date))
+		).run()
 
-		meta = frappe.get_meta("Stock Closing Entry")
-		for fieldname in STOCK_CLOSING_SCOPE_FIELDS:
-			if meta.has_field(fieldname):
-				filters[fieldname] = ("is", "not set")
-
-		return filters
+		if last_change and last_change[0][0] and last_change[0][0] > closing_entry.modified:
+			frappe.throw(
+				_(
+					"Stock transactions were created or modified after the Stock Closing Entry {0} was generated. Regenerate it before submitting the Period Closing Voucher."
+				).format(get_link_to_form("Stock Closing Entry", closing_entry.name)),
+				title=_("Stock Closing Entry Outdated"),
+			)
 
 	def on_submit(self):
 		self.db_set("gle_processing_status", "In Progress")

--- a/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
@@ -310,8 +310,23 @@ class TestPeriodClosingVoucher(ERPNextTestSuite):
 	def test_stock_validations_before_period_closing(self):
 		from unittest.mock import patch
 
+		from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
 		from erpnext.stock.doctype.item.test_item import make_item
 		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+		create_custom_fields(
+			{
+				"Stock Closing Entry": [
+					{
+						"fieldname": "warehouse",
+						"label": "Warehouse",
+						"fieldtype": "Link",
+						"options": "Warehouse",
+					}
+				]
+			}
+		)
 
 		item = make_item("Test PCV Stock Item", {"is_stock_item": 1})
 		se = make_stock_entry(
@@ -332,11 +347,19 @@ class TestPeriodClosingVoucher(ERPNextTestSuite):
 				"company": "Test PCV Company",
 				"from_date": pcv.period_start_date,
 				"to_date": pcv.period_end_date,
+				"warehouse": "Stores - TPC",
 			}
 		).insert()
 
 		with patch("erpnext.stock.doctype.stock_closing_entry.stock_closing_entry.enqueue"):
 			sce.submit()
+
+		sce.db_set("status", "Completed")
+
+		pcv.reload()
+		self.assertRaisesRegex(frappe.ValidationError, "Create a Stock Closing Entry", pcv.submit)
+
+		frappe.db.set_value("Stock Closing Entry", sce.name, {"warehouse": None, "status": "In Progress"})
 
 		pcv.reload()
 		self.assertRaisesRegex(frappe.ValidationError, "is not completed yet", pcv.submit)

--- a/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
@@ -307,6 +307,64 @@ class TestPeriodClosingVoucher(ERPNextTestSuite):
 		repost_doc.posting_date = today()
 		repost_doc.save()
 
+	def test_stock_validations_before_period_closing(self):
+		from unittest.mock import patch
+
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+		item = make_item("Test PCV Stock Item", {"is_stock_item": 1})
+		se = make_stock_entry(
+			item_code=item.name,
+			qty=10,
+			rate=100,
+			to_warehouse="Stores - TPC",
+			company="Test PCV Company",
+			posting_date="2021-03-15",
+		)
+
+		pcv = self.make_period_closing_voucher(posting_date="2021-03-31", submit=False)
+		self.assertRaisesRegex(frappe.ValidationError, "Create a Stock Closing Entry", pcv.submit)
+
+		sce = frappe.get_doc(
+			{
+				"doctype": "Stock Closing Entry",
+				"company": "Test PCV Company",
+				"from_date": pcv.period_start_date,
+				"to_date": pcv.period_end_date,
+			}
+		).insert()
+
+		with patch("erpnext.stock.doctype.stock_closing_entry.stock_closing_entry.enqueue"):
+			sce.submit()
+
+		pcv.reload()
+		self.assertRaisesRegex(frappe.ValidationError, "is not completed yet", pcv.submit)
+
+		sce.create_stock_closing_balance_entries()
+		sce.db_set("status", "Completed")
+
+		sle = frappe.db.get_value(
+			"Stock Ledger Entry",
+			{"voucher_no": se.name},
+			["name", "stock_value_difference"],
+			as_dict=1,
+		)
+		frappe.db.set_value(
+			"Stock Ledger Entry", sle.name, "stock_value_difference", sle.stock_value_difference + 100
+		)
+
+		pcv.reload()
+		self.assertRaisesRegex(frappe.ValidationError, "does not match", pcv.submit)
+
+		frappe.db.set_value(
+			"Stock Ledger Entry", sle.name, "stock_value_difference", sle.stock_value_difference
+		)
+
+		pcv.reload()
+		pcv.submit()
+		self.assertEqual(pcv.docstatus, 1)
+
 	def make_period_closing_voucher(self, posting_date, submit=True):
 		surplus_account = create_account()
 		cost_center = create_cost_center("Test Cost Center 1")

--- a/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
@@ -3,7 +3,7 @@
 import unittest
 
 import frappe
-from frappe.utils import today
+from frappe.utils import flt, today
 
 from erpnext.accounts.doctype.finance_book.test_finance_book import create_finance_book
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
@@ -385,8 +385,139 @@ class TestPeriodClosingVoucher(ERPNextTestSuite):
 		)
 
 		pcv.reload()
+		self.assertRaisesRegex(frappe.ValidationError, "Regenerate", pcv.submit)
+
+		self.rebuild_stock_closing_balance(sce)
+		pcv.reload()
 		pcv.submit()
 		self.assertEqual(pcv.docstatus, 1)
+
+	def test_batch_valuation_seeded_from_stock_closing_after_period_closing(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle import (
+			get_batch_from_bundle,
+		)
+		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+		item = make_item(
+			"Test PCV Batch Item",
+			{
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "TPCVB.####",
+			},
+		)
+		se1 = make_stock_entry(
+			item_code=item.name,
+			qty=10,
+			rate=100,
+			to_warehouse="Stores - TPC",
+			company="Test PCV Company",
+			posting_date="2021-03-15",
+		)
+		batch_no = get_batch_from_bundle(se1.items[0].serial_and_batch_bundle)
+		make_stock_entry(
+			item_code=item.name,
+			qty=10,
+			rate=200,
+			to_warehouse="Stores - TPC",
+			company="Test PCV Company",
+			posting_date="2021-06-15",
+			batch_no=batch_no,
+		)
+
+		pcv = self.make_period_closing_voucher(posting_date="2021-03-31", submit=False)
+		sce = self.make_completed_stock_closing_entry(pcv.period_start_date, pcv.period_end_date)
+		pcv.reload()
+		pcv.submit()
+
+		outward = make_stock_entry(
+			item_code=item.name,
+			qty=5,
+			from_warehouse="Stores - TPC",
+			company="Test PCV Company",
+			posting_date="2022-04-01",
+			batch_no=batch_no,
+		)
+		stock_value_difference = frappe.db.get_value(
+			"Stock Ledger Entry",
+			{"voucher_no": outward.name, "is_cancelled": 0},
+			"stock_value_difference",
+		)
+		self.assertEqual(flt(stock_value_difference, 2), -750.0)
+
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"frozen",
+			make_stock_entry,
+			item_code=item.name,
+			qty=1,
+			rate=100,
+			to_warehouse="Stores - TPC",
+			company="Test PCV Company",
+			posting_date="2021-05-01",
+		)
+		self.assertRaisesRegex(frappe.ValidationError, "frozen", se1.cancel)
+		self.assertRaisesRegex(frappe.ValidationError, "closed accounting period", sce.cancel)
+
+	def test_period_closing_blocks_stale_stock_closing_entry(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+		item = make_item("Test PCV Stock Item", {"is_stock_item": 1})
+		make_stock_entry(
+			item_code=item.name,
+			qty=10,
+			rate=100,
+			to_warehouse="Stores - TPC",
+			company="Test PCV Company",
+			posting_date="2021-03-15",
+		)
+
+		pcv = self.make_period_closing_voucher(posting_date="2021-03-31", submit=False)
+		sce = self.make_completed_stock_closing_entry(pcv.period_start_date, pcv.period_end_date)
+
+		make_stock_entry(
+			item_code=item.name,
+			qty=5,
+			rate=100,
+			to_warehouse="Stores - TPC",
+			company="Test PCV Company",
+			posting_date="2021-05-01",
+		)
+
+		pcv.reload()
+		self.assertRaisesRegex(frappe.ValidationError, "Regenerate", pcv.submit)
+
+		self.rebuild_stock_closing_balance(sce)
+		pcv.reload()
+		pcv.submit()
+		self.assertEqual(pcv.docstatus, 1)
+
+	def make_completed_stock_closing_entry(self, from_date, to_date):
+		from unittest.mock import patch
+
+		sce = frappe.get_doc(
+			{
+				"doctype": "Stock Closing Entry",
+				"company": "Test PCV Company",
+				"from_date": from_date,
+				"to_date": to_date,
+			}
+		).insert()
+
+		with patch("erpnext.stock.doctype.stock_closing_entry.stock_closing_entry.enqueue"):
+			sce.submit()
+
+		sce.create_stock_closing_balance_entries()
+		sce.db_set("status", "Completed")
+		return sce
+
+	def rebuild_stock_closing_balance(self, sce):
+		sce.remove_stock_closing()
+		sce.create_stock_closing_balance_entries()
+		sce.db_set("status", "Completed")
 
 	def make_period_closing_voucher(self, posting_date, submit=True):
 		surplus_account = create_account()

--- a/erpnext/stock/deprecated_serial_batch.py
+++ b/erpnext/stock/deprecated_serial_batch.py
@@ -159,6 +159,9 @@ class DeprecatedBatchNoValuation:
 		if self.sle.name:
 			query = query.where(sle.name != self.sle.name)
 
+		if getattr(self, "stock_closing_from_datetime", None):
+			query = query.where(sle.posting_datetime >= self.stock_closing_from_datetime)
+
 		return query.run(as_dict=True)
 
 	@deprecated(

--- a/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
+++ b/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
@@ -10,10 +10,50 @@ from frappe.desk.form.load import get_attachments
 from frappe.model.document import Document
 from frappe.utils import add_days, get_date_str, get_link_to_form, nowtime, parse_json
 from frappe.utils.background_jobs import enqueue
+from frappe.utils.caching import request_cache
 
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
 
 SCOPE_FIELDS = ("warehouse", "item_code", "item_group", "warehouse_type")
+
+
+def apply_unscoped_filters(filters):
+	meta = frappe.get_meta("Stock Closing Entry")
+	for fieldname in SCOPE_FIELDS:
+		if meta.has_field(fieldname):
+			filters[fieldname] = ("is", "not set")
+
+	return filters
+
+
+def get_closing_entry_for_closed_period(company):
+	closed_upto = frappe.db.get_value(
+		"Period Closing Voucher", {"docstatus": 1, "company": company}, [{"MAX": "period_end_date"}]
+	)
+	if not closed_upto:
+		return None
+
+	return _get_completed_closing_entry(company, str(closed_upto))
+
+
+@request_cache
+def _get_completed_closing_entry(company, closed_upto):
+	filters = apply_unscoped_filters(
+		{
+			"company": company,
+			"docstatus": 1,
+			"status": "Completed",
+			"to_date": ("<=", closed_upto),
+		}
+	)
+
+	return frappe.db.get_value(
+		"Stock Closing Entry",
+		filters,
+		["name", "to_date"],
+		order_by="to_date desc",
+		as_dict=True,
+	)
 
 
 class StockClosingEntry(Document):
@@ -88,14 +128,30 @@ class StockClosingEntry(Document):
 		self.enqueue_job()
 
 	def on_cancel(self):
+		self.validate_closed_period_lock()
 		self.set_status(save=True)
 		self.remove_stock_closing()
+
+	def validate_closed_period_lock(self):
+		pcv = frappe.db.get_value(
+			"Period Closing Voucher",
+			{"company": self.company, "docstatus": 1, "period_end_date": (">=", self.to_date)},
+			"name",
+		)
+
+		if pcv:
+			frappe.throw(
+				_(
+					"Stock Closing Entry {0} belongs to a closed accounting period. Cancel the Period Closing Voucher {1} first."
+				).format(self.name, get_link_to_form("Period Closing Voucher", pcv)),
+				title=_("Closed Period"),
+			)
 
 	def remove_stock_closing(self):
 		table = frappe.qb.DocType("Stock Closing Balance")
 		frappe.qb.from_(table).delete().where(table.stock_closing_entry == self.name).run()
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def enqueue_job(self):
 		self.db_set("status", "In Progress")
 		enqueue(prepare_closing_stock_balance, name=self.name, queue="long", timeout=1500)
@@ -105,8 +161,9 @@ class StockClosingEntry(Document):
 			).format(self.name)
 		)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def regenerate_closing_balance(self):
+		self.validate_closed_period_lock()
 		self.remove_stock_closing()
 		self.enqueue_job()
 

--- a/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
+++ b/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
@@ -13,6 +13,8 @@ from frappe.utils.background_jobs import enqueue
 
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
 
+SCOPE_FIELDS = ("warehouse", "item_code", "item_group", "warehouse_type")
+
 
 class StockClosingEntry(Document):
 	# begin: auto-generated types
@@ -68,7 +70,7 @@ class StockClosingEntry(Document):
 			)
 		)
 
-		for fieldname in ["warehouse", "item_code", "item_group", "warehouse_type"]:
+		for fieldname in SCOPE_FIELDS:
 			if self.get(fieldname):
 				query = query.where(table[fieldname] == self.get(fieldname))
 

--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -820,19 +820,66 @@ class BatchNoValuation(DeprecatedBatchNoValuation):
 				"Serial and Batch Bundle", self.sle.serial_and_batch_bundle, "total_amount"
 			)
 		else:
-			entries = self.get_batch_stock_before_date()
 			self.stock_value_change = 0.0
 			self.batch_avg_rate = defaultdict(float)
 			self.available_qty = defaultdict(float)
 			self.stock_value_differece = defaultdict(float)
 
-			for ledger in entries:
+			self.seed_from_stock_closing_balance()
+
+			for ledger in self.get_batch_stock_before_date():
 				self.stock_value_differece[ledger.batch_no] += flt(ledger.incoming_rate)
 				self.available_qty[ledger.batch_no] += flt(ledger.qty)
 
 			self.calculate_avg_rate_from_deprecarated_ledgers()
 			self.calculate_avg_rate_for_non_batchwise_valuation()
 			self.set_stock_value_difference()
+
+	def seed_from_stock_closing_balance(self):
+		self.stock_closing_from_datetime = None
+		closing_entry = self.get_closing_entry_for_seeding()
+		if not closing_entry:
+			return
+
+		from erpnext.stock.utils import get_combine_datetime
+
+		self.stock_closing_from_datetime = get_combine_datetime(
+			add_days(closing_entry.to_date, 1), "00:00:00"
+		)
+
+		for row in self.get_stock_closing_balance_entries(closing_entry.name):
+			self.stock_value_differece[row.batch_no] += flt(row.stock_value_difference)
+			self.available_qty[row.batch_no] += flt(row.actual_qty)
+
+	def get_closing_entry_for_seeding(self):
+		from erpnext.stock.doctype.stock_closing_entry.stock_closing_entry import (
+			get_closing_entry_for_closed_period,
+		)
+
+		if not self.batchwise_valuation_batches or not self.sle.posting_date:
+			return None
+
+		company = self.sle.company or frappe.get_cached_value("Warehouse", self.sle.warehouse, "company")
+		closing_entry = get_closing_entry_for_closed_period(company)
+		if not closing_entry or getdate(self.sle.posting_date) <= getdate(closing_entry.to_date):
+			return None
+
+		return closing_entry
+
+	def get_stock_closing_balance_entries(self, closing_entry):
+		table = frappe.qb.DocType("Stock Closing Balance")
+
+		return (
+			frappe.qb.from_(table)
+			.select(table.batch_no, table.actual_qty, table.stock_value_difference)
+			.where(
+				(table.stock_closing_entry == closing_entry)
+				& (table.item_code == self.sle.item_code)
+				& (table.warehouse == self.sle.warehouse)
+				& table.batch_no.isin(self.batchwise_valuation_batches)
+				& (table.inventory_dimension_key.isnull() | (table.inventory_dimension_key == ""))
+			)
+		).run(as_dict=True)
 
 	def get_batch_stock_before_date(self) -> list[dict]:
 		# Get batch wise stock value difference from Serial and Batch Bundle considering time condition
@@ -877,6 +924,9 @@ class BatchNoValuation(DeprecatedBatchNoValuation):
 		query = query.where(child.voucher_type != "Pick List")
 		if timestamp_condition:
 			query = query.where(timestamp_condition)
+
+		if self.stock_closing_from_datetime:
+			query = query.where(child.posting_datetime >= self.stock_closing_from_datetime)
 
 		return query.run(as_dict=True)
 

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -56,6 +56,32 @@ class SerialNoExistsInFutureTransaction(frappe.ValidationError):
 	pass
 
 
+def validate_stock_frozen_by_closing_entry(sl_entries):
+	from erpnext.stock.doctype.stock_closing_entry.stock_closing_entry import (
+		get_closing_entry_for_closed_period,
+	)
+
+	company = sl_entries[0].get("company")
+	if not company:
+		company = frappe.get_cached_value("Warehouse", sl_entries[0].get("warehouse"), "company")
+
+	closing_entry = get_closing_entry_for_closed_period(company)
+	if not closing_entry:
+		return
+
+	for sle in sl_entries:
+		if sle.get("posting_date") and getdate(sle.get("posting_date")) <= getdate(closing_entry.to_date):
+			frappe.throw(
+				_(
+					"Stock transactions dated on or before {0} are frozen because the period is closed and the Stock Closing Entry {1} has been generated. To make changes, cancel the Period Closing Voucher first."
+				).format(
+					frappe.bold(format_date(closing_entry.to_date)),
+					get_link_to_form("Stock Closing Entry", closing_entry.name),
+				),
+				title=_("Stock Frozen"),
+			)
+
+
 def make_sl_entries(sl_entries, allow_negative_stock=False, via_landed_cost_voucher=False):
 	"""Create SL entries from SL entry dicts
 
@@ -70,6 +96,8 @@ def make_sl_entries(sl_entries, allow_negative_stock=False, via_landed_cost_vouc
 	from erpnext.controllers.stock_controller import future_sle_exists
 
 	if sl_entries:
+		validate_stock_frozen_by_closing_entry(sl_entries)
+
 		cancelled = sl_entries[0].get("is_cancelled")
 		if cancelled:
 			validate_cancellation(sl_entries)


### PR DESCRIPTION
Backport of #57811 to version-16-hotfix.

On Period Closing Voucher submission (perpetual inventory companies with stock ledger entries up to the period end date):

1. **Stock value validation** — the balance of all `Stock` type asset accounts as on the period end date must match the closing stock value from the Stock Ledger; mismatches block submission while corrections are still possible.
2. **Mandatory Stock Closing Entry** — a submitted, completed, company-wide Stock Closing Entry with To Date equal to the period end date is required (scoped entries are not accepted).
3. **Freshness check** — a snapshot generated before later changes to in-period stock entries must be regenerated before closing.
4. **Stock freeze** — after closing, stock ledger entries dated on or before the closing date can no longer be created or cancelled; the Stock Closing Entry backing a submitted Period Closing Voucher is locked against cancel/regenerate.
5. **Snapshot-seeded batch valuation** — batch-wise valuation seeds per-batch qty/value from the closed period's Stock Closing Balance and bounds history scans to entries after the closing date.

Conflicts resolved against version-16-hotfix:
- dropped develop-only context (`validate_standard_cost_posting_date`, `sle_processing_gate`, postgres advisory-lock block, dimension-grouped opening balance test)
- adapted the closing-date bound to this branch's query-chaining style in `get_batch_stock_before_date` and `get_sle_for_batches`

🤖 Generated with [Claude Code](https://claude.com/claude-code)