### PR TITLE
fix(sales-invoice): respect Customize Form hidden setting on Update Stock

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -1180,7 +1180,16 @@ frappe.ui.form.on("Sales Invoice", {
 		}
 
 		frm.set_df_property("update_stock", "read_only", frm.doc.has_subcontracted);
-		frm.toggle_display("update_stock", !frm.doc.has_subcontracted);
+		// frm.set_df_property mutates a per-document copy, not the doctype's shared field
+		// metadata, so this always reflects the original (Customize Form) hidden value.
+		const hidden_by_customization = cint(
+			frappe.meta.get_docfield("Sales Invoice", "update_stock")?.hidden
+		);
+		frm.set_df_property(
+			"update_stock",
+			"hidden",
+			cint(frm.doc.has_subcontracted) || hidden_by_customization
+		);
 	},
 });
 


### PR DESCRIPTION
Backport of #57818.

Hiding \`update_stock\` via Customize Form doesn't stick — \`frm.toggle_display("update_stock", ...)\` in the refresh handler unconditionally shows it based only on \`has_subcontracted\`, overwriting the Customize Form setting every refresh.

Fix: OR that condition with the field's original (property-setter-driven) hidden value.