### PR TITLE
fix: optimize product bundle item search

### DIFF
--- a/erpnext/selling/doctype/product_bundle/product_bundle.js
+++ b/erpnext/selling/doctype/product_bundle/product_bundle.js
@@ -9,6 +9,11 @@ frappe.ui.form.on("Product Bundle", {
 				query: "erpnext.selling.doctype.product_bundle.product_bundle.get_new_item_code",
 			};
 		});
+		frm.set_query("item_code", "items", () => {
+			return {
+				query: "erpnext.controllers.queries.item_query",
+			};
+		});
 
 		// A submitted bundle is immutable. To change it, create a new version
 		// (a fresh draft copied from this one) and submit that instead.


### PR DESCRIPTION
Changes:
- Use ERPNext’s optimized Item query for Product Bundle child rows to prevent oversized search responses and UI freezes.