### PR TITLE
refactor: route in-pipeline SLE writes through a single writer module

### DIFF
--- a/erpnext/stock/doctype/bin/bin.py
+++ b/erpnext/stock/doctype/bin/bin.py
@@ -258,7 +258,13 @@ def get_bin_details(bin_name):
 	)
 
 
-def update_qty(bin_name, args):
+def update_qty_from_sle(bin_name, args):
+	"""Refresh the Bin's quantity fields after an SLE has been processed.
+
+	Distinct from ``stock_balance.update_bin_qty``, which writes caller-supplied
+	absolute values; this recomputes every quantity from the ledger and open
+	documents.
+	"""
 	from erpnext.controllers.stock_controller import future_sle_exists
 
 	bin_details = get_bin_details(bin_name)

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -15,6 +15,7 @@ from erpnext.accounts.utils import get_fiscal_year
 from erpnext.controllers.item_variant import ItemTemplateCannotHaveStock
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
 from erpnext.stock.serial_batch_bundle import SerialBatchBundle
+from erpnext.stock.services import stock_ledger_writer
 
 
 class StockFreezeError(frappe.ValidationError):
@@ -219,7 +220,7 @@ class StockLedgerEntry(Document):
 			values_to_be_change["has_serial_no"] = item_detail.has_serial_no
 
 		if values_to_be_change:
-			self.db_set(values_to_be_change)
+			stock_ledger_writer.set_fields(self, values_to_be_change)
 
 		if not item_detail:
 			self.throw_error_message(f"Item {self.item_code} not found")

--- a/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
@@ -1573,6 +1573,32 @@ class TestStockLedgerEntry(ERPNextTestSuite, StockTestMixin):
 			item_code=item_code, source=warehouse, qty=470.84, rate=100, posting_date=add_days(today(), -1)
 		)
 
+	def test_zero_qty_row_is_skipped(self):
+		"""A zero-qty non-reconciliation row must be skipped entirely: no SLE,
+		no crash, no reprocessing of the previous row's entry."""
+		from erpnext.stock.stock_ledger import make_sl_entries
+
+		item = make_item(properties={"is_stock_item": 1})
+		voucher_no = f"zero-qty-{uuid4()}"
+
+		make_sl_entries(
+			[
+				frappe._dict(
+					item_code=item.name,
+					warehouse="_Test Warehouse - _TC",
+					company="_Test Company",
+					posting_date=today(),
+					posting_time="12:00:00",
+					voucher_type="Stock Entry",
+					voucher_no=voucher_no,
+					actual_qty=0,
+					stock_uom=item.stock_uom,
+				)
+			]
+		)
+
+		self.assertFalse(frappe.db.exists("Stock Ledger Entry", {"voucher_no": voucher_no}))
+
 
 def create_repack_entry(**args):
 	args = frappe._dict(args)

