### PR TITLE
fix(stock): drop call to confirm_if_drafts_exist missing on v16

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -533,7 +533,7 @@ frappe.ui.form.on("Material Request", {
 				},
 			],
 			primary_action_label: __("Create"),
-			primary_action: async function (values) {
+			primary_action: function (values) {
 				const item_suppliers = (values.items || []).filter((row) => row.__checked);
 				if (!item_suppliers.length) {
 					frappe.throw(__("Select at least one Item"));
@@ -565,10 +565,6 @@ frappe.ui.form.on("Material Request", {
 							`<b>${pending_qty}</b>`,
 						])
 					);
-				}
-
-				if (!(await erpnext.utils.confirm_if_drafts_exist(frm.doc, "Purchase Order"))) {
-					return;
 				}
 
 				frappe.call({


### PR DESCRIPTION
`erpnext.utils.confirm_if_drafts_exist` does not exist on version-16-hotfix, so the "Create Purchase Orders by Supplier" dialog on Material Request throws when submitted. Removes the guard (and the now-unneeded `async`) so the dialog proceeds directly to creating the purchase orders.