### PR TITLE
fix: update payment terms on reconciliation

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -366,6 +366,8 @@ class JournalEntry(AccountsController):
 				account.reference_name,
 				account.payment_term,
 				max(account.debit_in_account_currency, account.credit_in_account_currency),
+				account.account_currency,
+				account.exchange_rate,
 				cancel=True,
 			)
 

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -329,6 +329,7 @@ class JournalEntry(AccountsController):
 
 		# References for this Journal are removed on the `on_cancel` event in accounts_controller
 		super().on_cancel()
+		self.reverse_payment_schedule_allocations()
 
 		from_doc_events = getattr(self, "ignore_linked_doctypes", ())
 		self.ignore_linked_doctypes = (
@@ -355,6 +356,18 @@ class JournalEntry(AccountsController):
 		self.unlink_inter_company_jv()
 		AssetService(self).unlink_asset_adjustment_entry()
 		self.update_invoice_discounting()
+
+	def reverse_payment_schedule_allocations(self):
+		from erpnext.accounts.services.payment_schedule import update_invoice_payment_schedule
+
+		for account in self.accounts:
+			update_invoice_payment_schedule(
+				account.reference_type,
+				account.reference_name,
+				account.payment_term,
+				max(account.debit_in_account_currency, account.credit_in_account_currency),
+				cancel=True,
+			)
 
 	def get_title(self):
 		return self.pay_to_recd_from or self.accounts[0].account

--- a/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
+++ b/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
@@ -30,6 +30,7 @@
   "reference",
   "reference_type",
   "reference_name",
+  "payment_term",
   "reference_due_date",
   "reference_detail_no",
   "advance_voucher_type",
@@ -196,6 +197,14 @@
    "no_copy": 1,
    "options": "reference_type",
    "search_index": 1
+  },
+  {
+   "fieldname": "payment_term",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Payment Term",
+   "options": "Payment Term",
+   "read_only": 1
   },
   {
    "depends_on": "eval:doc.reference_type&&!in_list(doc.reference_type, ['Expense Claim', 'Asset', 'Employee Loan', 'Employee Advance', 'Bank Transaction'])",

--- a/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.py
+++ b/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.py
@@ -34,6 +34,7 @@ class JournalEntryAccount(Document):
 		parenttype: DF.Data
 		party: DF.DynamicLink | None
 		party_type: DF.Link | None
+		payment_term: DF.Link | None
 		project: DF.Link | None
 		reference_detail_no: DF.Data | None
 		reference_due_date: DF.Date | None

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -617,16 +617,21 @@ class PaymentReconciliation(Document):
 				reconciled_entry.append(payment_details)
 
 		if entry_list:
+			for entry in entry_list:
+				(
+					entry.payment_currency,
+					entry.payment_exchange_rate,
+				) = self.get_payment_currency_and_exchange_rate(entry)
+
 			reconcile_against_document(entry_list, skip_ref_details_update_for_pe, self.dimensions)
 			for entry in entry_list:
-				payment_currency, payment_exchange_rate = self.get_payment_currency_and_exchange_rate(entry)
 				update_invoice_payment_schedule(
 					entry.against_voucher_type,
 					entry.against_voucher,
 					entry.payment_term,
 					entry.allocated_amount,
-					payment_currency,
-					payment_exchange_rate,
+					entry.payment_currency,
+					entry.payment_exchange_rate,
 				)
 
 		if dr_or_cr_notes:

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -19,6 +19,7 @@ from erpnext.accounts.doctype.process_payment_reconciliation.process_payment_rec
 )
 from erpnext.accounts.services.advances import get_advance_payment_entries_for_regional
 from erpnext.accounts.services.exchange_gain_loss import get_exchange_gain_loss_account
+from erpnext.accounts.services.payment_schedule import update_invoice_payment_schedule
 from erpnext.accounts.utils import (
 	QueryPaymentLedger,
 	create_gain_loss_journal,
@@ -409,7 +410,28 @@ class PaymentReconciliation(Document):
 			non_reconciled_invoices, key=lambda k: k["posting_date"] or getdate(nowdate())
 		)
 
