### PR TITLE
fix(accounts): enforce child user permissions in non-billed reports

### DIFF
--- a/erpnext/accounts/report/non_billed_report.py
+++ b/erpnext/accounts/report/non_billed_report.py
@@ -28,12 +28,13 @@ def get_ordered_to_be_billed_data(args, filters=None):
 
 	query = (
 		frappe.qb.get_query(
-			child_tab,
+			doctype_name,
 			fields=[doctype.name],
-			parent_doctype=doctype_name,
 			ignore_permissions=False,
 			ignore_user_permissions=False,
 		)
+		.inner_join(child_doctype)
+		.on(doctype.name == child_doctype.parent)
 		.join(item)
 		.on(item.name == child_doctype.item_code)
 		.select(

--- a/erpnext/accounts/report/non_billed_report.py
+++ b/erpnext/accounts/report/non_billed_report.py
@@ -32,7 +32,7 @@ def get_ordered_to_be_billed_data(args, filters=None):
 			fields=[doctype.name],
 			parent_doctype=doctype_name,
 			ignore_permissions=False,
-			apply_child_user_permissions=True,
+			ignore_user_permissions=False,
 		)
 		.join(item)
 		.on(item.name == child_doctype.item_code)

--- a/erpnext/accounts/report/non_billed_report.py
+++ b/erpnext/accounts/report/non_billed_report.py
@@ -10,8 +10,8 @@ from erpnext import get_default_currency
 
 
 def get_ordered_to_be_billed_data(args, filters=None):
-	doctype, party = args.get("doctype"), args.get("party")
-	child_tab = doctype + " Item"
+	doctype_name, party = args.get("doctype"), args.get("party")
+	child_tab = doctype_name + " Item"
 	precision = (
 		get_field_precision(
 			frappe.get_meta(child_tab).get_field("billed_amt"), currency=get_default_currency()
@@ -19,7 +19,7 @@ def get_ordered_to_be_billed_data(args, filters=None):
 		or 2
 	)
 
-	doctype = frappe.qb.DocType(doctype)
+	doctype = frappe.qb.DocType(doctype_name)
 	child_doctype = frappe.qb.DocType(child_tab)
 	item = frappe.qb.DocType("Item")
 
@@ -27,13 +27,16 @@ def get_ordered_to_be_billed_data(args, filters=None):
 	project_field = get_project_field(doctype, child_doctype, party)
 
 	query = (
-		frappe.qb.from_(doctype)
-		.inner_join(child_doctype)
-		.on(doctype.name == child_doctype.parent)
+		frappe.qb.get_query(
+			child_tab,
+			fields=[doctype.name],
+			parent_doctype=doctype_name,
+			ignore_permissions=False,
+			apply_child_user_permissions=True,
+		)
 		.join(item)
 		.on(item.name == child_doctype.item_code)
 		.select(
-			doctype.name,
 			doctype[args.get("date")].as_("date"),
 			doctype[party],
 			doctype[party + "_name"],

--- a/erpnext/accounts/report/received_items_to_be_billed/test_received_items_to_be_billed.py
+++ b/erpnext/accounts/report/received_items_to_be_billed/test_received_items_to_be_billed.py
@@ -100,7 +100,7 @@ class TestReceivedItemsToBeBilled(ERPNextTestSuite):
 		)
 		self.assertIsNotNone(self.get_row(self.run_report(posting_date="2026-06-30"), pr.name))
 
-	def test_child_project_user_permission_filters_receipts(self):
+	def test_project_user_permission_filters_receipts(self):
 		from frappe.permissions import add_user_permission
 
 		test_user = f"non-billed-report-{frappe.generate_hash(length=6)}@example.com"
@@ -136,10 +136,8 @@ class TestReceivedItemsToBeBilled(ERPNextTestSuite):
 				posting_date="2026-06-01",
 				do_not_submit=True,
 			)
-			purchase_receipt.project = None
-			purchase_receipt.items[0].project = project
+			purchase_receipt.project = project
 			purchase_receipt.save().submit()
-			frappe.db.set_value("Purchase Receipt", purchase_receipt.name, "project", None)
 			return purchase_receipt
 
 		allowed_receipt = make_receipt(allowed_project.name)

--- a/erpnext/accounts/report/received_items_to_be_billed/test_received_items_to_be_billed.py
+++ b/erpnext/accounts/report/received_items_to_be_billed/test_received_items_to_be_billed.py
@@ -99,3 +99,61 @@ class TestReceivedItemsToBeBilled(ERPNextTestSuite):
 			"Receipt dated after the cutoff should be excluded",
 		)
 		self.assertIsNotNone(self.get_row(self.run_report(posting_date="2026-06-30"), pr.name))
+
+	def test_child_project_user_permission_filters_receipts(self):
+		from frappe.permissions import add_user_permission
+
+		test_user = f"non-billed-report-{frappe.generate_hash(length=6)}@example.com"
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": test_user,
+				"first_name": "Non Billed Report User",
+				"send_welcome_email": 0,
+				"roles": [{"role": "Stock User"}],
+			}
+		).insert(ignore_permissions=True)
+
+		allowed_project = frappe.get_doc(
+			doctype="Project",
+			project_name=f"Allowed Project {frappe.generate_hash(length=6)}",
+			company="_Test Company",
+			status="Open",
+		).insert()
+		restricted_project = frappe.get_doc(
+			doctype="Project",
+			project_name=f"Restricted Project {frappe.generate_hash(length=6)}",
+			company="_Test Company",
+			status="Open",
+		).insert()
+
+		def make_receipt(project):
+			purchase_receipt = make_purchase_receipt(
+				item_code="_Test Item",
+				qty=1,
+				rate=100,
+				supplier="_Test Supplier",
+				posting_date="2026-06-01",
+				do_not_submit=True,
+			)
+			purchase_receipt.project = None
+			purchase_receipt.items[0].project = project
+			purchase_receipt.save().submit()
+			frappe.db.set_value("Purchase Receipt", purchase_receipt.name, "project", None)
+			return purchase_receipt
+
+		allowed_receipt = make_receipt(allowed_project.name)
+		restricted_receipt = make_receipt(restricted_project.name)
+
+		frappe.db.set_single_value("System Settings", "apply_strict_user_permissions", 0)
+		add_user_permission("Project", allowed_project.name, test_user, ignore_permissions=True)
+
+		with self.set_user(test_user):
+			self.assertIsNotNone(
+				self.get_row(self.run_report(purchase_receipt=allowed_receipt.name), allowed_receipt.name)
+			)
+			self.assertIsNone(
+				self.get_row(
+					self.run_report(purchase_receipt=restricted_receipt.name), restricted_receipt.name
+				)
+			)


### PR DESCRIPTION
Depends on frappe/frappe#41722.

## Problem

These reports can show a parent document that child User Permissions prevent the user from opening.

## Change

Start with a permission-aware Delivery Note or Purchase Receipt query, then join its items. The framework dependency applies User Permissions from stored child Link fields.

This covers Cost Center, Project, and future child Link fields without report-specific permission checks.

## Tests

- Received Items to be Billed: 5 passed
- Delivered Items to be Billed: 3 passed
- Pre-commit checks passed
- PostgreSQL case for `MAT-DN-2026-00004-1` passed