### PR TITLE
fix: sales invoice qty of 0 after a return is re-delivered 

### DIFF
--- a/erpnext/selling/doctype/sales_order/mapper.py
+++ b/erpnext/selling/doctype/sales_order/mapper.py
@@ -421,6 +421,13 @@ def make_delivery_note(
 	return target_doc
 
 
+def get_qty_net_of_returns(so_item) -> float:
+	"""Ordered qty, less the returns the customer is still holding."""
+	qty = flt(so_item.qty)
+
+	return min(qty, max(qty - flt(so_item.returned_qty), flt(so_item.delivered_qty)))
+
+
 @frappe.whitelist()
 def make_sales_invoice(
 	source_name: str,
@@ -496,7 +503,7 @@ def make_sales_invoice(
 		target.qty = (
 			source.qty - get_billed_qty(source.name)
 			if (source.qty and source.billed_amt)
-			else (source.qty if is_unit_price_row(source) else source.qty - source.returned_qty)
+			else (source.qty if is_unit_price_row(source) else get_qty_net_of_returns(source))
 		)
 
 		if source_parent.project:

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -288,6 +288,37 @@ class TestSalesOrder(ERPNextTestSuite):
 		si1 = make_sales_invoice(so.name)
 		self.assertEqual(len(si1.get("items")), 0)
 
+	def test_make_sales_invoice_after_return_and_redelivery(self):
+		from erpnext.stock.doctype.delivery_note.mapper import make_sales_return
+
+		so = make_sales_order(qty=10, rate=100)
+		dn = create_dn_against_so(so.name, 10)
+
+		# rebuild the return from the dict the way a client save does: Delivery Note only wires
+		# up the `returned_qty` status updater when `is_return` is set as the controller is built
+		dn_return = frappe.get_doc(make_sales_return(dn.name).as_dict())
+		dn_return.insert()
+		dn_return.submit()
+
+		create_dn_against_so(so.name, 10)
+
+		so.load_from_db()
+		item = so.get("items")[0]
+		self.assertEqual(item.delivered_qty, 10)
+		# returned_qty only counts up, the re-delivery never clears it
+		self.assertEqual(item.returned_qty, 10)
+
+		si = make_sales_invoice(so.name)
+		self.assertEqual(si.get("items")[0].qty, 10)
+
+	def test_make_sales_invoice_bills_ordered_qty_for_partial_delivery(self):
+		so = make_sales_order(qty=10, rate=100)
+		create_dn_against_so(so.name, 4)
+
+		# an undelivered qty is still billable, only returns reduce it
+		si = make_sales_invoice(so.name)
+		self.assertEqual(si.get("items")[0].qty, 10)
+
 	def test_so_billed_amount_against_return_entry(self):
 		from erpnext.accounts.doctype.sales_invoice.mapper import make_sales_return
 


### PR DESCRIPTION
**Issue:**

- A Sales Invoice created from a Sales Order shows 0 quantity after the delivered quantity is fully returned and delivered again.

**Description:**

- When all items in a Sales Order are delivered, returned, and then delivered again, creating a Sales Invoice from the Sales Order incorrectly fetches the quantity as 0 instead of the currently delivered quantity. No validation error is shown, allowing an incorrect invoice to be saved.

- The invoice should fetch the correct delivered quantity (10 in this case).


**Fixes** #57848

**Steps to reproduce:**
- Create a Sales Order for 10 qty.
- Deliver all 10.
- Return all 10.
- Deliver the same 10 again.
- From the Sales Order, click Create → Sales Invoice.

**Actual behaviour:**
- The invoice comes up with qty 0.
- No error is shown, so the wrong invoice can be saved unnoticed.

**Expected behaviour:**
- The invoice should come up with qty 10.


**Backport Needed For V15 and V16**