-		self.add_invoice_entries(non_reconciled_invoices)
+		self.add_invoice_entries(self.split_invoice_entries(non_reconciled_invoices))
+
+	def split_invoice_entries(self, invoices):
+		from erpnext.accounts.doctype.payment_entry.payment_entry import (
+			get_currency_data,
+			get_split_invoice_rows,
+		)
+
+		currency_data = get_currency_data(invoices, self.company)
+		entries = []
+		for invoice in invoices:
+			payment_terms_template = (
+				frappe.db.get_value(invoice.voucher_type, invoice.voucher_no, "payment_terms_template")
+				if invoice.voucher_type in ("Sales Invoice", "Purchase Invoice")
+				else None
+			)
+			entries.extend(
+				get_split_invoice_rows(invoice, payment_terms_template, currency_data)
+				if payment_terms_template
+				else [invoice]
+			)
+		return entries
 
 	def add_invoice_entries(self, non_reconciled_invoices):
 		# Populate 'invoices' with JVs and Invoices to reconcile against
@@ -423,6 +445,7 @@ class PaymentReconciliation(Document):
 			inv.amount = flt(entry.get("invoice_amount"))
 			inv.currency = entry.get("currency")
 			inv.outstanding_amount = flt(entry.get("outstanding_amount"))
+			inv.payment_term = entry.get("payment_term")
 
 	def get_difference_amount(self, payment_entry, invoice, allocated_amount):
 		party_account_defaults = frappe.get_cached_value(
@@ -553,6 +576,7 @@ class PaymentReconciliation(Document):
 				"allocated_amount": allocated_amount,
 				"difference_amount": pay.get("difference_amount"),
 				"currency": inv.get("currency"),
+				"payment_term": inv.get("payment_term"),
 				"cost_center": pay.get("cost_center"),
 			}
 		)
@@ -583,6 +607,13 @@ class PaymentReconciliation(Document):
 
 		if entry_list:
 			reconcile_against_document(entry_list, skip_ref_details_update_for_pe, self.dimensions)
+			for entry in entry_list:
+				update_invoice_payment_schedule(
+					entry.against_voucher_type,
+					entry.against_voucher,
+					entry.payment_term,
+					entry.allocated_amount,
+				)
 
 		if dr_or_cr_notes:
 			reconcile_dr_cr_note(dr_or_cr_notes, self.company, self.dimensions)
@@ -634,6 +665,7 @@ class PaymentReconciliation(Document):
 				"difference_account": row.get("difference_account"),
 				"difference_posting_date": row.get("gain_loss_posting_date"),
 				"debit_or_credit_note_posting_date": row.get("debit_or_credit_note_posting_date"),
+				"payment_term": row.get("payment_term"),
 				"cost_center": row.get("cost_center"),
 			}
 		)
@@ -750,7 +782,7 @@ class PaymentReconciliation(Document):
 
 		for inv in self.get("invoices"):
 			unreconciled_invoices.setdefault(inv.invoice_type, {}).setdefault(
-				inv.invoice_number, inv.outstanding_amount
+				(inv.invoice_number, inv.payment_term), inv.outstanding_amount
 			)
 
 		invoices_to_reconcile = []
@@ -765,7 +797,9 @@ class PaymentReconciliation(Document):
 						).format(row.idx, row.allocated_amount, row.amount)
 					)
 
