### PR TITLE
fix: negate stock value difference for outward transfer bundles

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -888,7 +888,7 @@ def make_bundle_for_material_transfer(**kwargs):
 		row.stock_value_difference = abs(row.stock_value_difference)
 		if kwargs.type_of_transaction == "Outward":
 			row.qty *= -1
-			row.stock_value_difference *= row.stock_value_difference
+			row.stock_value_difference *= -1
 			row.is_outward = 1
 
 		row.warehouse = kwargs.warehouse


### PR DESCRIPTION
**Issue:**

- On outward stock transfers, the code multiplies the stock value by itself instead of flipping it to a negative number.

**Description:** 

- When stock leaves a warehouse, both the quantity and its value should be recorded as negative. The quantity is handled correctly, but the value line has a typo — it multiplies the value by itself instead of by -1. Nothing actually breaks today, because the value gets recalculated from the quantity a moment later and the quantity is already correct. This just fixes the typo so it can't cause trouble later.

**Actual behaviour:**

- On an outward transfer, the code multiplies the stock value by itself. A value of 250 becomes 62,500, and because squaring always gives a positive number, it stays positive when it should be negative. Nothing goes wrong in practice; that number is thrown away and recalculated from the quantity before anything is saved, and the quantity is already correct, so no records are actually wrong today.

**Expected behaviour:**

- The stock value should be flipped to negative, the same way the quantity on the line above already is. A value of 250 should become -250, so stock leaving a warehouse is recorded as a reduction.

Backport Needed For V15 and V16