### PR TITLE
fix: run batch delivered_qty update for every batch, not only the last

### DIFF
--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -1921,7 +1921,7 @@ def update_serial_batch_delivered_qty(row, name, is_cancelled=False):
 				.where((doctype.parent == name) & (doctype.batch_no == batch_no))
 			)
 
-		query.run()
+			query.run()
 
 
 def get_reserved_materials(voucher_no):


### PR DESCRIPTION
## Problem

In `stock_reservation_entry.py`, `update_serial_batch_delivered_qty()` builds one
UPDATE query per batch inside the loop but executes `query.run()` **outside** it:

```python
elif row.batches:
	for batch_no, qty in row.batches.items():
		doctype = frappe.qb.DocType("Serial and Batch Entry")
		query = (
			frappe.qb.update(doctype)
			.set(doctype.delivered_qty, ...)
			.where((doctype.parent == name) & (doctype.batch_no == batch_no))
		)

	query.run()   # <- only the LAST batch's update ever executes
```

### Failure scenario

A delivery consumes 3 batches of a batch-wise reserved item. Only the last
batch's `Serial and Batch Entry.delivered_qty` is updated; the other two stay
stale. The reservation's delivered totals, its Partially Delivered/Delivered
status, and any subsequent availability computation that reads per-batch
delivered quantities are then wrong. Cancelling the delivery
(`is_cancelled=True`) has the same one-batch-only behavior in reverse, so the
error does not even round-trip away.

## Fix

Move `query.run()` inside the loop so each batch's update executes. (The serial
branch above it is unaffected — it already runs a single set-based query.)

## How to test

Automated coverage for this path needs a multi-batch reservation + delivery
fixture that does not exist yet in `test_stock_reservation_entry.py`; the defect
itself is visible by inspection (loop-scoped query, loop-external run). Manual:

1. Enable Stock Reservation with batch-wise items; receive stock into 2+
   batches of one item.
2. Reserve against a Sales Order, deliver quantities drawn from both batches.
3. Before the fix: only one batch's `Serial and Batch Entry.delivered_qty` on
   the reservation is updated. After: both are.