-				invoice_outstanding = unreconciled_invoices.get(row.invoice_type, {}).get(row.invoice_number)
+				invoice_outstanding = unreconciled_invoices.get(row.invoice_type, {}).get(
+					(row.invoice_number, row.payment_term), 0
+				)
 				if flt(row.allocated_amount) - invoice_outstanding > 0.009:
 					frappe.throw(
 						_(

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -419,13 +419,24 @@ class PaymentReconciliation(Document):
 		)
 
 		currency_data = get_currency_data(invoices, self.company)
+		invoice_names = {
+			doctype: [invoice.voucher_no for invoice in invoices if invoice.voucher_type == doctype]
+			for doctype in ("Sales Invoice", "Purchase Invoice")
+		}
+		payment_terms_templates = {
+			(doctype, name): template
+			for doctype, names in invoice_names.items()
+			if names
+			for name, template in frappe.get_all(
+				doctype,
+				filters={"name": ("in", names)},
+				fields=["name", "payment_terms_template"],
+				as_list=True,
+			)
+		}
 		entries = []
 		for invoice in invoices:
-			payment_terms_template = (
-				frappe.db.get_value(invoice.voucher_type, invoice.voucher_no, "payment_terms_template")
-				if invoice.voucher_type in ("Sales Invoice", "Purchase Invoice")
-				else None
-			)
+			payment_terms_template = payment_terms_templates.get((invoice.voucher_type, invoice.voucher_no))
 			entries.extend(
 				get_split_invoice_rows(invoice, payment_terms_template, currency_data)
 				if payment_terms_template
@@ -608,11 +619,14 @@ class PaymentReconciliation(Document):
 		if entry_list:
 			reconcile_against_document(entry_list, skip_ref_details_update_for_pe, self.dimensions)
 			for entry in entry_list:
+				payment_currency, payment_exchange_rate = self.get_payment_currency_and_exchange_rate(entry)
 				update_invoice_payment_schedule(
 					entry.against_voucher_type,
 					entry.against_voucher,
 					entry.payment_term,
 					entry.allocated_amount,
+					payment_currency,
+					payment_exchange_rate,
 				)
 
 		if dr_or_cr_notes:
@@ -643,6 +657,22 @@ class PaymentReconciliation(Document):
 		msgprint(_("Successfully Reconciled"))
 
 		self.get_unreconciled_entries()
+
+	def get_payment_currency_and_exchange_rate(self, entry):
+		if entry.voucher_type == "Journal Entry":
+			return frappe.db.get_value(
+				"Journal Entry Account",
+				entry.voucher_detail_no,
+				["account_currency", "exchange_rate"],
+			) or (None, None)
+
+		if entry.voucher_type == "Payment Entry":
+			payment_entry = frappe.get_cached_doc("Payment Entry", entry.voucher_no)
+			if payment_entry.payment_type == "Receive":
+				return payment_entry.paid_from_account_currency, payment_entry.source_exchange_rate
+			return payment_entry.paid_to_account_currency, payment_entry.target_exchange_rate
+
+		return None, None
 
 	def get_payment_details(self, row, dr_or_cr):
 		payment_details = frappe._dict(

--- a/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
@@ -8,7 +8,10 @@ from frappe.utils.data import getdate as convert_to_date
 
 from erpnext.accounts.doctype.account.test_account import create_account
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
-from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_entry
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+	create_payment_entry,
+	create_payment_terms_template,
+)
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.party import get_party_account
@@ -643,6 +646,48 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		# check PR tool output
 		self.assertEqual(len(pr.get("invoices")), 0)
 		self.assertEqual(len(pr.get("payments")), 0)
+
+	def test_journal_against_invoice_with_payment_terms(self):
+		create_payment_terms_template()
+		template = frappe.get_doc("Payment Terms Template", "Test Receivable Template")
+		template.terms[0].invoice_portion = 30
+		template.terms[1].invoice_portion = 70
+		template.save()
+
+		si = self.create_sales_invoice(qty=1, rate=100, do_not_save=True, do_not_submit=True)
+		si.payment_terms_template = "Test Receivable Template"
+		si.save().submit()
+
+		je = self.create_journal_entry(self.bank, self.debit_to, 100)
+		je.accounts[1].party_type = "Customer"
+		je.accounts[1].party = self.customer
+		je.save().submit()
+
+		pr = self.create_payment_reconciliation()
+		pr.invoice_name = si.name
+		pr.payment_name = je.name
+		pr.get_unreconciled_entries()
+		self.assertEqual(len(pr.invoices), 2)
+
+		pr.allocate_entries(
+			frappe._dict(
+				{
+					"invoices": [invoice.as_dict() for invoice in pr.invoices],
+					"payments": [payment.as_dict() for payment in pr.payments],
+				}
+			)
+		)
+		pr.reconcile()
+
+		si.reload()
+		self.assertEqual([term.outstanding for term in si.payment_schedule], [0, 0])
+
+		je.reload().cancel()
+		si.reload()
+		self.assertEqual(
+			[term.outstanding for term in si.payment_schedule],
+			[term.payment_amount for term in si.payment_schedule],
+		)
 
 	def test_negative_debit_or_credit_journal_against_invoice(self):
 		transaction_date = nowdate()

--- a/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.json
+++ b/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.json
@@ -11,6 +11,7 @@
   "column_break_3",
   "invoice_type",
   "invoice_number",
+  "payment_term",
   "section_break_6",
   "allocated_amount",
   "unreconciled_amount",
@@ -105,6 +106,13 @@
    "options": "DocType",
    "read_only": 1,
    "reqd": 1
+  },
+  {
+   "fieldname": "payment_term",
+   "fieldtype": "Link",
+   "label": "Payment Term",
+   "options": "Payment Term",
+   "read_only": 1
   },
   {
    "fieldname": "section_break_6",

--- a/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.py
@@ -29,6 +29,7 @@ class PaymentReconciliationAllocation(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		payment_term: DF.Link | None
 		reference_name: DF.DynamicLink
 		reference_row: DF.Data | None
 		reference_type: DF.Link

--- a/erpnext/accounts/doctype/payment_reconciliation_invoice/payment_reconciliation_invoice.json
+++ b/erpnext/accounts/doctype/payment_reconciliation_invoice/payment_reconciliation_invoice.json
@@ -8,6 +8,7 @@
   "invoice_type",
   "invoice_number",
   "invoice_date",
+  "payment_term",
   "col_break1",
   "amount",
   "outstanding_amount",
@@ -36,6 +37,13 @@
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Invoice Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "payment_term",
+   "fieldtype": "Link",
+   "label": "Payment Term",
+   "options": "Payment Term",
    "read_only": 1
   },
   {

--- a/erpnext/accounts/doctype/payment_reconciliation_invoice/payment_reconciliation_invoice.py
+++ b/erpnext/accounts/doctype/payment_reconciliation_invoice/payment_reconciliation_invoice.py
@@ -24,6 +24,7 @@ class PaymentReconciliationInvoice(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		payment_term: DF.Link | None
 	# end: auto-generated types
 
 	@staticmethod

--- a/erpnext/accounts/services/payment_schedule.py
+++ b/erpnext/accounts/services/payment_schedule.py
@@ -327,6 +327,50 @@ class PaymentScheduleService:
 		self.validate_payment_schedule_amount()
 
 
+def update_invoice_payment_schedule(
+	invoice_type: str,
+	invoice_name: str,
+	payment_term: str | None,
+	allocated_amount: float,
+	cancel: bool = False,
+) -> None:
+	if not payment_term or invoice_type not in ("Sales Invoice", "Purchase Invoice"):
+		return
+
+	invoice = frappe.get_cached_doc(invoice_type, invoice_name)
+	if not frappe.db.get_value(
+		"Payment Terms Template", invoice.payment_terms_template, "allocate_payment_based_on_payment_terms"
+	):
+		return
+
+	party_type, party = invoice.get_party()
+	party_account_currency = invoice.party_account_currency or get_party_account_currency(
+		party_type, party, invoice.company
+	)
+	if invoice.currency != invoice.company_currency and party_account_currency == invoice.company_currency:
+		allocated_amount = flt(allocated_amount / invoice.conversion_rate, invoice.precision("grand_total"))
+
+	base_allocated_amount = flt(
+		allocated_amount * invoice.conversion_rate, invoice.precision("base_grand_total")
+	)
+	payment_schedule = frappe.qb.DocType("Payment Schedule")
+	change = 1 if cancel else -1
+	(
+		frappe.qb.update(payment_schedule)
+		.set(payment_schedule.paid_amount, payment_schedule.paid_amount - (change * allocated_amount))
+		.set(
+			payment_schedule.base_paid_amount,
+			payment_schedule.base_paid_amount - (change * base_allocated_amount),
+		)
+		.set(payment_schedule.outstanding, payment_schedule.outstanding + (change * allocated_amount))
+		.set(
+			payment_schedule.base_outstanding,
+			payment_schedule.base_outstanding + (change * base_allocated_amount),
+		)
+		.where((payment_schedule.parent == invoice_name) & (payment_schedule.payment_term == payment_term))
+	).run()
+
+
 def linked_order_has_payment_terms_template(po_or_so, doctype) -> str | None:
 	return frappe.get_value(doctype, po_or_so, "payment_terms_template")
 

--- a/erpnext/accounts/services/payment_schedule.py
+++ b/erpnext/accounts/services/payment_schedule.py
@@ -332,6 +332,8 @@ def update_invoice_payment_schedule(
 	invoice_name: str,
 	payment_term: str | None,
 	allocated_amount: float,
+	payment_currency: str | None,
+	payment_exchange_rate: float | None,
 	cancel: bool = False,
 ) -> None:
 	if not payment_term or invoice_type not in ("Sales Invoice", "Purchase Invoice"):
@@ -343,12 +345,11 @@ def update_invoice_payment_schedule(
 	):
 		return
 
-	party_type, party = invoice.get_party()
-	party_account_currency = invoice.party_account_currency or get_party_account_currency(
-		party_type, party, invoice.company
-	)
-	if invoice.currency != invoice.company_currency and party_account_currency == invoice.company_currency:
-		allocated_amount = flt(allocated_amount / invoice.conversion_rate, invoice.precision("grand_total"))
+	if payment_currency and payment_currency != invoice.currency:
+		allocated_amount = flt(
+			allocated_amount * flt(payment_exchange_rate) / invoice.conversion_rate,
+			invoice.precision("grand_total"),
+		)
 
 	base_allocated_amount = flt(
 		allocated_amount * invoice.conversion_rate, invoice.precision("base_grand_total")
@@ -367,7 +368,11 @@ def update_invoice_payment_schedule(
 			payment_schedule.base_outstanding,
 			payment_schedule.base_outstanding + (change * base_allocated_amount),
 		)
-		.where((payment_schedule.parent == invoice_name) & (payment_schedule.payment_term == payment_term))
+		.where(
+			(payment_schedule.parent == invoice_name)
+			& (payment_schedule.parenttype == invoice_type)
+			& (payment_schedule.payment_term == payment_term)
+		)
 	).run()
 
 

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1056,6 +1056,8 @@ def remove_ref_doc_link_from_jv(
 			jea.payment_term,
 			jea.debit_in_account_currency,
 			jea.credit_in_account_currency,
+			jea.account_currency,
+			jea.exchange_rate,
 		)
 		.where((jea.reference_type == ref_type) & (jea.reference_name == ref_no) & (jea.docstatus.lt(2)))
 	)
@@ -1067,6 +1069,8 @@ def remove_ref_doc_link_from_jv(
 			allocation.reference_name,
 			allocation.payment_term,
 			max(allocation.debit_in_account_currency, allocation.credit_in_account_currency),
+			allocation.account_currency,
+			allocation.exchange_rate,
 			cancel=True,
 		)
 
@@ -1140,11 +1144,24 @@ def remove_ref_doc_link_from_pe(
 	for row in reference_rows:
 		linked_pe.add(row.parent)
 		row_names.add(row.name)
+		payment_entry = frappe.get_cached_doc("Payment Entry", row.parent)
+		payment_currency = (
+			payment_entry.paid_from_account_currency
+			if payment_entry.payment_type == "Receive"
+			else payment_entry.paid_to_account_currency
+		)
+		payment_exchange_rate = (
+			payment_entry.source_exchange_rate
+			if payment_entry.payment_type == "Receive"
+			else payment_entry.target_exchange_rate
+		)
 		update_invoice_payment_schedule(
 			row.reference_doctype,
 			row.reference_name,
 			row.payment_term,
 			row.allocated_amount,
+			payment_currency,
+			payment_exchange_rate,
 			cancel=True,
 		)
 

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -721,6 +721,7 @@ def update_reference_in_journal_entry(d, journal_entry, do_not_save=False):
 
 	new_row.set("reference_type", d["against_voucher_type"])
 	new_row.set("reference_name", d["against_voucher"])
+	new_row.set("payment_term", d.get("payment_term"))
 
 	new_row.against_account = cstr(jv_detail.against_account)
 	new_row.is_advance = cstr(jv_detail.is_advance)
@@ -749,6 +750,7 @@ def update_reference_in_payment_entry(
 		"total_amount": d.grand_total,
 		"outstanding_amount": d.outstanding_amount,
 		"allocated_amount": d.allocated_amount,
+		"payment_term": d.get("payment_term"),
 		"exchange_rate": d.exchange_rate
 		if d.difference_amount is not None
 		else payment_entry.get_exchange_rate(),
@@ -1042,7 +1044,31 @@ def unlink_ref_doc_from_payment_entries(ref_doc: object = None, payment_name: st
 def remove_ref_doc_link_from_jv(
 	ref_type: str | None = None, ref_no: str | None = None, payment_name: str | None = None
 ):
+	from erpnext.accounts.services.payment_schedule import update_invoice_payment_schedule
+
 	jea = qb.DocType("Journal Entry Account")
+
+	payment_schedule_allocations = (
+		qb.from_(jea)
+		.select(
+			jea.reference_type,
+			jea.reference_name,
+			jea.payment_term,
+			jea.debit_in_account_currency,
+			jea.credit_in_account_currency,
+		)
+		.where((jea.reference_type == ref_type) & (jea.reference_name == ref_no) & (jea.docstatus.lt(2)))
+	)
+	if payment_name:
+		payment_schedule_allocations = payment_schedule_allocations.where(jea.parent == payment_name)
+	for allocation in payment_schedule_allocations.run(as_dict=True):
+		update_invoice_payment_schedule(
+			allocation.reference_type,
+			allocation.reference_name,
+			allocation.payment_term,
+			max(allocation.debit_in_account_currency, allocation.credit_in_account_currency),
+			cancel=True,
+		)
 
 	linked_jv = (
 		qb.from_(jea)
@@ -1109,9 +1135,18 @@ def remove_ref_doc_link_from_pe(
 	linked_pe = set()
 	row_names = set()
 
+	from erpnext.accounts.services.payment_schedule import update_invoice_payment_schedule
+
 	for row in reference_rows:
 		linked_pe.add(row.parent)
 		row_names.add(row.name)
+		update_invoice_payment_schedule(
+			row.reference_doctype,
+			row.reference_name,
+			row.payment_term,
+			row.allocated_amount,
+			cancel=True,
+		)
 
 	from erpnext.accounts.doctype.payment_request.payment_request import (
 		update_payment_requests_as_per_pe_references,


### PR DESCRIPTION
## Summary
- split payment-reconciliation invoice allocations by payment term
- update payment-schedule outstanding amounts for reconciled Journal Entries and Payment Entries
- restore term balances when reconciled entries are cancelled or unreconciled

Fix for https://support.frappe.io/helpdesk/tickets/75782?view=VIEW-HD+Ticket-1547