### PR TITLE
fix: guard reconciliation table deletes when tables are missing

### DIFF
--- a/erpnext/patches/v14_0/clear_reconciliation_values_from_singles.py
+++ b/erpnext/patches/v14_0/clear_reconciliation_values_from_singles.py
@@ -1,3 +1,4 @@
+import frappe
 from frappe import qb
 
 
@@ -13,5 +14,8 @@ def execute():
 		"Payment Reconciliation Allocation",
 	]
 	for x in doctypes:
+		# child tables may not exist yet on sites where this pre-model-sync patch runs first
+		if not frappe.db.table_exists(x):
+			continue
 		dt = qb.DocType(x)
 		qb.from_(dt).delete().run()


### PR DESCRIPTION
https://support.frappe.io/helpdesk/tickets/75682?view=VIEW-HD+Ticket-70177