### PR TITLE
fix: tolerate floating-point drift in sales team allocated percentage 

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -254,7 +254,7 @@ class SellingController(StockController):
 
 			total += sales_person.allocated_percentage
 
-		if sales_team and total != 100.0:
+		if sales_team and flt(total, self.precision("allocated_percentage", "sales_team")) != 100.0:
 			throw(_("Total allocated percentage for sales team should be 100"))
 
 	def validate_sales_team(self, sales_team):

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -199,7 +199,8 @@ class Customer(TransactionBase):
 				self.loyalty_program_tier = customer.loyalty_program_tier
 
 		if self.sales_team:
-			if sum(member.allocated_percentage or 0 for member in self.sales_team) != 100:
+			total = sum(flt(member.allocated_percentage) for member in self.sales_team)
+			if flt(total, self.precision("allocated_percentage", "sales_team")) != 100:
 				frappe.throw(_("Total contribution percentage should be equal to 100"))
 
 	@frappe.whitelist(methods=["POST"])

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -3215,6 +3215,17 @@ class TestSalesOrder(ERPNextTestSuite):
 			so.save()
 			self.assertEqual(sum(d.allocated_percentage for d in so.sales_team), 100)
 
+		with self.subTest("floating-point drift in the total is tolerated"):
+			# 10.0 + 58.02 + 31.98 accumulates to 100.00000000000001 in binary floating point
+			so = make_sales_order(do_not_save=True)
+			for sales_person, percentage in (
+				("_Test Sales Person", 10.0),
+				("_Test Sales Person 1", 58.02),
+				("_Test Sales Person 2", 31.98),
+			):
+				so.append("sales_team", {"sales_person": sales_person, "allocated_percentage": percentage})
+			so.save()
+
 	def test_sales_team_disabled_sales_person_rejected(self):
 		frappe.db.set_value("Sales Person", "_Test Sales Person 2", "enabled", 0)
 		try:


### PR DESCRIPTION
**Issue:** 

The sales team total is compared to 100 with exact float equality, so a valid allocation whose sum drifts is rejected.

Fixes: [#57802](https://github.com/frappe/erpnext/issues/57802)

**Steps to reproduce:**

1. Ensure at least three Sales Persons exist and are enabled.
2. Create a new Sales Order with any customer and item.
3. In the Sales Team table, add three rows with these contributions:

| Sales Person   | Contribution (%) |
|----------------|------------------|
| Sales Person A | 10.00            |
| Sales Person B | 58.02            |
| Sales Person C | 31.98            |

4. Save.


**Before:**

<img width="1845" height="929" alt="image" src="https://github.com/user-attachments/assets/30891ab2-a8d6-4ffa-a666-f4e1dff6e9ce" />

<img width="1408" height="839" alt="image" src="https://github.com/user-attachments/assets/070faa39-1ebc-4f7c-8b9d-65cbc69211d7" />



**After:** 


<img width="1857" height="927" alt="image" src="https://github.com/user-attachments/assets/57c6cbbe-dbfd-4475-b81b-60270a1baac3" />

**Backport Needed For V15 and V16**