### PR TITLE
fix: count same-instant rows in dimension negative stock validation

### DIFF
--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -492,6 +492,48 @@ class TestInventoryDimension(ERPNextTestSuite):
 
 		self.assertEqual(site_name, "Site 1")
 
+	def test_validate_negative_stock_same_instant_sibling_rows(self):
+		item_code = "Test Negative Inv Dimension Sibling Item"
+		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
+		create_item(item_code)
+
+		create_inventory_dimension(
+			apply_to_all_doctypes=1,
+			dimension_name="Inv Site",
+			reference_document="Inv Site",
+			document_type="Inv Site",
+			validate_negative_stock=1,
+		)
+
+		warehouse = create_warehouse("Negative Stock Sibling Warehouse")
+
+		receipt = make_stock_entry(item_code=item_code, target=warehouse, qty=8, do_not_submit=True)
+		receipt.items[0].to_inv_site = "Site 1"
+		receipt.submit()
+
+		# Two sibling rows issuing 5 each share one posting_datetime; each row alone
+		# fits the balance of 8, together they drive the dimension to -2.
+		issue = make_stock_entry(item_code=item_code, source=warehouse, qty=5, do_not_submit=True)
+		issue.items[0].inv_site = "Site 1"
+		first = issue.items[0]
+		issue.append(
+			"items",
+			{
+				"item_code": first.item_code,
+				"qty": first.qty,
+				"uom": first.uom,
+				"stock_uom": first.stock_uom,
+				"conversion_factor": first.conversion_factor,
+				"transfer_qty": first.transfer_qty,
+				"s_warehouse": first.s_warehouse,
+				"expense_account": first.expense_account,
+				"cost_center": first.cost_center,
+				"basic_rate": first.basic_rate,
+				"inv_site": "Site 1",
+			},
+		)
+		self.assertRaises(InventoryDimensionNegativeStockError, issue.submit)
+
 	@ERPNextTestSuite.change_settings("Stock Settings", {"allow_negative_stock": 0})
 	def test_validate_negative_stock_with_multiple_dimension(self):
 		item_code = "Test Negative Multi Inventory Dimension Item"

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -120,13 +120,18 @@ class StockLedgerEntry(Document):
 
 	def get_available_qty_after_prev_transaction(self, dimensions):
 		sle = frappe.qb.DocType("Stock Ledger Entry")
+		# Same-instant rows (e.g. sibling rows of this voucher) count as previous;
+		# before insert self.creation is unset and every existing row precedes this one.
+		same_instant_earlier = sle.posting_datetime == self.posting_datetime
+		if self.creation:
+			same_instant_earlier &= sle.creation < self.creation
 		available_qty_query = (
 			frappe.qb.from_(sle)
 			.select(Sum(sle.actual_qty))
 			.where(
 				(sle.item_code == self.item_code)
 				& (sle.warehouse == self.warehouse)
-				& (sle.posting_datetime < self.posting_datetime)
+				& ((sle.posting_datetime < self.posting_datetime) | same_instant_earlier)
 				& (sle.company == self.company)
 				& (sle.is_cancelled == 0)
 			)


### PR DESCRIPTION
Fixes https://github.com/frappe/erpnext/issues/55871

## Problem

`StockLedgerEntry.get_available_qty_after_prev_transaction()` (used by
`validate_inventory_dimension_negative_stock`) filters strictly on

```python
sle.posting_datetime < self.posting_datetime
```

Rows sharing the exact posting instant are invisible to the guard — most
commonly **sibling rows of the same voucher**, which always share one
`posting_datetime`.

### Failure scenario

Dimension balance is 8. One Stock Entry issues two rows of 5 each against the
same item, warehouse, and dimension value. Each row alone fits the balance
(8 − 5 ≥ 0), so both pass validation — jointly they drive the dimension to −2
with `validate_negative_stock` enabled on the Inventory Dimension.

## Fix

Same-instant rows now count as previous, with a `creation` tie-breaker matching
the existing `get_datetime_limit_condition()` convention in `stock_ledger.py`.
Before insert (`self.creation` unset) every existing same-instant row precedes
the row being validated, which is exactly the sibling-row case.

## How to test

`bench --site <site> run-tests --module erpnext.stock.doctype.inventory_dimension.test_inventory_dimension --test test_validate_negative_stock_same_instant_sibling_rows`

The new test receives 8 into a dimension, then submits one Stock Entry with two
sibling rows issuing 5 each and asserts `InventoryDimensionNegativeStockError`.
Verified to fail on develop without the fix and pass with it.
