### PR TITLE
fix(queries): apply additional link filters in project search

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -417,6 +417,26 @@ def bom(
 	return query.run()
 
 
+def get_additional_project_filter_conditions(proj, filters, exclude_fields):
+	from frappe.database.operator_map import OPERATOR_MAP
+
+	conditions = []
+	valid_fieldnames = {df.fieldname for df in frappe.get_meta("Project").fields}
+
+	for fieldname, value in filters.items():
+		if fieldname in exclude_fields or fieldname not in valid_fieldnames:
+			continue
+
+		if isinstance(value, list | tuple) and len(value) == 2 and value[0] in OPERATOR_MAP:
+			operator, val = value
+		else:
+			operator, val = "=", value
+
+		conditions.append(OPERATOR_MAP[operator](proj[fieldname], val))
+
+	return conditions
+
+
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_project_name(
@@ -434,6 +454,10 @@ def get_project_name(
 
 		if filters.get("company"):
 			qb_filter_and_conditions.append(proj.company == filters.get("company"))
+
+		qb_filter_and_conditions.extend(
+			get_additional_project_filter_conditions(proj, filters, exclude_fields={"customer", "company"})
+		)
 
 	qb_filter_and_conditions.append(proj.status.notin(["Completed", "Cancelled", "On hold"]))
 


### PR DESCRIPTION
**Issue:**
The project field on Sales Invoice and Purchase Order already has a built-in query that controls which projects appear in the dropdown. On Sales Invoice it uses a server-side method that filters by the customer on the invoice; on Purchase Order it filters by company. This built-in query is set up in ERPNext's controller code and runs separately from the Link Filters setting in Customize Form.

**Ref:**[#75674](https://support.frappe.io/helpdesk/tickets/75674?view=VIEW-HD+Ticket-745)

**Steps To Reproduce:**

1. On a test site, go to Customize Form and select Sales Invoice.
2. Find the project field and add the following under Link Filters: [["Project","is_active","=","Yes"]]. Save.
3. Open a new Sales Invoice. Click on the Project field and check whether the dropdown opens. Open the browser console (F12) and look for a TypeError: Cannot read properties of undefined (reading 'customer') error.
4. Repeat steps 1-2 for Purchase Order. Open a new Purchase Order, click the Project field, and confirm the dropdown still opens.
5. On the Purchase Order, check whether inactive projects (where Is Active = No) still appear in the dropdown — they should be absent if link_filters is working, but are expected to still appear based on this report.

**Before:**

<img width="1256" height="495" alt="image" src="https://github.com/user-attachments/assets/4ae283a0-5564-4c9a-9ec2-53575a2d055f" />


**After:**
<img width="1256" height="495" alt="image" src="https://github.com/user-attachments/assets/cfb0ded0-e12f-4ac8-a02f-62f6f1175982" />


