### PR TITLE
refactor: drop redundant time_in_mins assignment in workstation complete_job

### DIFF
--- a/erpnext/manufacturing/doctype/workstation/workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/workstation.py
@@ -242,7 +242,7 @@ class Workstation(Document):
 		for row in doc.time_logs:
 			if not row.to_time:
 				row.to_time = to_time
-				row.time_in_mins = time_diff_in_hours(row.to_time, row.from_time) / 60
+				row.time_in_mins = time_diff_in_hours(row.to_time, row.from_time) * 60
 				row.completed_qty = qty
 
 		doc.save()

--- a/erpnext/manufacturing/doctype/workstation/workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/workstation.py
@@ -242,7 +242,6 @@ class Workstation(Document):
 		for row in doc.time_logs:
 			if not row.to_time:
 				row.to_time = to_time
-				row.time_in_mins = time_diff_in_hours(row.to_time, row.from_time) * 60
 				row.completed_qty = qty
 
 		doc.save()


### PR DESCRIPTION
**Issue:**

- `complete_job` computed `time_in_mins` with the wrong conversion (`/ 60` instead of `* 60`). The wrong value never persisted though: `doc.save()` runs `JobCard.validate_time_logs` → `validate_time_log_row`, which recomputes `time_in_mins` for every row that has both timestamps, before anything reads the assignment.

**Fix:**

- Drop the assignment instead of correcting it. Job card validation owns this derived value, and duplicating the conversion here is what let the two copies drift. Matches `start_job`, which sets only the inputs.

No behavior change.

**Backport Needed For V15 and V16**
