### PR TITLE
docs: correct stale reposting spec

### DIFF
--- a/erpnext/stock/spec/reposting.md
+++ b/erpnext/stock/spec/reposting.md
@@ -15,8 +15,18 @@ presentation for explanation: https://www.youtube.com/watch?v=mw3WAnekGIM
 ## How is this implemented?
 Whenever backdated transaction is detected, instead of
 fully processing it while submitting, the processing is queued using "Repost
-Item Valuation" doctype. Every hour a scheduled job runs and processes this
-queue (for up to maximum of 25 minutes)
+Item Valuation" doctype. Two scheduled modes exist, selected by "Stock
+Reposting Settings > Enable Parallel Reposting":
+
+- *Parallel reposting enabled*: a cron job runs every 15 minutes as a recovery
+  net; each reposting job also re-triggers the dispatcher on completion, so the
+  queue drains continuously between cron ticks. Up to "No of Parallel
+  Reposting" entries (default 4) run concurrently, at most one per item.
+- *Parallel reposting disabled*: an hourly maintenance job processes the queue
+  sequentially.
+
+Both modes respect the reposting timeslot configured in Stock Reposting
+Settings. There is no fixed per-run time budget.
 
 
 ## Queue implementation
@@ -27,7 +37,9 @@ queue (for up to maximum of 25 minutes)
 - When background job runs, it picks the oldest pending reposts and changes the status to "In Progress" and when it finishes it
 changes to "Completed"
 - There are two more status: "Failed" when reposting failed and "Skipped" when reposting is deemed not necessary so it's skipped.
-- technical detail: Entry point for whole process is "repost_entries" function in repost_item_valuation.py
+- technical detail: entry points are "run_parallel_reposting" (parallel mode,
+  15-minute cron) and "repost_entries" (sequential mode, hourly) in
+  repost_item_valuation.py
 
 
 ## How to identify broken stock data:


### PR DESCRIPTION
## Problem

`erpnext/stock/spec/reposting.md` documents a mechanism that no longer exists:

- "Every hour a scheduled job runs and processes this queue (for up to maximum
  of 25 minutes)" — `repost_time_limit` appears nowhere in the codebase.
- "Entry point for whole process is `repost_entries`" — that is only the
  sequential fallback now.

## Fix

The spec now describes the current mechanism, verified against `hooks.py` and
`repost_item_valuation.py`:

- Two modes gated by **Stock Reposting Settings > Enable Parallel Reposting**.
- Parallel mode: `run_parallel_reposting` runs on a 15-minute cron as a
  recovery net; completing jobs re-trigger the dispatcher so the queue drains
  continuously; up to "No of Parallel Reposting" entries (default 4) run
  concurrently, at most one per item.
- Sequential mode: `repost_entries` runs hourly (hourly_maintenance).
- Both respect the configured reposting timeslot; there is no fixed per-run
  time budget.

## How to test

Documentation only — cross-check the described behavior against
`erpnext/hooks.py` `scheduler_events` and
`repost_item_valuation.py::run_parallel_reposting` / `repost_entries`.
