### PR TITLE
refactor(ui): hide the primary address and contact preview fields

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -378,6 +378,7 @@
   {
    "fieldname": "primary_address_and_contact_detail_section",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Primary Address and Contact"
   },
   {
@@ -392,6 +393,7 @@
    "fetch_from": "supplier_primary_contact.mobile_no",
    "fieldname": "mobile_no",
    "fieldtype": "Read Only",
+   "hidden": 1,
    "label": "Mobile No",
    "no_copy": 1
   },
@@ -399,12 +401,14 @@
    "fetch_from": "supplier_primary_contact.email_id",
    "fieldname": "email_id",
    "fieldtype": "Read Only",
+   "hidden": 1,
    "label": "Email ID",
    "no_copy": 1
   },
   {
    "fieldname": "primary_address",
    "fieldtype": "Text Editor",
+   "hidden": 1,
    "label": "Primary Address Preview",
    "no_copy": 1,
    "read_only": 1
@@ -588,7 +592,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-07-23 10:00:00.000000",
+ "modified": "2026-08-06 14:58:00.561519",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -282,7 +282,6 @@
    "depends_on": "eval:!doc.__islocal",
    "fieldname": "address_contacts",
    "fieldtype": "Section Break",
-   "label": "Address and Contact",
    "options": "fa fa-map-marker"
   },
   {
@@ -314,6 +313,7 @@
    "description": "Select, to make the customer searchable with these fields",
    "fieldname": "primary_address_and_contact_detail",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Primary Address and Contact"
   },
   {
@@ -328,6 +328,7 @@
    "fetch_from": "customer_primary_contact.mobile_no",
    "fieldname": "mobile_no",
    "fieldtype": "Read Only",
+   "hidden": 1,
    "label": "Mobile No",
    "no_copy": 1,
    "options": "Mobile"
@@ -336,6 +337,7 @@
    "fetch_from": "customer_primary_contact.email_id",
    "fieldname": "email_id",
    "fieldtype": "Read Only",
+   "hidden": 1,
    "label": "Email Id",
    "no_copy": 1,
    "options": "Email"
@@ -355,6 +357,7 @@
   {
    "fieldname": "primary_address",
    "fieldtype": "Text Editor",
+   "hidden": 1,
    "label": "Primary Address",
    "no_copy": 1,
    "read_only": 1
@@ -524,19 +527,19 @@
   },
   {
    "default": "0",
+   "description": "If checked, this Customer is only available for transactions in the companies listed below.",
    "fieldname": "restrict_to_companies",
    "fieldtype": "Check",
    "label": "Restrict to Companies",
-   "description": "If checked, this Customer is only available for transactions in the companies listed below.",
    "permlevel": 1
   },
   {
+   "depends_on": "eval:doc.restrict_to_companies",
    "fieldname": "allowed_companies",
    "fieldtype": "Table MultiSelect",
    "label": "Allowed Companies",
-   "options": "Company Restriction",
-   "depends_on": "eval:doc.restrict_to_companies",
    "mandatory_depends_on": "eval:doc.restrict_to_companies",
+   "options": "Company Restriction",
    "permlevel": 1
   },
   {
@@ -727,7 +730,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-07-23 12:00:00.000000",
+ "modified": "2026-08-06 15:14:35.049972",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",


### PR DESCRIPTION
The Address & Contact cards now show these details and mark which record is primary, so the read only copies below them only repeat it. Values are still stored and Customer.search_fields keeps working, since search reads the column rather than the form.

Depends on frappe/frappe#41600.

