### PR TITLE
fix: fall back to nearest fiscal year when today is outside all fiscal years

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -445,8 +445,8 @@ $.extend(erpnext.utils, {
 		let fiscal_year = "";
 		if (
 			frappe.boot.current_fiscal_year &&
-			date >= frappe.boot.current_fiscal_year[1] &&
-			date <= frappe.boot.current_fiscal_year[2]
+			(date == today ||
+				(date >= frappe.boot.current_fiscal_year[1] && date <= frappe.boot.current_fiscal_year[2]))
 		) {
 			if (with_dates) fiscal_year = frappe.boot.current_fiscal_year;
 			else fiscal_year = frappe.boot.current_fiscal_year[0];

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -4,7 +4,7 @@
 
 import frappe
 from frappe.defaults import get_user_default
-from frappe.utils import cint
+from frappe.utils import cint, getdate
 
 from erpnext.accounts.utils import get_fiscal_years
 
@@ -56,17 +56,35 @@ def boot_session(bootinfo):
 		)
 
 		party_account_types = frappe.db.sql(""" select name, ifnull(account_type, '') from `tabParty Type`""")
-		fiscal_year = get_fiscal_years(
-			frappe.utils.nowdate(), company=get_user_default("company"), boolean=True
-		)
+		fiscal_year = get_current_or_nearest_fiscal_year()
 		if fiscal_year:
-			bootinfo.current_fiscal_year = fiscal_year[0]
+			bootinfo.current_fiscal_year = fiscal_year
 		bootinfo.party_account_types = frappe._dict(party_account_types)
 
 		bootinfo.sysdefaults.demo_company = frappe.db.get_single_value("Global Defaults", "demo_company")
 		bootinfo.sysdefaults.default_ageing_range = frappe.db.get_single_value(
 			"Accounts Settings", "default_ageing_range"
 		)
+
+
+def get_current_or_nearest_fiscal_year():
+	company = get_user_default("company")
+	fiscal_year = get_fiscal_years(frappe.utils.nowdate(), company=company, boolean=True)
+	if fiscal_year:
+		return fiscal_year[0]
+	return get_nearest_fiscal_year(company)
+
+
+def get_nearest_fiscal_year(company):
+	today = getdate(frappe.utils.nowdate())
+	nearest = None
+	for fiscal_year in get_fiscal_years(company=company):
+		nearest = fiscal_year
+		if getdate(fiscal_year.year_start_date) <= today:
+			break
+	if not nearest:
+		return None
+	return (nearest.name, nearest.year_start_date, nearest.year_end_date)
 
 
 def update_page_info(bootinfo):


### PR DESCRIPTION
Fixes the Accounting workspace failing with "Start Year and End Year are mandatory" when today's date is not inside any active Fiscal Year — e.g. the last FY ended on 30 June and the next one was never created because the scheduler was down around year end, so `auto_create_fiscal_year` never ran. Reported in https://discuss.frappe.io/t/164081 (v15.119.0).

The standard Profit and Loss chart resolves its fiscal year filters through `erpnext.utils.get_fiscal_year()` in `dynamic_filters_json`. For today's date that helper only reads `frappe.boot.current_fiscal_year`, and boot skips setting it when no Fiscal Year covers today. The helper then returns `""` (the server-call fallback is gated on `date != today`), the chart runs the Profit and Loss Statement with empty `from_fiscal_year`/`to_fiscal_year`, and the thrown error blocks the whole workspace. Budget Variance, Top Customers, Top Suppliers and the order trends charts fail the same way; fiscal year report defaults come up empty in the same state.

(The forum post blames a "non-existent `erpnext.utils.get_fiscal_year`" — that's the Python path; `dynamic_filters_json` is evaluated client side, where the helper exists but returned an empty string.)

Changes:
- boot: when no Fiscal Year covers today, send the nearest one — the latest FY that has already started, else the earliest upcoming one.
- `erpnext.utils.get_fiscal_year`: use the boot fiscal year whenever it is asked for today's fiscal year, even if today lies outside its dates. Exact lookups for other dates keep the existing server round trip and still return nothing when the date is uncovered.

The fiscal-year number cards already guard against this exact absence with their own calendar-year fallback (`frappe.boot.current_fiscal_year || [...]`); with boot now populated they show the nearest FY's range instead, consistent with the charts.

develop has the same gap (`raise_on_missing=False` in boot, same client-side guard) — I'll forward-port after review.
