### PR TITLE
fix BOM Explorer nested quantities

### DIFF
--- a/erpnext/manufacturing/report/bom_explorer/bom_explorer.py
+++ b/erpnext/manufacturing/report/bom_explorer/bom_explorer.py
@@ -25,10 +25,13 @@ def fetch_exploded_bom_items(root_bom):
 	recursive CTE -- replaces a query-per-node walk with a single query. UNION keeps it cycle-safe
 	and fetches each sub-BOM's items only once even when it is reused across the tree."""
 	bom_item = frappe.qb.DocType("BOM Item")
+	child_bom = frappe.qb.DocType("BOM").as_("child_bom")
 	tree = frappe.qb.Table("exploded_bom")
 	fields = [
 		bom_item.parent,
+		child_bom.quantity.as_("bom_qty"),
 		bom_item.qty,
+		bom_item.stock_qty,
 		bom_item.bom_no,
 		bom_item.item_code,
 		bom_item.item_name,
@@ -37,9 +40,17 @@ def fetch_exploded_bom_items(root_bom):
 		bom_item.idx,
 		bom_item.is_phantom_item,
 	]
-	seed = frappe.qb.from_(bom_item).select(*fields).where(bom_item.parent == root_bom)
+	seed = (
+		frappe.qb.from_(bom_item)
+		.left_join(child_bom)
+		.on(bom_item.bom_no == child_bom.name)
+		.select(*fields)
+		.where(bom_item.parent == root_bom)
+	)
 	recursion = (
 		frappe.qb.from_(bom_item)
+		.left_join(child_bom)
+		.on(bom_item.bom_no == child_bom.name)
 		.join(tree)
 		.on(bom_item.parent == tree.bom_no)
 		.select(*fields)
@@ -71,7 +82,9 @@ def build_exploded_rows(bom, children_map, data, indent=0, qty=1):
 			}
 		)
 		if item.bom_no:
-			build_exploded_rows(item.bom_no, children_map, data, indent + 1, item.qty)
+			build_exploded_rows(
+				item.bom_no, children_map, data, indent + 1, qty * item.stock_qty / item.bom_qty
+			)
 
 
 def get_columns():

--- a/erpnext/manufacturing/report/bom_explorer/test_bom_explorer.py
+++ b/erpnext/manufacturing/report/bom_explorer/test_bom_explorer.py
@@ -4,7 +4,7 @@
 import frappe
 
 from erpnext.manufacturing.doctype.bom.test_bom import create_nested_bom
-from erpnext.manufacturing.report.bom_explorer.bom_explorer import execute
+from erpnext.manufacturing.report.bom_explorer.bom_explorer import build_exploded_rows, execute
 from erpnext.tests.utils import ERPNextTestSuite
 
 
@@ -78,3 +78,36 @@ class TestBOMExplorer(ERPNextTestSuite):
 		# The leaf belongs to the sub-assembly, so it is exploded one level deeper.
 		self.assertEqual(rows_by_item[leaf_item]["indent"], 1)
 		self.assertEqual(rows_by_item[leaf_item]["bom_level"], 1)
+
+	def test_nested_bom_quantity_is_normalized_by_output_quantity(self):
+		parent_bom = create_nested_bom(
+			{"parent": {"sub": {"leaf": {}}}},
+			prefix="_Test explorer quantity ",
+		)
+		sub_bom = frappe.get_doc("BOM", parent_bom.items[0].bom_no)
+
+		# Two sub-assemblies are required; each sub-BOM produces three units from nine leaves.
+		frappe.db.set_value("BOM", sub_bom.name, "quantity", 3)
+		frappe.db.set_value("BOM Item", sub_bom.items[0].name, {"qty": 9, "stock_qty": 9})
+		frappe.db.set_value("BOM Item", parent_bom.items[0].name, {"qty": 2, "stock_qty": 2})
+
+		data = self.run_report(parent_bom.name)
+		leaf_row = next(row for row in data if row["item_code"] == "_Test explorer quantity leaf")
+
+		self.assertEqual(leaf_row["qty"], 6)
+
+	def test_nested_bom_uses_stock_qty_at_every_level(self):
+		children_map = {
+			"root": [
+				frappe._dict(item_code="parent", idx=1, bom_no="parent-bom", bom_qty=2, qty=8, stock_qty=16)
+			],
+			"parent-bom": [
+				frappe._dict(item_code="child", idx=1, bom_no="child-bom", bom_qty=3, qty=4, stock_qty=12)
+			],
+			"child-bom": [frappe._dict(item_code="raw-material", idx=1, bom_no="", qty=2)],
+		}
+		data = []
+
+		build_exploded_rows("root", children_map, data)
+
+		self.assertEqual([row["qty"] for row in data], [8, 32, 64])


### PR DESCRIPTION
Changes:
- Fixed BOM Explorer to correctly multiply component quantities across all nested BOM levels.

Before fix:
<img width="2398" height="510" alt="image" src="https://github.com/user-attachments/assets/0f29dffa-491f-4ecd-85ca-111f42a69b98" />

After fix:
<img width="2414" height="749" alt="image" src="https://github.com/user-attachments/assets/ed26683e-616f-4286-8571-01acb131e493" />
