### PR TITLE
fix(accounts): make sync_auto_reconcile_config self-healing and permi…

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/test_accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/test_accounts_settings.py
@@ -1,5 +1,6 @@
 import frappe
 
+from erpnext.accounts.utils import sync_auto_reconcile_config
 from erpnext.tests.utils import ERPNextTestSuite
 
 
@@ -40,3 +41,4 @@ class TestAccountsSettings(ERPNextTestSuite):
 	@staticmethod
 	def _restore_trigger(value):
 		frappe.db.set_single_value("Accounts Settings", "auto_reconciliation_job_trigger", value)
+		sync_auto_reconcile_config(value)

--- a/erpnext/accounts/doctype/accounts_settings/test_accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/test_accounts_settings.py
@@ -13,3 +13,30 @@ class TestAccountsSettings(ERPNextTestSuite):
 
 		cur_settings.stale_days = -1
 		self.assertRaises(frappe.ValidationError, cur_settings.save)
+
+	def test_auto_reconciliation_job_trigger_creates_missing_scheduler_event(self):
+		method = (
+			"erpnext.accounts.doctype.process_payment_reconciliation."
+			"process_payment_reconciliation.trigger_reconciliation_for_queued_docs"
+		)
+		frappe.db.delete("Scheduled Job Type", {"method": method})
+		frappe.db.delete("Scheduler Event", {"method": method})
+
+		cur_settings = frappe.get_doc("Accounts Settings", "Accounts Settings")
+		self.addCleanup(self._restore_trigger, cur_settings.auto_reconciliation_job_trigger)
+
+		cur_settings.auto_reconciliation_job_trigger = 25
+		cur_settings.save()
+
+		self.assertTrue(
+			frappe.db.exists(
+				"Scheduler Event", {"scheduled_against": "Process Payment Reconciliation", "method": method}
+			)
+		)
+		self.assertEqual(
+			frappe.db.get_value("Scheduled Job Type", {"method": method}, "cron_format"), "0/25 * * * *"
+		)
+
+	@staticmethod
+	def _restore_trigger(value):
+		frappe.db.set_single_value("Accounts Settings", "auto_reconciliation_job_trigger", value)

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2701,7 +2701,9 @@ def sync_auto_reconcile_config(auto_reconciliation_job_trigger: int = 15):
 	method = "erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.trigger_reconciliation_for_queued_docs"
 
 	sch_event_name = frappe.db.get_value(
-		"Scheduler Event", {"scheduled_against": "Process Payment Reconciliation", "method": method}
+		"Scheduler Event",
+		{"scheduled_against": "Process Payment Reconciliation", "method": method},
+		for_update=True,
 	)
 	if not sch_event_name:
 		sch_event_name = (

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2700,9 +2700,22 @@ def sync_auto_reconcile_config(auto_reconciliation_job_trigger: int = 15):
 	)
 	method = "erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.trigger_reconciliation_for_queued_docs"
 
-	sch_event = frappe.get_doc(
+	sch_event_name = frappe.db.get_value(
 		"Scheduler Event", {"scheduled_against": "Process Payment Reconciliation", "method": method}
 	)
+	if not sch_event_name:
+		sch_event_name = (
+			frappe.get_doc(
+				{
+					"doctype": "Scheduler Event",
+					"scheduled_against": "Process Payment Reconciliation",
+					"method": method,
+				}
+			)
+			.insert(ignore_permissions=True)
+			.name
+		)
+
 	if frappe.db.get_value("Scheduled Job Type", {"method": method}):
 		frappe.get_doc(
 			"Scheduled Job Type",
@@ -2712,21 +2725,21 @@ def sync_auto_reconcile_config(auto_reconciliation_job_trigger: int = 15):
 		).update(
 			{
 				"cron_format": f"0/{auto_reconciliation_job_trigger} * * * *",
-				"scheduler_event": sch_event.name,
+				"scheduler_event": sch_event_name,
 			}
-		).save()
+		).save(ignore_permissions=True)
 	else:
 		frappe.get_doc(
 			{
 				"doctype": "Scheduled Job Type",
 				"method": method,
-				"scheduler_event": sch_event.name,
+				"scheduler_event": sch_event_name,
 				"cron_format": f"0/{auto_reconciliation_job_trigger} * * * *",
 				"create_log": True,
 				"stopped": False,
 				"frequency": "Cron",
 			}
-		).save()
+		).insert(ignore_permissions=True)
 
 
 def get_link_fields_grouped_by_option(doctype):


### PR DESCRIPTION
**Issue:**
Unable to change the Auto Reconciliation Job Trigger interval.

**Steps To Reproduce:**

1. Go to Account Settings.
2. Change the Auto Reconciliation Job Trigger interval.
3. Click Save.

**Before:**

<img width="2880" height="1368" alt="image" src="https://github.com/user-attachments/assets/40124ef4-e2ab-4ae6-80dd-f0e5e92a9573" />

**After:**

<img width="1244" height="614" alt="image" src="https://github.com/user-attachments/assets/d1f89565-84df-4bec-bfff-59a4c25d2f35" />


