### PR TITLE
fix: keep asset repair downtime in sync with entered dates

### DIFF
--- a/erpnext/assets/doctype/asset_repair/asset_repair.js
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.js
@@ -86,24 +86,39 @@ frappe.ui.form.on("Asset Repair", {
 	},
 
 	repair_status: (frm) => {
-		if (frm.doc.completion_date && frm.doc.repair_status == "Completed") {
-			frappe.call({
-				method: "erpnext.assets.doctype.asset_repair.asset_repair.get_downtime",
-				args: {
-					failure_date: frm.doc.failure_date,
-					completion_date: frm.doc.completion_date,
-				},
-				callback: function (r) {
-					if (r.message) {
-						frm.set_value("downtime", r.message + " Hrs");
-					}
-				},
-			});
-		}
-
 		if (frm.doc.repair_status == "Completed" && !frm.doc.completion_date) {
 			frm.set_value("completion_date", frappe.datetime.now_datetime());
 		}
+
+		frm.events.set_downtime(frm);
+	},
+
+	failure_date: (frm) => {
+		frm.events.set_downtime(frm);
+	},
+
+	completion_date: (frm) => {
+		frm.events.set_downtime(frm);
+	},
+
+	set_downtime: (frm) => {
+		if (frm.doc.repair_status != "Completed" || !frm.doc.failure_date || !frm.doc.completion_date) {
+			frm.set_value("downtime", null);
+			return;
+		}
+
+		frappe.call({
+			method: "erpnext.assets.doctype.asset_repair.asset_repair.get_downtime",
+			args: {
+				failure_date: frm.doc.failure_date,
+				completion_date: frm.doc.completion_date,
+			},
+			callback: function (r) {
+				if (r.message) {
+					frm.set_value("downtime", r.message + " Hrs");
+				}
+			},
+		});
 	},
 
 	stock_items_on_form_rendered() {

--- a/erpnext/assets/doctype/asset_repair/asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.py
@@ -65,6 +65,7 @@ class AssetRepair(AccountsController):
 			self.set_stock_items_cost()
 		self.calculate_total_repair_cost()
 		self.validate_purchase_invoice_status()
+		self.set_downtime()
 
 	def validate_purchase_invoice_status(self):
 		if self.purchase_invoice:
@@ -214,6 +215,13 @@ class AssetRepair(AccountsController):
 	def check_repair_status(self):
 		if self.repair_status == "Pending":
 			frappe.throw(_("Please update Repair Status."))
+
+	def set_downtime(self):
+		# keep downtime in sync with the entered dates, regardless of edit order
+		if self.repair_status == "Completed" and self.failure_date and self.completion_date:
+			self.downtime = f"{get_downtime(self.failure_date, self.completion_date)} Hrs"
+		else:
+			self.downtime = None
 
 	def check_for_stock_items_and_warehouse(self):
 		if not self.get("stock_items"):

--- a/erpnext/assets/doctype/asset_repair/test_asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/test_asset_repair.py
@@ -100,6 +100,21 @@ class TestAssetRepair(unittest.TestCase):
 		asset_repair = create_asset_repair(submit=1)
 		self.assertNotEqual(asset_repair.repair_status, "Pending")
 
+	def test_downtime_stays_in_sync_with_dates(self):
+		asset = create_asset(submit=1)
+		asset_repair = create_asset_repair(asset=asset)
+
+		asset_repair.failure_date = "2026-07-31 09:00:00"
+		asset_repair.completion_date = "2026-07-31 11:00:00"
+		asset_repair.repair_status = "Completed"
+		asset_repair.save()
+		self.assertEqual(asset_repair.downtime, "2.0 Hrs")
+
+		# editing a date must refresh downtime, not leave a stale value
+		asset_repair.completion_date = "2026-07-31 14:30:00"
+		asset_repair.save()
+		self.assertEqual(asset_repair.downtime, "5.5 Hrs")
+
 	def test_stock_items(self):
 		asset_repair = create_asset_repair(stock_consumption=1)
 		self.assertTrue(asset_repair.stock_consumption)


### PR DESCRIPTION
Manual backport of #57822 