### PR TITLE
fix: require material transfer before job card actions

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -597,8 +597,7 @@ frappe.ui.form.on("Job Card", {
 		const has_remaining_qty = doc.for_quantity + doc.process_loss_qty > doc.total_completed_qty;
 		const pending_transfer =
 			has_items && doc.items.some((row) => flt(row.transferred_qty) < flt(row.required_qty));
-		const materials_ready =
-			doc.skip_material_transfer || !pending_transfer || !doc.finished_good || !has_items;
+		const materials_ready = doc.skip_material_transfer || !pending_transfer || !has_items;
 
 		let last_row = {};
 		const has_sub_ops_or_pending_qty = doc.sub_operations?.length || doc.pending_qty > 0;

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -1692,6 +1692,7 @@ class JobCard(Document):
 		frappe.has_permission("Job Card", "write", doc=self, throw=True)
 
 		self.validate_docstatus()
+		self.validate_transfer_qty()
 
 		if isinstance(kwargs, dict):
 			kwargs = frappe._dict(kwargs)
@@ -1707,6 +1708,7 @@ class JobCard(Document):
 		frappe.has_permission("Job Card", "write", doc=self, throw=True)
 
 		self.validate_docstatus()
+		self.validate_transfer_qty()
 
 		if isinstance(kwargs, dict):
 			kwargs = frappe._dict(kwargs)

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -2833,3 +2833,17 @@ class TestJobCardLogic(ERPNextTestSuite):
 		jc.finished_good = None
 		jc.track_semi_finished_goods = 0
 		self.assertRaises(frappe.ValidationError, jc.validate_transfer_qty)
+
+	def test_material_transfer_is_required_before_starting_or_completing_job(self):
+		jc = frappe.new_doc("Job Card")
+		jc.for_quantity = 10
+		jc.append("items", {"required_qty": 10, "transferred_qty": 0})
+
+		for action, kwargs in (
+			(jc.start_timer, {"start_time": now(), "employees": []}),
+			(
+				jc.complete_job_card,
+				{"qty": 10, "for_quantity": 10, "pending_qty": 0, "process_loss_qty": 0},
+			),
+		):
+			self.assertRaises(frappe.ValidationError, action, **kwargs)


### PR DESCRIPTION
## What changed

- Block Start Job and Complete Job until material transfer is done.
- Hide these actions while material transfer is pending.
- Add a regression test.

## Why

Job Cards could record work before Material Transfer for Manufacture was completed.

## Tests

- Focused Job Card regression tests
- Pre-commit checks