--- a/erpnext/stock/services/stock_ledger_writer.py
+++ b/erpnext/stock/services/stock_ledger_writer.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+"""Single write path for `tabStock Ledger Entry`.
+
+Every statement that inserts or mutates Stock Ledger Entry rows belongs here,
+so the table has exactly one write address. Business logic (what to write and
+when) stays with the callers; this module owns the writes. This is also where
+event emission and bypass detection attach in later phases.
+"""
+
+from typing import TYPE_CHECKING
+
+import frappe
+from frappe.utils import now
+
+if TYPE_CHECKING:
+	from frappe.model.document import Document
+
+
+def submit_new(
+	args: dict, allow_negative_stock: bool = False, via_landed_cost_voucher: bool = False
+) -> "Document":
+	"""Insert and submit one Stock Ledger Entry — the only insert path."""
+	args["doctype"] = "Stock Ledger Entry"
+	sle = frappe.get_doc(args)
+	sle.flags.ignore_permissions = 1
+	sle.allow_negative_stock = allow_negative_stock
+	sle.via_landed_cost_voucher = via_landed_cost_voucher
+	if args.get("is_cancelled"):
+		sle.flags.ignore_links = True
+	sle.submit()
+
+	# SLEs recreated while reposting a Stock Reconciliation keep their original creation
+	if args.get("creation_time") and args.get("voucher_type") == "Stock Reconciliation":
+		set_fields(sle, {"creation": args.get("creation_time")})
+
+	return sle
+
+
+def set_fields(sle: "Document | str", values: dict, update_modified: bool = True) -> None:
+	"""Update fields on one SLE row; ``sle`` is a Document or a name."""
+	if isinstance(sle, str):
+		frappe.db.set_value("Stock Ledger Entry", sle, values, update_modified=update_modified)
+	else:
+		sle.db_set(values, update_modified=update_modified)
+
+
+def write_valuation(sle: dict) -> None:
+	"""Write back recomputed valuation fields during a repost.
+
+	Full-row UPDATE via ``db_update`` — deliberately no validation and no hooks,
+	matching how reposting has always written.
+	"""
+	frappe.get_doc(sle).db_update()
+
+
+def flag_voucher_cancelled(voucher_type: str, voucher_no: str) -> None:
+	"""Mark all live SLEs of a voucher cancelled.
+
+	Rows are flagged, never deleted; the caller inserts reversal rows via
+	:func:`submit_new` so the ledger stays append-only.
+	"""
+	sle = frappe.qb.DocType("Stock Ledger Entry")
+	(
+		frappe.qb.update(sle)
+		.set(sle.is_cancelled, 1)
+		.set(sle.modified, now())
+		.set(sle.modified_by, frappe.session.user)
+		.where((sle.voucher_type == voucher_type) & (sle.voucher_no == voucher_no) & (sle.is_cancelled == 0))
+	).run()
+
+
+def shift_future_qty(
+	args: dict, qty_shift: float, next_stock_reco_detail=None, standard_rate: float | None = None
+) -> None:
+	"""Shift ``qty_after_transaction`` on every future row of the (item, warehouse).
+
+	``standard_rate`` is passed only for Standard Cost items, whose
+	``stock_value`` is carried at that rate and can be updated in place.
+	"""
+	from erpnext.stock.stock_ledger import get_datetime_limit_condition
+
+	posting_datetime = args["posting_datetime"]
+	sle = frappe.qb.DocType("Stock Ledger Entry")
+
+	future_condition = sle.posting_datetime > posting_datetime
+	if args.get("creation") and not args.get("is_cancelled"):
+		future_condition = future_condition | (
+			(sle.posting_datetime == posting_datetime) & (sle.creation > args.get("creation"))
+		)
+
+	query = frappe.qb.update(sle).where(
+		(sle.item_code == args.get("item_code"))
+		& (sle.warehouse == args.get("warehouse"))
+		& (sle.is_cancelled == 0)
+		& future_condition
+	)
+
+	if next_stock_reco_detail:
+		query = query.where(get_datetime_limit_condition(sle, next_stock_reco_detail[0]))
+
+	new_qty = sle.qty_after_transaction + qty_shift
+
+	if standard_rate is not None:
+		# Set stock_value before qty_after_transaction: MariaDB evaluates SET left-to-right with the
+		# already-updated values, so stock_value must be computed while qty still holds its pre-shift
+		# value. (Postgres uses pre-update values throughout, so the result is the same either way.)
+		query = query.set(sle.stock_value, new_qty * standard_rate)
+
+	query = query.set(sle.qty_after_transaction, new_qty)
+	query.run()

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1937,18 +1937,6 @@ class update_entries_after:
 			else:
 				raise NegativeStockError(message)
 
-	def update_bin_data(self, sle):
-		bin_name = get_or_make_bin(sle.item_code, sle.warehouse)
-		values_to_update = {
-			"actual_qty": sle.qty_after_transaction,
-			"stock_value": sle.stock_value,
-		}
-
-		if sle.valuation_rate is not None:
-			values_to_update["valuation_rate"] = sle.valuation_rate
-
-		frappe.db.set_value("Bin", bin_name, values_to_update)
-
 	def update_bin(self):
 		# update bin for each warehouse
 		for (item_code, warehouse), data in self.prev_sle_dict.items():

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -172,9 +172,10 @@ def make_sl_entries(sl_entries, allow_negative_stock=False, via_landed_cost_vouc
 					)
 					sle["outgoing_rate"] = 0.0
 
