### PR TITLE
fix: stop forcing allow_negative_stock on every repost

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
@@ -145,7 +145,7 @@
    "reqd": 1
   },
   {
-   "default": "1",
+   "default": "0",
    "fieldname": "allow_negative_stock",
    "fieldtype": "Check",
    "label": "Allow Negative Stock"
@@ -272,7 +272,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-06-16 17:30:42.715321",
+ "modified": "2026-08-10 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Repost Item Valuation",

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -224,7 +224,10 @@ class RepostItemValuation(Document):
 			self.item_code = None
 			self.warehouse = None
 
-		self.allow_negative_stock = 1
+		if not self.allow_negative_stock:
+			self.allow_negative_stock = cint(
+				frappe.db.get_single_value("Stock Settings", "allow_negative_stock")
+			)
 
 	def on_cancel(self):
 		self.clear_attachment()

--- a/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
@@ -147,6 +147,30 @@ class TestRepostItemValuation(ERPNextTestSuite, StockTestMixin):
 			self.assertEqual(riv.company, "_Test Company with perpetual inventory")
 			self.assertEqual(riv.warehouse, "Stores - TCP1")
 
+	def test_repost_respects_global_negative_stock_setting(self):
+		def make_draft_riv(**overrides):
+			args = {
+				"doctype": "Repost Item Valuation",
+				"based_on": "Item and Warehouse",
+				"company": "_Test Company",
+				"item_code": "_Test Item",
+				"warehouse": "_Test Warehouse - _TC",
+				"posting_date": today(),
+			}
+			args.update(overrides)
+			return frappe.get_doc(args).insert(ignore_permissions=True)
+
+		with self.change_settings("Stock Settings", {"allow_negative_stock": 0}):
+			riv = make_draft_riv()
+			self.assertEqual(riv.allow_negative_stock, 0)
+
+			explicit_riv = make_draft_riv(allow_negative_stock=1)
+			self.assertEqual(explicit_riv.allow_negative_stock, 1)
+
+		with self.change_settings("Stock Settings", {"allow_negative_stock": 1}):
+			riv = make_draft_riv()
+			self.assertEqual(riv.allow_negative_stock, 1)
+
 	def test_deduplication(self):
 		def _assert_status(doc, status):
 			doc.load_from_db()


### PR DESCRIPTION
## Problem

`RepostItemValuation.reset_field_values()` unconditionally set
`self.allow_negative_stock = 1` on every validate:

```python
def reset_field_values(self):
	if self.based_on == "Transaction":
		self.item_code = None
		self.warehouse = None

	self.allow_negative_stock = 1
```

That value is passed down to `repost_future_sle()` /
`update_entries_after`, so **every background repost runs with negative-stock
validation disabled**, regardless of what `Stock Settings > Allow Negative Stock`
says. Reposting is exactly the moment when the ledger is being rewritten in bulk and
unattended — the moment the check matters most. With the check forced off, a
backdated entry that drives an item-warehouse negative slips through the repost
silently, and FIFO then has to invent a rate for stock that does not exist, feeding a
fabricated valuation into COGS and the GL.

### Failure scenario

1. `Allow Negative Stock` is off (the default). Day-to-day submissions correctly
   block negative balances.
2. A user backdates a receipt cancellation (or inserts a backdated issue). The
   synchronous validation passes at the insertion point, and a Repost Item Valuation
   is queued for the future entries.
3. The repost recalculates all future SLEs with `allow_negative_stock = 1`, so an
   intermediate negative balance that the user would have been stopped for at entry
   time is silently accepted and valued at a guessed rate.

## Fix

`reset_field_values()` now defaults `allow_negative_stock` from the actual global
setting (`Stock Settings.allow_negative_stock`) instead of hardcoding `1`. An
explicitly checked flag on the document is preserved, so operators (and ERPNext's own
repair tooling, which sets the flag deliberately) can still opt in per repost.

The doctype JSON's field default also changes from `1` to `0` — with the old
default, every new document started at 1 before `reset_field_values()` ran, so
the derivation could never take effect and an explicit user choice was
indistinguishable from the default.

Note: paths that genuinely need the bypass already pass it explicitly —
`recreate_stock_ledger_entries()` calls `update_stock_ledger(allow_negative_stock=True)`
and the Landed Cost Voucher flow passes its own flag. Those are unchanged.

## How to test

1. Automated: `bench --site <site> run-tests --module erpnext.stock.doctype.repost_item_valuation.test_repost_item_valuation`
   — new test `test_repost_respects_global_negative_stock_setting` covers all three
   cases (global off -> 0, explicit 1 preserved, global on -> 1).
2. Manual: with Allow Negative Stock off, submit a receipt then an issue consuming
   it, then cancel the backdated receipt. The queued repost should now fail with the
   negative stock error instead of completing and leaving a negative balance.

## Notes

- This is the corruption path behind upstream #57677 ("deprecate Allow Negative
  Stock") — the flag is off by default, yet reposts ignored it.
- Related symptom class: stock/account mismatch and negative-qty reports
  (`incorrect_balance_qty_after_transaction`) after backdated transactions.
- Behavior change: sites that relied on reposts silently allowing negative stock
  will now see those reposts fail loudly. That is the intent; the explicit per-repost
  flag remains available.
