### PR TITLE
fix: allow suppliers to create quotations from portal

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -441,50 +441,7 @@ def get_party_account(
 			_("User don't have permissions to select/read this account."), exc=frappe.PermissionError
 		)
 
-	if not party_type:
-		frappe.throw(_("Party Type is mandatory"))
-	if not company:
-		frappe.throw(_("Please select a Company"))
-
-	if not party and party_type in ["Customer", "Supplier"]:
-		default_account_name = (
-			"default_receivable_account" if party_type == "Customer" else "default_payable_account"
-		)
-
-		account = frappe.get_cached_value("Company", company, default_account_name)
-	else:
-		account = frappe.db.get_value(
-			"Party Account", {"parenttype": party_type, "parent": party, "company": company}, "account"
-		)
-
-		if not account and party_type in ["Customer", "Supplier"]:
-			party_group_doctype = "Customer Group" if party_type == "Customer" else "Supplier Group"
-			group = frappe.get_cached_value(party_type, party, scrub(party_group_doctype))
-			account = frappe.db.get_value(
-				"Party Account",
-				{"parenttype": party_group_doctype, "parent": group, "company": company},
-				"account",
-			)
-
-		if not account and party_type in ["Customer", "Supplier"]:
-			default_account_name = (
-				"default_receivable_account" if party_type == "Customer" else "default_payable_account"
-			)
-			account = frappe.get_cached_value("Company", company, default_account_name)
-
-		existing_gle_currency = get_party_gle_currency(party_type, party, company)
-		if existing_gle_currency:
-			if account:
-				account_currency = frappe.get_cached_value("Account", account, "account_currency")
-			if (account and account_currency != existing_gle_currency) or not account:
-				account = get_party_gle_account(party_type, party, company)
-
-		# get default account on the basis of party type
-		if not account:
-			account_type = frappe.get_cached_value("Party Type", party_type, "account_type")
-			default_account_name = "default_" + account_type.lower() + "_account"
-			account = frappe.get_cached_value("Company", company, default_account_name)
-
+	account = _get_party_account(party_type, party, company)
 	if account:
 		account_perm_check(account)
 
