### PR TITLE
fix: keep asset repair downtime in sync with entered dates

### DIFF
--- a/erpnext/assets/doctype/asset_repair/asset_repair.js
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.js
@@ -116,24 +116,39 @@ frappe.ui.form.on("Asset Repair", {
 	},
 
 	repair_status: (frm) => {
-		if (frm.doc.completion_date && frm.doc.repair_status == "Completed") {
-			frappe.call({
-				method: "erpnext.assets.doctype.asset_repair.asset_repair.get_downtime",
-				args: {
-					failure_date: frm.doc.failure_date,
-					completion_date: frm.doc.completion_date,
-				},
-				callback: function (r) {
-					if (r.message) {
-						frm.set_value("downtime", r.message + " Hrs");
-					}
-				},
-			});
-		}
-
 		if (frm.doc.repair_status == "Completed" && !frm.doc.completion_date) {
 			frm.set_value("completion_date", frappe.datetime.now_datetime());
 		}
+
+		frm.events.set_downtime(frm);
+	},
+
+	failure_date: (frm) => {
+		frm.events.set_downtime(frm);
+	},
+
+	completion_date: (frm) => {
+		frm.events.set_downtime(frm);
+	},
+
+	set_downtime: (frm) => {
+		if (frm.doc.repair_status != "Completed" || !frm.doc.failure_date || !frm.doc.completion_date) {
+			frm.set_value("downtime", null);
+			return;
+		}
+
+		frappe.call({
+			method: "erpnext.assets.doctype.asset_repair.asset_repair.get_downtime",
+			args: {
+				failure_date: frm.doc.failure_date,
+				completion_date: frm.doc.completion_date,
+			},
+			callback: function (r) {
+				if (r.message) {
+					frm.set_value("downtime", r.message + " Hrs");
+				}
+			},
+		});
 	},
 
 	stock_items_on_form_rendered() {

--- a/erpnext/assets/doctype/asset_repair/asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.py
@@ -67,6 +67,7 @@ class AssetRepair(AccountsController):
 		self.calculate_repair_cost()
 		self.calculate_total_repair_cost()
 		self.check_repair_status()
+		self.set_downtime()
 
 	def validate_asset(self):
 		if self.asset_doc.status in ("Sold", "Scrapped"):
@@ -238,6 +239,13 @@ class AssetRepair(AccountsController):
 	def check_repair_status(self):
 		if self.repair_status == "Pending" and self.docstatus == 1:
 			frappe.throw(_("Please update Repair Status."))
+
+	def set_downtime(self):
+		# keep downtime in sync with the entered dates, regardless of edit order
+		if self.repair_status == "Completed" and self.failure_date and self.completion_date:
+			self.downtime = f"{get_downtime(self.failure_date, self.completion_date)} Hrs"
+		else:
+			self.downtime = None
 
 	def update_asset_value(self):
 		total_repair_cost = self.total_repair_cost if self.docstatus == 1 else -1 * self.total_repair_cost

--- a/erpnext/assets/doctype/asset_repair/test_asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/test_asset_repair.py
@@ -98,6 +98,21 @@ class TestAssetRepair(ERPNextTestSuite):
 		asset_repair = create_asset_repair(submit=1)
 		self.assertNotEqual(asset_repair.repair_status, "Pending")
 
+	def test_downtime_stays_in_sync_with_dates(self):
+		asset = create_asset(submit=1)
+		asset_repair = create_asset_repair(asset=asset)
+
+		asset_repair.failure_date = "2026-07-31 09:00:00"
+		asset_repair.completion_date = "2026-07-31 11:00:00"
+		asset_repair.repair_status = "Completed"
+		asset_repair.save()
+		self.assertEqual(asset_repair.downtime, "2.0 Hrs")
+
+		# editing a date must refresh downtime, not leave a stale value
+		asset_repair.completion_date = "2026-07-31 14:30:00"
+		asset_repair.save()
+		self.assertEqual(asset_repair.downtime, "5.5 Hrs")
+
 	def test_stock_items(self):
 		asset_repair = create_asset_repair(stock_consumption=1)
 		self.assertTrue(asset_repair.stock_consumption)


### PR DESCRIPTION
The Downtime field only recalculated when the Repair Status changed, and only client-side. Editing the Failure or Completion date afterwards left a stale value (e.g. showing 11.25 Hrs for a 2-hour window), which then got saved as-is since nothing recomputed it server-side.

- Compute `downtime` in `validate()` so the saved value always matches the entered dates, independent of the JS trigger order.
- Refresh it on `failure_date` / `completion_date` changes on the form, not just on `repair_status`.
- Add a test covering recalculation on date change.

https://support.frappe.io/helpdesk/tickets/75581?view=VIEW-HD+Ticket-70177