### PR TITLE
fix(reports): respect user permissions in non-billed reports

### DIFF
--- a/erpnext/accounts/report/non_billed_report.py
+++ b/erpnext/accounts/report/non_billed_report.py
@@ -10,8 +10,8 @@ from erpnext import get_default_currency
 
 
 def get_ordered_to_be_billed_data(args, filters=None):
-	doctype, party = args.get("doctype"), args.get("party")
-	child_tab = doctype + " Item"
+	doctype_name, party = args.get("doctype"), args.get("party")
+	child_tab = doctype_name + " Item"
 	precision = (
 		get_field_precision(
 			frappe.get_meta(child_tab).get_field("billed_amt"), currency=get_default_currency()
@@ -19,7 +19,7 @@ def get_ordered_to_be_billed_data(args, filters=None):
 		or 2
 	)
 
-	doctype = frappe.qb.DocType(doctype)
+	doctype = frappe.qb.DocType(doctype_name)
 	child_doctype = frappe.qb.DocType(child_tab)
 	item = frappe.qb.DocType("Item")
 
@@ -27,13 +27,12 @@ def get_ordered_to_be_billed_data(args, filters=None):
 	project_field = get_project_field(doctype, child_doctype, party)
 
 	query = (
-		frappe.qb.from_(doctype)
+		frappe.qb.get_query(doctype_name, fields=[doctype.name], ignore_permissions=False)
 		.inner_join(child_doctype)
 		.on(doctype.name == child_doctype.parent)
 		.join(item)
 		.on(item.name == child_doctype.item_code)
 		.select(
-			doctype.name,
 			doctype[args.get("date")].as_("date"),
 			doctype[party],
 			doctype[party + "_name"],
@@ -71,7 +70,41 @@ def get_ordered_to_be_billed_data(args, filters=None):
 	if docname:
 		query = query.where(doctype.name == docname)
 
+	if condition := get_child_permission_conditions(child_doctype, child_tab):
+		query = query.where(condition)
+
 	return query.run(as_dict=True)
+
+
+def get_child_permission_conditions(child_table, child_doctype_name):
+	user_permissions = frappe.permissions.get_user_permissions(frappe.session.user)
+	if not user_permissions:
+		return None
+
+	strict_user_permissions = frappe.get_system_settings("apply_strict_user_permissions")
+	condition = None
+
+	for df in frappe.get_meta(child_doctype_name).get_link_fields():
+		if df.get("ignore_user_permissions"):
+			continue
+
+		permitted_docs = [
+			d.get("doc")
+			for d in user_permissions.get(df.get("options"), [])
+			if not d.get("applicable_for") or d.get("applicable_for") == child_doctype_name
+		]
+		if not permitted_docs:
+			continue
+
+		field = child_table[df.get("fieldname")]
+		field_condition = (
+			field.isin(permitted_docs)
+			if strict_user_permissions
+			else (IfNull(field, "") == "") | field.isin(permitted_docs)
+		)
+		condition = field_condition if condition is None else condition & field_condition
+
+	return condition
 
 
 def get_project_field(doctype, child_doctype, party):


### PR DESCRIPTION
**Issue:** 
We have configured Cost Center permissions for users. However, when accessing reports, users are still able to view data related to Cost Centers that are not assigned or permitted to them. 

**Before:**

<img width="1256" height="382" alt="image" src="https://github.com/user-attachments/assets/0ca8f648-8e29-4ba9-bcf6-7695fc518ea2" />

<img width="1256" height="382" alt="image" src="https://github.com/user-attachments/assets/4834a9b2-89c4-4338-974e-e003f4c3df52" />



**After:**

<img width="1244" height="614" alt="image" src="https://github.com/user-attachments/assets/76cf6768-6dd9-4957-9f4b-c05628b31a78" />

