### PR TITLE
fix: round derived stock_qty to field precision at computation

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -743,6 +743,19 @@ class TestPurchaseOrder(ERPNextTestSuite):
 		fractional.items[0].conversion_factor = 0.6
 		self.assertRaises(UOMMustBeIntegerError, fractional.insert)
 
+	def test_stock_qty_rounded_to_field_precision(self):
+		item_doc = make_item(properties={"stock_uom": "Kg"})
+		item_doc.append("uoms", {"uom": "Litre", "conversion_factor": 0.6})
+		item_doc.save()
+
+		po = create_purchase_order(item_code=item_doc.name, qty=3333.333, do_not_save=1)
+		po.items[0].uom = "Litre"
+		po.items[0].conversion_factor = 0.6
+		po.insert()
+
+		row = po.items[0]
+		self.assertEqual(row.stock_qty, flt(3333.333 * 0.6, row.precision("stock_qty")))
+
 	def test_ordered_qty_for_closing_po(self):
 		bin = frappe.get_all(
 			"Bin",

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -698,10 +698,6 @@ class BuyingController(SubcontractingController):
 				)
 
 	def set_qty_as_per_stock_uom(self):
-		allow_to_edit_stock_qty = frappe.get_single_value(
-			"Stock Settings", "allow_to_edit_stock_uom_qty_for_purchase"
-		)
-
 		for d in self.get("items"):
 			if d.meta.get_field("stock_qty"):
 				# Check if item code is present
@@ -713,18 +709,14 @@ class BuyingController(SubcontractingController):
 							field_label=_(d.meta.get_label("conversion_factor")),
 						)
 					)
-				d.stock_qty = flt(d.qty) * flt(d.conversion_factor)
+				d.stock_qty = flt(flt(d.qty) * flt(d.conversion_factor), d.precision("stock_qty"))
 
 				if self.doctype == "Purchase Receipt" and d.meta.get_field("received_stock_qty"):
 					# Set Received Qty in Stock UOM
-					d.received_stock_qty = flt(d.received_qty) * flt(
-						d.conversion_factor, d.precision("conversion_factor")
+					d.received_stock_qty = flt(
+						flt(d.received_qty) * flt(d.conversion_factor, d.precision("conversion_factor")),
+						d.precision("received_stock_qty"),
 					)
-
-				if allow_to_edit_stock_qty:
-					d.stock_qty = flt(d.stock_qty, d.precision("stock_qty"))
-					if d.get("received_stock_qty") and d.meta.get_field("received_stock_qty"):
-						d.received_stock_qty = flt(d.received_stock_qty, d.precision("received_stock_qty"))
 
 	def validate_purchase_return(self):
 		for d in self.get("items"):

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -280,17 +280,11 @@ class SellingController(StockController):
 					frappe.throw(_("Maximum discount for Item {0} is {1}%").format(d.item_code, discount))
 
 	def set_qty_as_per_stock_uom(self):
-		allow_to_edit_stock_qty = frappe.get_single_value(
-			"Stock Settings", "allow_to_edit_stock_uom_qty_for_sales"
-		)
-
 		for d in self.get("items"):
 			if d.meta.get_field("stock_qty"):
 				if not d.conversion_factor:
 					frappe.throw(_("Row {0}: Conversion Factor is mandatory").format(d.idx))
-				d.stock_qty = flt(d.qty) * flt(d.conversion_factor)
-				if allow_to_edit_stock_qty:
-					d.stock_qty = flt(d.stock_qty, d.precision("stock_qty"))
+				d.stock_qty = flt(flt(d.qty) * flt(d.conversion_factor), d.precision("stock_qty"))
 
 	def validate_selling_price(self):
 		def throw_message(idx, item_name, rate, ref_rate_field):

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -40,14 +40,6 @@ from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestSalesOrder(ERPNextTestSuite):
-	@ERPNextTestSuite.change_settings(
-		"Stock Settings",
-		{
-			"auto_insert_price_list_rate_if_missing": 1,
-			"update_existing_price_list_rate": 1,
-			"update_price_list_based_on": "Rate",
-		},
-	)
 	def test_stock_qty_rounded_to_field_precision(self):
 		item_doc = make_item(properties={"stock_uom": "Kg"})
 		item_doc.append("uoms", {"uom": "Litre", "conversion_factor": 0.6})
@@ -61,6 +53,14 @@ class TestSalesOrder(ERPNextTestSuite):
 		row = so.items[0]
 		self.assertEqual(row.stock_qty, flt(3333.333 * 0.6, row.precision("stock_qty")))
 
+	@ERPNextTestSuite.change_settings(
+		"Stock Settings",
+		{
+			"auto_insert_price_list_rate_if_missing": 1,
+			"update_existing_price_list_rate": 1,
+			"update_price_list_based_on": "Rate",
+		},
+	)
 	def test_sales_order_expired_item_price(self):
 		price_list = "_Test Price List"
 

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -48,6 +48,19 @@ class TestSalesOrder(ERPNextTestSuite):
 			"update_price_list_based_on": "Rate",
 		},
 	)
+	def test_stock_qty_rounded_to_field_precision(self):
+		item_doc = make_item(properties={"stock_uom": "Kg"})
+		item_doc.append("uoms", {"uom": "Litre", "conversion_factor": 0.6})
+		item_doc.save()
+
+		so = make_sales_order(item_code=item_doc.name, qty=3333.333, do_not_save=1)
+		so.items[0].uom = "Litre"
+		so.items[0].conversion_factor = 0.6
+		so.insert()
+
+		row = so.items[0]
+		self.assertEqual(row.stock_qty, flt(3333.333 * 0.6, row.precision("stock_qty")))
+
 	def test_sales_order_expired_item_price(self):
 		price_list = "_Test Price List"
 


### PR DESCRIPTION
`stock_qty` was stored as the raw `qty * conversion_factor` product, so ordering exactly 2000 stock units through a purchase UOM stored `1999.999999131832`, which leaked into validations, reports and printouts. Buying and selling controllers only rounded it when the *Allow to Edit Stock UOM Qty* setting was on; Stock Entry already rounds `transfer_qty` unconditionally, so this aligns `set_qty_as_per_stock_uom` (buying and selling) with that precedent and drops the setting gate. The setting keeps its UI meaning (whether the field is editable).

Deliberately excluded: BOM `stock_qty` (feeds cost rollups, larger blast radius). Complements #57859 and #57861 — threshold comparisons still need precision-aware `flt` because sums and differences of rounded floats reintroduce binary dust.