### PR TITLE
fix: sync open reference forms after Quality Inspection submit

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -265,6 +265,9 @@ class QualityInspection(Document):
 					self.modified,
 				)
 
+		if self.reference_type and self.reference_name:
+			frappe.get_lazy_doc(self.reference_type, self.reference_name).notify_update()
+
 	def inspect_and_set_status(self):
 		for reading in self.readings:
 			if not reading.manual_inspection:  # dont auto set status if manual

--- a/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 from contextlib import contextmanager
+from unittest.mock import patch
 
 import frappe
 from frappe.utils import nowdate
@@ -77,6 +78,27 @@ class TestQualityInspection(ERPNextTestSuite):
 
 		qa.delete()
 		dn.delete()
+
+	def test_doc_update_published_for_reference_on_submit(self):
+		"""Submitting a QI publishes doc_update so open reference forms resync their timestamp."""
+		dn = create_delivery_note(item_code="_Test Item with QA", do_not_submit=True)
+		qa = create_quality_inspection(
+			reference_type="Delivery Note", reference_name=dn.name, do_not_submit=True
+		)
+
+		with patch.object(frappe, "publish_realtime") as publish_realtime:
+			qa.submit()
+
+		reference_updates = [
+			call
+			for call in publish_realtime.call_args_list
+			if call.args and call.args[0] == "doc_update" and call.kwargs.get("docname") == dn.name
+		]
+		self.assertEqual(len(reference_updates), 1)
+
+		message = reference_updates[0].args[1]
+		self.assertEqual(message["doctype"], "Delivery Note")
+		self.assertEqual(message["modified"], frappe.db.get_value("Delivery Note", dn.name, "modified"))
 
 	def test_value_based_qi_readings(self):
 		# Test QI based on acceptance values (Non formula)


### PR DESCRIPTION
Submitting, cancelling, or deleting a Quality Inspection updates its reference document (Purchase Receipt, Delivery Note, Stock Entry, Job Card) through raw db writes in `update_qc_reference()`, bumping the reference's `modified` without emitting any realtime event. A reference form still open in the browser keeps its stale timestamp and fails the timestamp conflict check on the next save/submit — the user must manually refresh after every QI submit.

Fix: call `notify_update()` on the reference after the write. The standard `doc_update` event makes an open, unedited form silently reload and sync its timestamp (`model.js` → `debounced_reload_doc()`); a form with unsaved edits still gets the conflict message, as it should. `get_lazy_doc` avoids loading child tables just to publish the event.

Replaces #57651, which duplicated `Document.notify_update` internals — losing the `in_patch`/`in_import` guards and the `list_update` event — and did not cover the Job Card branch, which bumps `modified` the same way.