### PR TITLE
fix: fail loudly when the reposting data file is missing or corrupt

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
@@ -688,6 +688,38 @@ class TestRepostItemValuation(ERPNextTestSuite, StockTestMixin):
 					)
 				)
 
+	def test_missing_or_corrupt_reposting_data_file_fails_loudly(self):
+		from erpnext.stock.stock_ledger import get_reposting_data
+
+		self.assertRaises(
+			frappe.ValidationError, get_reposting_data, "/files/non-existent-repost-data.json.gz"
+		)
+
+		riv = frappe.get_doc(
+			{
+				"doctype": "Repost Item Valuation",
+				"based_on": "Item and Warehouse",
+				"company": "_Test Company",
+				"item_code": "_Test Item",
+				"warehouse": "_Test Warehouse - _TC",
+				"posting_date": today(),
+			}
+		).insert(ignore_permissions=True)
+
+		attached = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "corrupt_repost_data.json.gz",
+				"content": "not gzip content",
+				"attached_to_doctype": riv.doctype,
+				"attached_to_name": riv.name,
+				"attached_to_field": "reposting_data_file",
+			}
+		).insert(ignore_permissions=True)
+		riv.db_set("reposting_data_file", attached.file_url)
+
+		self.assertRaises(frappe.ValidationError, get_reposting_data, attached.file_url)
+
 	def test_clear_attachment_skips_referenced_data_file(self):
 		riv = frappe.get_doc(
 			{

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -546,7 +546,11 @@ def get_reposting_data(file_path) -> dict:
 	)
 
 	if not file_name:
-		return frappe._dict()
+		frappe.throw(
+			_(
+				"The reposting data file {0} is missing. Resuming this repost without it would silently skip the affected transactions during GL reposting. Restart the repost to regenerate it."
+			).format(bold(file_path))
+		)
 
 	attached_file = frappe.get_doc("File", file_name)
 
@@ -557,7 +561,15 @@ def get_reposting_data(file_path) -> dict:
 	try:
 		data = gzip.decompress(content)
 	except Exception:
-		return frappe._dict()
+		frappe.log_error(
+			title="Corrupted reposting data file",
+			message=f"Could not decompress the reposting data file {file_path}",
+		)
+		frappe.throw(
+			_(
+				"The reposting data file {0} is corrupted. Resuming this repost without it would silently skip the affected transactions during GL reposting. Restart the repost to regenerate it."
+			).format(bold(file_path))
+		)
 
 	data = json.loads(data.decode("utf-8"))
 


### PR DESCRIPTION
## Problem

`get_reposting_data()` in `erpnext/stock/stock_ledger.py` loads the gzipped JSON
checkpoint attached to a Repost Item Valuation (`reposting_data_file`). It swallowed
every failure:

- if the `File` record was missing, it returned `frappe._dict()`;
- if the attachment content could not be gunzipped (truncated upload, corrupted
  storage, content replaced), it did `except Exception: return frappe._dict()`.

The checkpoint holds `repost_affected_transaction` — the set of vouchers whose GL
entries must be reposted. An empty dict here silently empties that set, so
`repost_gl_entries()` reposts only the directly dependent vouchers and every other
affected voucher keeps its stale GL entries. The repost then completes with status
"Completed" and **no error anywhere**, producing a stock vs. account balance mismatch
that only surfaces later in the Stock and Account Value Comparison report.

### Failure scenario

1. A large backdated repost runs partially, persisting its progress and the affected
   transaction set to the gz attachment, then is interrupted (worker restart).
2. The attachment is lost or corrupted (file storage issue, manual cleanup, partial
   write).
3. The repost resumes, reads an empty checkpoint, finishes "successfully", and the
   vouchers collected before the interruption never get their GL entries reposted.

## Fix

`get_reposting_data()` now raises a clear `frappe.ValidationError` (via
`frappe.throw`) when the file record is missing or the content cannot be
decompressed, and logs an Error Log entry for the corrupt case. The message tells the
operator to restart the repost so the checkpoint is regenerated.

Raising is safe for all callers: every call sits inside `repost()`'s
try/except, which rolls back, records the message and traceback in
`error_log`, sets the Repost Item Valuation to **Failed**, and notifies stock
managers — exactly the loud failure this situation needs. A failed RIV can be
restarted, which regenerates the data file from scratch.

## How to test

1. Automated: `bench --site <site> run-tests --module erpnext.stock.doctype.repost_item_valuation.test_repost_item_valuation`
   — new test `test_missing_or_corrupt_reposting_data_file_fails_loudly` asserts both
   the missing-file and corrupt-content paths raise.
2. Manual: create a backdated repost large enough to checkpoint, replace the
   attached `.json.gz` with garbage, resume reposting — the RIV must go to
   **Failed** with a clear error instead of completing.

## Notes

- Related symptom class: "stock and account balance mismatch" reports where reposts
  show Completed with no errors.
