### PR TITLE
refactor: stock write-path cleanups (SLE/Bin chokepoint groundwork)

### DIFF
--- a/erpnext/stock/doctype/bin/bin.py
+++ b/erpnext/stock/doctype/bin/bin.py
@@ -258,7 +258,13 @@ def get_bin_details(bin_name):
 	)
 
 
-def update_qty(bin_name, args):
+def update_qty_from_sle(bin_name, args):
+	"""Refresh the Bin's quantity fields after an SLE has been processed.
+
+	Distinct from ``stock_balance.update_bin_qty``, which writes caller-supplied
+	absolute values; this recomputes every quantity from the ledger and open
+	documents.
+	"""
 	from erpnext.controllers.stock_controller import future_sle_exists
 
 	bin_details = get_bin_details(bin_name)

--- a/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
@@ -1573,6 +1573,32 @@ class TestStockLedgerEntry(ERPNextTestSuite, StockTestMixin):
 			item_code=item_code, source=warehouse, qty=470.84, rate=100, posting_date=add_days(today(), -1)
 		)
 
+	def test_zero_qty_row_is_skipped(self):
+		"""A zero-qty non-reconciliation row must be skipped entirely: no SLE,
+		no crash, no reprocessing of the previous row's entry."""
+		from erpnext.stock.stock_ledger import make_sl_entries
+
+		item = make_item(properties={"is_stock_item": 1})
+		voucher_no = f"zero-qty-{uuid4()}"
+
+		make_sl_entries(
+			[
+				frappe._dict(
+					item_code=item.name,
+					warehouse="_Test Warehouse - _TC",
+					company="_Test Company",
+					posting_date=today(),
+					posting_time="12:00:00",
+					voucher_type="Stock Entry",
+					voucher_no=voucher_no,
+					actual_qty=0,
+					stock_uom=item.stock_uom,
+				)
+			]
+		)
+
+		self.assertFalse(frappe.db.exists("Stock Ledger Entry", {"voucher_no": voucher_no}))
+
 
 def create_repack_entry(**args):
 	args = frappe._dict(args)

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1937,18 +1937,6 @@ class update_entries_after:
 			else:
 				raise NegativeStockError(message)
 
-	def update_bin_data(self, sle):
-		bin_name = get_or_make_bin(sle.item_code, sle.warehouse)
-		values_to_update = {
-			"actual_qty": sle.qty_after_transaction,
-			"stock_value": sle.stock_value,
-		}
-
-		if sle.valuation_rate is not None:
-			values_to_update["valuation_rate"] = sle.valuation_rate
-
-		frappe.db.set_value("Bin", bin_name, values_to_update)
-
 	def update_bin(self):
 		# update bin for each warehouse
 		for (item_code, warehouse), data in self.prev_sle_dict.items():

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -172,9 +172,10 @@ def make_sl_entries(sl_entries, allow_negative_stock=False, via_landed_cost_vouc
 					)
 					sle["outgoing_rate"] = 0.0
 
-			if sle.get("actual_qty") or sle.get("voucher_type") == "Stock Reconciliation":
-				sle_doc = make_entry(sle, allow_negative_stock, via_landed_cost_voucher)
+			if not (sle.get("actual_qty") or sle.get("voucher_type") == "Stock Reconciliation"):
+				continue
 
+			sle_doc = make_entry(sle, allow_negative_stock, via_landed_cost_voucher)
 			args = sle_doc.as_dict()
 			args["posting_datetime"] = get_combine_datetime(args.posting_date, args.posting_time)
 

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -26,7 +26,7 @@ from frappe.utils import (
 )
 
 import erpnext
-from erpnext.stock.doctype.bin.bin import update_qty as update_bin_qty
+from erpnext.stock.doctype.bin.bin import update_qty_from_sle
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
 from erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle import (
 	get_auto_batch_nos,
@@ -190,7 +190,7 @@ def make_sl_entries(sl_entries, allow_negative_stock=False, via_landed_cost_vouc
 				repost_current_voucher(
 					args, allow_negative_stock, via_landed_cost_voucher, cancelled=cancelled
 				)
-				update_bin_qty(bin_name, args)
+				update_qty_from_sle(bin_name, args)
 			else:
 				frappe.msgprint(
 					_("Item {0} ignored since it is not a stock item").format(args.get("item_code"))


### PR DESCRIPTION
First of a series routing all Stock Ledger Entry / Bin writes through single
chokepoints. This one is groundwork: one bug fix and two behavior-neutral
cleanups found while auditing every SLE/Bin write path.

## 1. fix: zero-qty rows in `make_sl_entries` reused the previous entry

`stock_ledger.py`:

```python
if sle.get("actual_qty") or sle.get("voucher_type") == "Stock Reconciliation":
	sle_doc = make_entry(sle, allow_negative_stock, via_landed_cost_voucher)

args = sle_doc.as_dict()   # <- runs unconditionally
```

A zero-qty non-reconciliation row never gets an SLE, but the rest of the loop
body still ran with the **previous iteration's** `sle_doc` — so
`repost_current_voucher()` and the Bin update executed twice for the previous
row. If the zero-qty row came first, the call crashed with
`UnboundLocalError`. Such rows are now skipped entirely.

## 2. refactor: remove dead `update_entries_after.update_bin_data`

Zero callers anywhere in the codebase. It duplicates `update_bin()` with
subtly different semantics (no `update_modified`), so it only invites
accidental resurrection as a second Bin write path.

## 3. refactor: rename `bin.update_qty` → `update_qty_from_sle`

Two unrelated functions circulated under the name `update_bin_qty`:

- `bin.update_qty` — recomputes every quantity from the ledger and open
  documents; imported in `stock_ledger.py` under the alias `update_bin_qty`
- `stock_balance.update_bin_qty` — writes caller-supplied absolute values;
  imported under its real name by six modules

The SLE-driven one now has a name that states its semantics, and the alias is
gone.

## How to test

`bench --site <site> run-tests --module erpnext.stock.doctype.stock_ledger_entry.test_stock_ledger_entry --test test_zero_qty_row_is_skipped`

The new test calls `make_sl_entries` with a single zero-qty row — verified to
fail with `UnboundLocalError` before the fix and pass after. Full
`test_stock_ledger_entry` (28 tests) and `test_bin` modules pass.
