### PR TITLE
fix(sales-invoice): respect Customize Form hidden setting on Update Stock

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -587,7 +587,12 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 		super.set_dynamic_labels();
 		this.frm.events.hide_fields(this.frm);
 		const hide_update_stock = cint(this.frm.doc.is_debit_note) || cint(this.frm.doc.has_subcontracted);
-		this.frm.set_df_property("update_stock", "hidden", hide_update_stock);
+		// frm.set_df_property mutates a per-document copy, not the doctype's shared field
+		// metadata, so this always reflects the original (Customize Form) hidden value.
+		const hidden_by_customization = cint(
+			frappe.meta.get_docfield("Sales Invoice", "update_stock")?.hidden
+		);
+		this.frm.set_df_property("update_stock", "hidden", hide_update_stock || hidden_by_customization);
 	}
 
 	items_on_form_rendered() {


### PR DESCRIPTION
Hiding \`update_stock\` via Customize Form (Property Setter) doesn't stick — it reappears on a new Sales Invoice.

\`set_dynamic_labels()\` unconditionally sets \`hidden\` based only on \`is_debit_note\`/\`has_subcontracted\`, overwriting whatever Customize Form set, on every refresh.

Fix: OR that condition with the field's original (property-setter-driven) hidden value, read from \`frappe.meta.get_docfield\` (the doctype's shared metadata, unaffected by \`set_df_property\`'s per-document mutation).

This is for V17 Develop