### PR TITLE
feat(manufacturing): prompt for qty when creating material request from work order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/mapper.py
+++ b/erpnext/manufacturing/doctype/work_order/mapper.py
@@ -523,15 +523,35 @@ def _set_pick_list_item_qty(source, target, source_parent, for_qty, max_finished
 
 
 @frappe.whitelist()
-def make_material_request(source_name: str, target_doc: str | dict | Document | None = None):
+def make_material_request(
+	source_name: str, target_doc: str | dict | Document | None = None, for_qty: float | None = None
+):
 	frappe.has_permission("Material Request", "create", throw=True)
 
-	doc = get_mapped_doc("Work Order", source_name, _material_request_mapping(), target_doc)
+	# make_mapped_doc sets js `args` into `frappe.flags.args`
+	if not for_qty and frappe.flags.args:
+		for_qty = frappe.flags.args.for_qty
+
+	work_order = frappe.db.get_value(
+		"Work Order", source_name, ["qty", "material_transferred_for_manufacturing"], as_dict=True
+	)
+	for_qty = flt(for_qty) or _pending_transfer_qty(work_order)
+	postprocess = partial(
+		_set_material_request_item, for_qty=for_qty, max_finished_goods_qty=flt(work_order.qty)
+	)
+
+	doc = get_mapped_doc("Work Order", source_name, _material_request_mapping(postprocess), target_doc)
 	doc.material_request_type = "Material Transfer"
 	return doc
 
 
-def _material_request_mapping():
+def _pending_transfer_qty(work_order):
+	"""Fallback when no qty is passed: whatever is still to be transferred, else the full qty."""
+	pending = flt(work_order.qty) - flt(work_order.material_transferred_for_manufacturing)
+	return pending if pending > 0 else flt(work_order.qty)
+
+
+def _material_request_mapping(postprocess):
 	return {
 		"Work Order": {
 			"doctype": "Material Request",
@@ -541,19 +561,26 @@ def _material_request_mapping():
 		"Work Order Item": {
 			"doctype": "Material Request Item",
 			"field_map": [
-				("required_qty", "qty"),
 				("stock_uom", "uom"),
 				("source_warehouse", "from_warehouse"),
 			],
-			"postprocess": _set_material_request_item,
+			"postprocess": postprocess,
 			"condition": lambda doc: abs(doc.transferred_qty) < abs(doc.required_qty),
 		},
 	}
 
 
-def _set_material_request_item(source, target, source_parent):
+def _set_material_request_item(source, target, source_parent, for_qty, max_finished_goods_qty):
+	pending_to_issue = flt(source.required_qty) - flt(source.transferred_qty)
+	desire_to_transfer = flt(source.required_qty) / max_finished_goods_qty * flt(for_qty)
+
+	qty = min(desire_to_transfer, pending_to_issue)
+	if qty <= 0:
+		target.delete()
+		return
+
 	target.warehouse = source_parent.wip_warehouse
-	target.qty = flt(source.required_qty) - flt(source.transferred_qty)
+	target.qty = qty
 	target.schedule_date = nowdate()
 
 

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1638,6 +1638,49 @@ class TestWorkOrder(ERPNextTestSuite):
 		self.assertEqual(work_order.material_transferred_for_manufacturing, 0.0)
 		self.assertEqual(work_order.status, "In Process")
 
+	def test_material_request_qty_scales_with_requested_qty(self):
+		work_order = make_wo_order_test_record(
+			planned_start_date=now(), qty=10, source_warehouse="Stores - _TC"
+		)
+		required_qty = {row.item_code: flt(row.required_qty) for row in work_order.required_items}
+
+		mr = make_material_request(work_order.name, for_qty=4)
+		self.assertEqual(len(mr.items), len(required_qty))
+		for row in mr.items:
+			self.assertEqual(row.qty, required_qty[row.item_code] * 4 / 10)
+
+		# no qty passed: whole outstanding requirement, unchanged from before
+		mr = make_material_request(work_order.name)
+		for row in mr.items:
+			self.assertEqual(row.qty, required_qty[row.item_code])
+
+	def test_material_request_qty_capped_at_pending_qty(self):
+		work_order = make_wo_order_test_record(
+			planned_start_date=now(), qty=10, source_warehouse="Stores - _TC"
+		)
+		partially_transferred = work_order.required_items[0]
+		partially_transferred.db_set("transferred_qty", flt(partially_transferred.required_qty) - 1)
+		work_order.reload()
+
+		mr = make_material_request(work_order.name, for_qty=10)
+		requested_qty = {row.item_code: row.qty for row in mr.items}
+		self.assertEqual(requested_qty[partially_transferred.item_code], 1)
+
+	def test_material_request_maps_only_selected_rows(self):
+		work_order = make_wo_order_test_record(
+			planned_start_date=now(), qty=10, source_warehouse="Stores - _TC"
+		)
+		selected = work_order.required_items[0]
+
+		try:
+			frappe.flags.selected_children = {"required_items": [selected.name]}
+			mr = make_material_request(work_order.name, for_qty=4)
+		finally:
+			frappe.flags.selected_children = None
+
+		self.assertEqual([row.item_code for row in mr.items], [selected.item_code])
+		self.assertEqual(mr.items[0].qty, flt(selected.required_qty) * 4 / 10)
+
 	def test_backflushed_batch_raw_materials_based_on_transferred(self):
 		frappe.db.set_single_value(
 			"Manufacturing Settings",

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -1161,11 +1161,21 @@ erpnext.work_order = {
 		}
 	},
 
-	make_material_request: function (frm) {
-		frappe.model.open_mapped_doc({
-			method: "erpnext.manufacturing.doctype.work_order.mapper.make_material_request",
-			frm,
-		});
+	make_material_request: function (frm, purpose = "Material Transfer for Manufacture") {
+		const max = this.get_max_transferable_qty(frm, purpose);
+
+		const get_material_request = (for_qty) =>
+			frappe.model.open_mapped_doc({
+				method: "erpnext.manufacturing.doctype.work_order.mapper.make_material_request",
+				frm,
+				args: { for_qty: for_qty },
+			});
+
+		if (max <= 0) {
+			get_material_request(frm.doc.qty);
+		} else {
+			this.show_prompt_for_qty_input(frm, purpose).then((data) => get_material_request(data.qty));
+		}
 	},
 
 	create_pick_list: function (frm, purpose = "Material Transfer for Manufacture") {


### PR DESCRIPTION
Follow-up to #56961.

The Material Request button on Work Order opened the mapped doc directly and always requested the full outstanding requirement, unlike Start and Create Pick List which both prompt for a quantity first. Users had to edit every row by hand to request a partial transfer.

`make_material_request` now takes `for_qty` and scales each row with the same arithmetic as `_set_pick_list_item_qty`, capped at the row's own pending qty, so BOM ratios are preserved. The client reuses `show_prompt_for_qty_input`, giving the same Select Quantity dialog as Start. Omitting `for_qty` falls back to the outstanding transfer qty, so existing API callers are unaffected.

no-docs