@@ -496,6 +453,52 @@ def get_party_account(
 			return [account, advance_account]
 
 		return [account]
+
+	return account
+
+
+def _get_party_account(party_type, party, company):
+	if not party_type:
+		frappe.throw(_("Party Type is mandatory"))
+	if not company:
+		frappe.throw(_("Please select a Company"))
+
+	if not party and party_type in ["Customer", "Supplier"]:
+		default_account_name = (
+			"default_receivable_account" if party_type == "Customer" else "default_payable_account"
+		)
+		return frappe.get_cached_value("Company", company, default_account_name)
+
+	account = frappe.db.get_value(
+		"Party Account", {"parenttype": party_type, "parent": party, "company": company}, "account"
+	)
+
+	if not account and party_type in ["Customer", "Supplier"]:
+		party_group_doctype = "Customer Group" if party_type == "Customer" else "Supplier Group"
+		group = frappe.get_cached_value(party_type, party, scrub(party_group_doctype))
+		account = frappe.db.get_value(
+			"Party Account",
+			{"parenttype": party_group_doctype, "parent": group, "company": company},
+			"account",
+		)
+
+	if not account and party_type in ["Customer", "Supplier"]:
+		default_account_name = (
+			"default_receivable_account" if party_type == "Customer" else "default_payable_account"
+		)
+		account = frappe.get_cached_value("Company", company, default_account_name)
+
+	existing_gle_currency = get_party_gle_currency(party_type, party, company)
+	if existing_gle_currency:
+		if account:
+			account_currency = frappe.get_cached_value("Account", account, "account_currency")
+		if (account and account_currency != existing_gle_currency) or not account:
+			account = get_party_gle_account(party_type, party, company)
+
+	if not account:
+		account_type = frappe.get_cached_value("Party Type", party_type, "account_type")
+		default_account_name = "default_" + account_type.lower() + "_account"
+		account = frappe.get_cached_value("Company", company, default_account_name)
 
 	return account
 
@@ -527,7 +530,7 @@ def get_party_advance_account(party_type, party, company):
 
 def get_party_account_currency(party_type, party, company):
 	def generator():
-		party_account = get_party_account(party_type, party, company)
+		party_account = _get_party_account(party_type, party, company)
 		return frappe.get_cached_value("Account", party_account, "account_currency")
 
 	return frappe.local_cache("party_account_currency", (party_type, party, company), generator)

--- a/erpnext/buying/doctype/request_for_quotation/mapper.py
+++ b/erpnext/buying/doctype/request_for_quotation/mapper.py
@@ -59,10 +59,21 @@ def make_supplier_quotation_from_rfq(
 def create_supplier_quotation(doc: str | Document | dict):
 	doc = frappe.parse_json(doc)
 
+	if not all(
+		(
+			isinstance(doc.get("name"), str),
+			isinstance(doc.get("supplier"), str),
+			isinstance(doc.get("items"), list),
+		)
+	):
+		frappe.throw(_("Not Permitted"), frappe.PermissionError)
+
 	if frappe.session.user not in frappe.get_all(
 		"Portal User", {"parent": doc.get("supplier")}, pluck="user"
 	):
 		frappe.throw(_("Not Permitted"), frappe.PermissionError)
+
+	rfq = validate_supplier_quotation_data(doc)
 
 	sq_doc = frappe.get_doc(
 		{
@@ -76,7 +87,7 @@ def create_supplier_quotation(doc: str | Document | dict):
 			or frappe.db.get_single_value("Buying Settings", "buying_price_list"),
 		}
 	)
-	add_items(sq_doc, doc.get("supplier"), doc.get("items"))
+	add_items(sq_doc, doc.get("supplier"), doc.get("items"), rfq)
 	sq_doc.flags.ignore_permissions = True
 	sq_doc.run_method("set_missing_values")
 	sq_doc.save()
@@ -84,23 +95,45 @@ def create_supplier_quotation(doc: str | Document | dict):
 	return sq_doc.name
 
 
-def add_items(sq_doc, supplier, items):
+def validate_supplier_quotation_data(doc):
+	if not frappe.db.exists("Request for Quotation", doc.get("name")) or any(
+		not isinstance(item.get("name"), str) or not isinstance(item.get("item_code"), str)
+		for item in doc.get("items")
+	):
+		frappe.throw(_("Not Permitted"), frappe.PermissionError)
+
+	rfq = frappe.get_doc("Request for Quotation", doc.get("name"))
+	rfq_items = {(item.name, item.item_code) for item in rfq.items}
+	submitted_items = {(item.get("name"), item.get("item_code")) for item in doc.get("items")}
+	is_supplier_invited = doc.get("supplier") in {row.supplier for row in rfq.suppliers}
+
+	if (
+		rfq.docstatus != 1
+		or not is_supplier_invited
+		or len(doc.get("items")) != len(rfq.items)
+		or submitted_items != rfq_items
+	):
+		frappe.throw(_("Not Permitted"), frappe.PermissionError)
+
+	return rfq
+
+
+def add_items(sq_doc, supplier, items, rfq):
+	rfq_items = {item.name: item for item in rfq.items}
 	for data in items:
 		if isinstance(data, dict):
 			data = frappe._dict(data)
 
-		create_rfq_items(sq_doc, supplier, data)
+		create_rfq_items(sq_doc, supplier, rfq_items[data.name], data)
 
 
-def create_rfq_items(sq_doc, supplier, data):
-	args = {}
+def create_rfq_items(sq_doc, supplier, rfq_item, data):
+	args = {"qty": data.get("qty"), "rate": data.get("rate")}
 
 	for field in [
 		"item_code",
 		"item_name",
 		"description",
-		"qty",
-		"rate",
 		"conversion_factor",
 		"warehouse",
 		"material_request",
@@ -109,14 +142,14 @@ def create_rfq_items(sq_doc, supplier, data):
 		"uom",
 		"cost_center",
 	]:
-		args[field] = data.get(field)
+		args[field] = rfq_item.get(field)
 
 	args.update(
 		{
-			"request_for_quotation_item": data.name,
-			"request_for_quotation": data.parent,
+			"request_for_quotation_item": rfq_item.name,
+			"request_for_quotation": rfq_item.parent,
 			"supplier_part_no": frappe.db.get_value(
-				"Item Supplier", {"parent": data.item_code, "supplier": supplier}, "supplier_part_no"
+				"Item Supplier", {"parent": rfq_item.item_code, "supplier": supplier}, "supplier_part_no"
 			),
 		}
 	)

--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -8,6 +8,7 @@ import frappe
 from frappe.tests import change_settings
 from frappe.utils import nowdate
 
+from erpnext.accounts.party import get_party_account
 from erpnext.buying.doctype.request_for_quotation.mapper import (
 	create_supplier_quotation,
 	make_supplier_quotation_from_rfq,
@@ -175,10 +176,22 @@ class TestRequestforQuotation(ERPNextTestSuite):
 		frappe.form_dict.name = None
 
 	def test_make_supplier_quotation_from_portal(self):
-		rfq = make_request_for_quotation()
+		portal_user = frappe.new_doc(
+			"User",
+			email=frappe.generate_hash() + "@example.com",
+			first_name="Supplier Portal User",
+			roles=[{"role": "Supplier"}],
+			send_welcome_email=False,
+			user_type="Website User",
+		).insert()
+		rfq = make_request_for_quotation(portal_user=portal_user.name)
 		rfq.get("items")[0].rate = 100
 		rfq.supplier = rfq.suppliers[0].supplier
-		supplier_quotation_name = create_supplier_quotation(rfq)
+
+		with self.set_user(portal_user.name):
+			with self.assertRaises(frappe.PermissionError):
+				get_party_account("Supplier", rfq.supplier, rfq.company)
+			supplier_quotation_name = create_supplier_quotation(rfq)
 
 		supplier_quotation_doc = frappe.get_doc("Supplier Quotation", supplier_quotation_name)
 
@@ -339,7 +352,7 @@ def make_request_for_quotation(**args):
 		rfq.append("suppliers", data)
 		frappe.new_doc(
 			"Portal User",
-			user="Administrator",
+			user=args.portal_user or "Administrator",
 			parent=data.get("supplier"),
 			parentfield="portal_users",
 			parenttype="Supplier",

--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -185,13 +185,21 @@ class TestRequestforQuotation(ERPNextTestSuite):
 			user_type="Website User",
 		).insert()
 		rfq = make_request_for_quotation(portal_user=portal_user.name)
-		rfq.get("items")[0].rate = 100
-		rfq.supplier = rfq.suppliers[0].supplier
+		portal_doc = frappe.parse_json(rfq.as_json())
+		portal_doc.supplier = rfq.suppliers[0].supplier
+		portal_doc["items"][0]["rate"] = 100
 
 		with self.set_user(portal_user.name):
 			with self.assertRaises(frappe.PermissionError):
-				get_party_account("Supplier", rfq.supplier, rfq.company)
-			supplier_quotation_name = create_supplier_quotation(rfq)
+				get_party_account("Supplier", portal_doc.supplier, rfq.company)
+
+			item_code = portal_doc["items"][0]["item_code"]
+			portal_doc["items"][0]["item_code"] = "Unauthorized Item"
+			with self.assertRaises(frappe.PermissionError):
+				create_supplier_quotation(frappe.as_json(portal_doc))
+			portal_doc["items"][0]["item_code"] = item_code
+
+			supplier_quotation_name = create_supplier_quotation(frappe.as_json(portal_doc))
 
 		supplier_quotation_doc = frappe.get_doc("Supplier Quotation", supplier_quotation_name)
 

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -107,8 +107,10 @@ def get_item_details(
 	_preprocess_ctx(ctx)
 	for_validate = parse_json(for_validate)
 	overwrite_warehouse = parse_json(overwrite_warehouse)
+	ignore_permissions = isinstance(doc, Document) and doc.flags.ignore_permissions
 	item = frappe.get_cached_doc("Item", ctx.item_code)
-	item.check_permission()
+	if not ignore_permissions:
+		item.check_permission()
 	validate_item_details(ctx, item)
 
 	doc = frappe.parse_json(doc)


### PR DESCRIPTION
## Problem
Supplier portal users cannot create a Supplier Quotation from an RFQ because internal party-account currency and item-detail lookups enforce Account and Item read permissions.

## Fix
- keep Account permission checks on the whitelisted account lookup while using a private resolver for internal currency validation
- honor a server-created document's `ignore_permissions` flag during internal item-detail lookup
- require the supplier and submitted item identities to match the authorized, submitted RFQ
- source immutable quotation item fields from the server-side RFQ instead of client input
- run the portal quotation test as an actual Website User and verify arbitrary items are rejected