-			if sle.get("actual_qty") or sle.get("voucher_type") == "Stock Reconciliation":
-				sle_doc = make_entry(sle, allow_negative_stock, via_landed_cost_voucher)
+			if not (sle.get("actual_qty") or sle.get("voucher_type") == "Stock Reconciliation"):
+				continue
 
+			sle_doc = make_entry(sle, allow_negative_stock, via_landed_cost_voucher)
 			args = sle_doc.as_dict()
 			args["posting_datetime"] = get_combine_datetime(args.posting_date, args.posting_time)
 

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -26,7 +26,7 @@ from frappe.utils import (
 )
 
 import erpnext
-from erpnext.stock.doctype.bin.bin import update_qty as update_bin_qty
+from erpnext.stock.doctype.bin.bin import update_qty_from_sle
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
 from erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle import (
 	get_auto_batch_nos,
@@ -190,7 +190,7 @@ def make_sl_entries(sl_entries, allow_negative_stock=False, via_landed_cost_vouc
 				repost_current_voucher(
 					args, allow_negative_stock, via_landed_cost_voucher, cancelled=cancelled
 				)
-				update_bin_qty(bin_name, args)
+				update_qty_from_sle(bin_name, args)
 			else:
 				frappe.msgprint(
 					_("Item {0} ignored since it is not a stock item").format(args.get("item_code"))

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -35,6 +35,7 @@ from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry impor
 	get_sre_reserved_batch_nos_details,
 	get_sre_reserved_serial_nos_details,
 )
+from erpnext.stock.services import stock_ledger_writer
 from erpnext.stock.utils import (
 	get_combine_datetime,
 	get_incoming_outgoing_rate_for_cancel,
@@ -269,31 +270,11 @@ def validate_cancellation(kargs):
 
 
 def set_as_cancel(voucher_type, voucher_no):
-	sle = frappe.qb.DocType("Stock Ledger Entry")
-	(
-		frappe.qb.update(sle)
-		.set(sle.is_cancelled, 1)
-		.set(sle.modified, now())
-		.set(sle.modified_by, frappe.session.user)
-		.where((sle.voucher_type == voucher_type) & (sle.voucher_no == voucher_no) & (sle.is_cancelled == 0))
-	).run()
+	stock_ledger_writer.flag_voucher_cancelled(voucher_type, voucher_no)
 
 
 def make_entry(args, allow_negative_stock=False, via_landed_cost_voucher=False):
-	args["doctype"] = "Stock Ledger Entry"
-	sle = frappe.get_doc(args)
-	sle.flags.ignore_permissions = 1
-	sle.allow_negative_stock = allow_negative_stock
-	sle.via_landed_cost_voucher = via_landed_cost_voucher
-	if args.get("is_cancelled"):
-		sle.flags.ignore_links = True
-	sle.submit()
-
-	# Added to handle the case when the stock ledger entry is created from the repostig
-	if args.get("creation_time") and args.get("voucher_type") == "Stock Reconciliation":
-		sle.db_set("creation", args.get("creation_time"))
-
-	return sle
+	return stock_ledger_writer.submit_new(args, allow_negative_stock, via_landed_cost_voucher)
 
 
 # A repost waits this long for another repost's per-(item, warehouse) gate before giving up. Kept
@@ -1204,7 +1185,7 @@ class update_entries_after:
 
 		sle.doctype = "Stock Ledger Entry"
 		sle.modified = now()
-		frappe.get_doc(sle).db_update()
+		stock_ledger_writer.write_valuation(sle)
 
 		self.prev_sle_dict[key] = sle
 
@@ -2269,28 +2250,7 @@ def update_qty_in_future_sle(args, allow_negative_stock=False):
 	if args.voucher_type == "Stock Reconciliation":
 		qty_shift = get_stock_reco_qty_shift(args)
 
-	sle = frappe.qb.DocType("Stock Ledger Entry")
-
-	future_condition = sle.posting_datetime > posting_datetime
-	if args.get("creation") and not args.get("is_cancelled"):
-		future_condition = future_condition | (
-			(sle.posting_datetime == posting_datetime) & (sle.creation > args.get("creation"))
-		)
-
-	query = frappe.qb.update(sle).where(
-		(sle.item_code == args.get("item_code"))
-		& (sle.warehouse == args.get("warehouse"))
-		& (sle.is_cancelled == 0)
-		& future_condition
-	)
-
-	# find the next nearest stock reco so that we only recalculate SLEs till that point
-	next_stock_reco_detail = get_next_stock_reco(args)
-	if next_stock_reco_detail:
-		query = query.where(get_datetime_limit_condition(sle, next_stock_reco_detail[0]))
-
-	new_qty = sle.qty_after_transaction + qty_shift
-
+	standard_rate = None
 	if get_valuation_method(args.get("item_code"), args.get("company")) == "Standard Cost":
 		# Standard Cost inventory is always carried at the standard rate, so a backdated entry only
 		# shifts future balances — no full repost is needed. Update qty and value in place:
@@ -2303,13 +2263,10 @@ def update_qty_in_future_sle(args, allow_negative_stock=False):
 			get_item_standard_rate(args.get("item_code"), args.get("company"), args.get("posting_date"))
 		)
 
-		# Set stock_value before qty_after_transaction: MariaDB evaluates SET left-to-right with the
-		# already-updated values, so stock_value must be computed while qty still holds its pre-shift
-		# value. (Postgres uses pre-update values throughout, so the result is the same either way.)
-		query = query.set(sle.stock_value, new_qty * standard_rate)
-
-	query = query.set(sle.qty_after_transaction, new_qty)
-	query.run()
+	# limit the recalculation to the next nearest stock reco
+	stock_ledger_writer.shift_future_qty(
+		args, qty_shift, next_stock_reco_detail=get_next_stock_reco(args), standard_rate=standard_rate
+	)
 
 	validate_negative_qty_in_future_sle(args, allow_negative_stock)
 


### PR DESCRIPTION
Second PR in the stock write-path consolidation series. Builds on #57980
(its three commits are included here until it merges; the new work is the
last commit).

## What

Introduces `erpnext/stock/services/stock_ledger_writer.py` as the single
write address for `tabStock Ledger Entry`, and routes the six in-pipeline
write sites through it:

| primitive | absorbs |
|---|---|
| `submit_new` | `make_entry`'s doc insert+submit — the only insert path |
| `set_fields` | the reposted-reconciliation `creation` fix-up; the `has_serial_no`/`has_batch_no` `db_set` in `validate_serial_batch_no_bundle` |
| `write_valuation` | `process_sle`'s full-row `db_update()` repost writeback |
| `shift_future_qty` | `update_qty_in_future_sle`'s bulk qty shift (incl. the Standard Cost in-place `stock_value` update) |
| `flag_voucher_cancelled` | `set_as_cancel`'s bulk `is_cancelled=1` flagging |

## Why

An audit of every SLE write in the codebase found 17 distinct write sites,
of which these six form the official pipeline (the rest are side channels —
next PR). Giving the table one write address is groundwork for instrumenting
external/bypass writes and, later, for emitting stock events at the write
boundary.

## Non-goals / notes

- **No behavior change.** Business logic (what to write, when) stays with the
  callers; the writer owns the DB statements. `make_entry` and
  `set_as_cancel` remain as public delegators so existing imports keep
  working.
- Side-channel writers (serial/batch bundle links, the PR `recalculate_rate`
  flag, POS delink, the hourly rename job, deletes, the console repair
  insert) are routed in the follow-up PR.

## How to test

Pure refactor — covered by the existing suites:

- `erpnext.stock.doctype.stock_ledger_entry.test_stock_ledger_entry` (28 tests) — pass
- `erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation` (40 tests) — pass
- `erpnext.stock.doctype.repost_item_valuation.test_repost_item_valuation` — 23/24 pass; `test_account_freeze_validation` fails identically on current develop without this change (`Company` has no attribute `exchange_gain_account` — unrelated, pre-existing).
