### PR TITLE
refactor: route side-channel SLE writes through the writer module

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -506,14 +506,20 @@ def rename_temporarily_named_docs(doctype):
 			oldname = doc.name
 			set_name_from_naming_options(autoname, doc)
 			newname = doc.name
-			dt = frappe.qb.DocType(doctype)
-			(
-				frappe.qb.update(dt)
-				.set(dt.name, newname)
-				.set(dt.to_rename, 0)
-				.set(dt.modified, now())
-				.where(dt.name == oldname)
-			).run()
+
+			if doctype == "Stock Ledger Entry":
+				from erpnext.stock.services import stock_ledger_writer
+
+				stock_ledger_writer.rename_row(oldname, newname)
+			else:
+				dt = frappe.qb.DocType(doctype)
+				(
+					frappe.qb.update(dt)
+					.set(dt.name, newname)
+					.set(dt.to_rename, 0)
+					.set(dt.modified, now())
+					.where(dt.name == oldname)
+				).run()
 
 			for hook_type in ("on_gle_rename", "on_sle_rename"):
 				for hook in frappe.get_hooks(hook_type):

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -387,18 +387,13 @@ class POSInvoiceMergeLog(Document):
 				pos_invoice.set_serial_and_batch_bundle(table_name)
 
 	def delink_serial_and_batch_bundle(self):
+		from erpnext.stock.services import stock_ledger_writer
+
 		bundles = self.get_serial_and_batch_bundles()
 		if not bundles:
 			return
 
-		sle_table = frappe.qb.DocType("Stock Ledger Entry")
-		query = (
-			frappe.qb.update(sle_table)
-			.set(sle_table.serial_and_batch_bundle, None)
-			.where(sle_table.serial_and_batch_bundle.isin(bundles) & sle_table.is_cancelled == 1)
-		)
-
-		query.run()
+		stock_ledger_writer.clear_bundle_links(bundles)
 
 	def get_serial_and_batch_bundles(self):
 		pos_invoices = []

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -460,10 +460,9 @@ class AccountsController(TransactionBase):
 			frappe.qb.from_(gle).delete().where(
 				(gle.voucher_type == self.doctype) & (gle.voucher_no == self.name)
 			).run()
-			sle = frappe.qb.DocType("Stock Ledger Entry")
-			frappe.qb.from_(sle).delete().where(
-				(sle.voucher_type == self.doctype) & (sle.voucher_no == self.name)
-			).run()
+			from erpnext.stock.services import stock_ledger_writer
+
+			stock_ledger_writer.delete_for_voucher(self.doctype, self.name)
 
 			self._remove_advance_payment_ledger_entries()
 

--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
@@ -924,7 +924,12 @@ class TransactionDeletionRecord(Document):
 			frappe.db.delete(table, {"parent": ["in", reference_doc_names]})
 
 	def delete_docs_linked_with_specified_company(self, doctype, reference_doc_names):
-		frappe.db.delete(doctype, {"name": ("in", reference_doc_names)})
+		if doctype == "Stock Ledger Entry":
+			from erpnext.stock.services import stock_ledger_writer
+
+			stock_ledger_writer.delete_rows(reference_doc_names)
+		else:
+			frappe.db.delete(doctype, {"name": ("in", reference_doc_names)})
 
 	@staticmethod
 	def get_naming_series_prefix(naming_series: str, doctype_name: str) -> str:

--- a/erpnext/stock/doctype/bin/bin.py
+++ b/erpnext/stock/doctype/bin/bin.py
@@ -258,7 +258,13 @@ def get_bin_details(bin_name):
 	)
 
 
-def update_qty(bin_name, args):
+def update_qty_from_sle(bin_name, args):
+	"""Refresh the Bin's quantity fields after an SLE has been processed.
+
+	Distinct from ``stock_balance.update_bin_qty``, which writes caller-supplied
+	absolute values; this recomputes every quantity from the ledger and open
+	documents.
+	"""
 	from erpnext.controllers.stock_controller import future_sle_exists
 
 	bin_details = get_bin_details(bin_name)

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -506,18 +506,15 @@ class PurchaseReceipt(BuyingController):
 		BillingStatusService(self).update_billing_status(update_modified)
 
 	def enable_recalculate_rate_in_sles(self):
+		from erpnext.stock.services import stock_ledger_writer
+
 		rejected_warehouses = frappe.get_all(
 			"Purchase Receipt Item", filters={"parent": self.name}, pluck="rejected_warehouse"
 		)
 
-		sle_table = frappe.qb.DocType("Stock Ledger Entry")
-		(
-			frappe.qb.update(sle_table)
-			.set(sle_table.recalculate_rate, 1)
-			.where(sle_table.voucher_no == self.name)
-			.where(sle_table.voucher_type == "Purchase Receipt")
-			.where(sle_table.warehouse.notin(rejected_warehouses))
-		).run()
+		stock_ledger_writer.set_fields_for_voucher(
+			"Purchase Receipt", self.name, {"recalculate_rate": 1}, except_warehouses=rejected_warehouses
+		)
 
 
 def get_stock_value_difference(voucher_no, voucher_detail_no, warehouse):

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -1444,10 +1444,12 @@ class SerialandBatchBundle(Document):
 		self.delink_serial_and_batch_bundle()
 
 	def delink_serial_and_batch_bundle(self):
+		from erpnext.stock.services import stock_ledger_writer
+
 		sles = frappe.get_all("Stock Ledger Entry", filters={"serial_and_batch_bundle": self.name})
 
 		for sle in sles:
-			frappe.db.set_value("Stock Ledger Entry", sle.name, "serial_and_batch_bundle", None)
+			stock_ledger_writer.set_fields(sle.name, {"serial_and_batch_bundle": None})
 
 	@property
 	def child_table(self):

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -15,6 +15,7 @@ from erpnext.accounts.utils import get_fiscal_year
 from erpnext.controllers.item_variant import ItemTemplateCannotHaveStock
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
 from erpnext.stock.serial_batch_bundle import SerialBatchBundle
+from erpnext.stock.services import stock_ledger_writer
 
 
 class StockFreezeError(frappe.ValidationError):
@@ -219,7 +220,7 @@ class StockLedgerEntry(Document):
 			values_to_be_change["has_serial_no"] = item_detail.has_serial_no
 
 		if values_to_be_change:
-			self.db_set(values_to_be_change)
+			stock_ledger_writer.set_fields(self, values_to_be_change)
 
 		if not item_detail:
 			self.throw_error_message(f"Item {self.item_code} not found")

--- a/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
@@ -1573,6 +1573,32 @@ class TestStockLedgerEntry(ERPNextTestSuite, StockTestMixin):
 			item_code=item_code, source=warehouse, qty=470.84, rate=100, posting_date=add_days(today(), -1)
 		)
 
+	def test_zero_qty_row_is_skipped(self):
+		"""A zero-qty non-reconciliation row must be skipped entirely: no SLE,
+		no crash, no reprocessing of the previous row's entry."""
+		from erpnext.stock.stock_ledger import make_sl_entries
+
+		item = make_item(properties={"is_stock_item": 1})
+		voucher_no = f"zero-qty-{uuid4()}"
+
+		make_sl_entries(
+			[
+				frappe._dict(
+					item_code=item.name,
+					warehouse="_Test Warehouse - _TC",
+					company="_Test Company",
+					posting_date=today(),
+					posting_time="12:00:00",
+					voucher_type="Stock Entry",
+					voucher_no=voucher_no,
+					actual_qty=0,
+					stock_uom=item.stock_uom,
+				)
+			]
+		)
+
+		self.assertFalse(frappe.db.exists("Stock Ledger Entry", {"voucher_no": voucher_no}))
+
 
 def create_repack_entry(**args):
 	args = frappe._dict(args)

--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -12,6 +12,7 @@ from erpnext.stock.deprecated_serial_batch import (
 	DeprecatedBatchNoValuation,
 	DeprecatedSerialNoValuation,
 )
+from erpnext.stock.services import stock_ledger_writer
 from erpnext.stock.valuation import round_off_if_near_zero
 
 CONSUMED_SERIAL_NO_STOCK_ENTRY_PURPOSES = (
@@ -127,7 +128,7 @@ class SerialBatchBundle:
 				type_of_transaction="Inward" if self.sle.actual_qty > 0 else "Outward",
 				do_not_submit=0,
 			)
-			self.sle.db_set({"serial_and_batch_bundle": new_bundle_id})
+			stock_ledger_writer.set_fields(self.sle, {"serial_and_batch_bundle": new_bundle_id})
 
 	def make_serial_batch_no_bundle(self):
 		self.validate_item()
@@ -209,7 +210,9 @@ class SerialBatchBundle:
 
 	def set_serial_and_batch_bundle(self, sn_doc):
 		self.sle.auto_created_serial_and_batch_bundle = 1
-		self.sle.db_set({"serial_and_batch_bundle": sn_doc.name, "auto_created_serial_and_batch_bundle": 1})
+		stock_ledger_writer.set_fields(
+			self.sle, {"serial_and_batch_bundle": sn_doc.name, "auto_created_serial_and_batch_bundle": 1}
+		)
 
 		if sn_doc.is_rejected:
 			frappe.db.set_value(
@@ -1270,7 +1273,9 @@ class SerialBatchCreation:
 			if self.get("sle"):
 				doc.flags.ignore_validate = True
 				doc.save()
-				self.sle.db_set("serial_and_batch_bundle", doc.name, update_modified=False)
+				stock_ledger_writer.set_fields(
+					self.sle, {"serial_and_batch_bundle": doc.name}, update_modified=False
+				)
 
 			if doc.flags.ignore_validate:
 				doc.flags.ignore_validate = False

--- a/erpnext/stock/services/stock_ledger_writer.py
+++ b/erpnext/stock/services/stock_ledger_writer.py
@@ -38,6 +38,20 @@ def submit_new(
 	return sle
 
 
+def insert_raw(args: dict) -> "Document":
+	"""Insert a draft SLE skipping validations and link checks.
+
+	Exists only for console repair tooling
+	(``stock_balance.set_stock_balance_as_per_serial_no``); everything else
+	must go through :func:`submit_new`.
+	"""
+	sle = frappe.get_doc(args)
+	sle.flags.ignore_validate = True
+	sle.flags.ignore_links = True
+	sle.insert()
+	return sle
+
+
 def set_fields(sle: "Document | str", values: dict, update_modified: bool = True) -> None:
 	"""Update fields on one SLE row; ``sle`` is a Document or a name."""
 	if isinstance(sle, str):
@@ -69,6 +83,58 @@ def flag_voucher_cancelled(voucher_type: str, voucher_no: str) -> None:
 		.set(sle.modified_by, frappe.session.user)
 		.where((sle.voucher_type == voucher_type) & (sle.voucher_no == voucher_no) & (sle.is_cancelled == 0))
 	).run()
+
+
+def set_fields_for_voucher(
+	voucher_type: str, voucher_no: str, values: dict, except_warehouses: list[str] | None = None
+) -> None:
+	"""Bulk-update fields on all of a voucher's SLE rows."""
+	sle = frappe.qb.DocType("Stock Ledger Entry")
+	query = frappe.qb.update(sle).where((sle.voucher_type == voucher_type) & (sle.voucher_no == voucher_no))
+	if except_warehouses:
+		query = query.where(sle.warehouse.notin(except_warehouses))
+	for field, value in values.items():
+		query = query.set(sle[field], value)
+	query.run()
+
+
+def clear_bundle_links(bundle_names: list[str]) -> None:
+	"""Null the bundle link on cancelled SLEs referencing these bundles (POS merge delink)."""
+	sle = frappe.qb.DocType("Stock Ledger Entry")
+	(
+		frappe.qb.update(sle)
+		.set(sle.serial_and_batch_bundle, None)
+		.where(sle.serial_and_batch_bundle.isin(bundle_names) & (sle.is_cancelled == 1))
+	).run()
+
+
+def rename_row(oldname: str, newname: str) -> None:
+	"""Rename a temporarily named SLE row to its final series name (hourly rename job)."""
+	sle = frappe.qb.DocType("Stock Ledger Entry")
+	(
+		frappe.qb.update(sle)
+		.set(sle.name, newname)
+		.set(sle.to_rename, 0)
+		.set(sle.modified, now())
+		.where(sle.name == oldname)
+	).run()
+
+
+def delete_for_voucher(voucher_type: str, voucher_no: str) -> None:
+	"""Hard-delete a voucher's SLE rows.
+
+	Only reached from document deletion with Accounts Settings
+	``delete_linked_ledger_entries`` enabled; cancellation never deletes.
+	"""
+	sle = frappe.qb.DocType("Stock Ledger Entry")
+	frappe.qb.from_(sle).delete().where(
+		(sle.voucher_type == voucher_type) & (sle.voucher_no == voucher_no)
+	).run()
+
+
+def delete_rows(names: list[str]) -> None:
+	"""Hard-delete SLE rows by name (per-company transaction deletion job)."""
+	frappe.db.delete("Stock Ledger Entry", {"name": ("in", names)})
 
 
 def shift_future_qty(

--- a/erpnext/stock/services/stock_ledger_writer.py
+++ b/erpnext/stock/services/stock_ledger_writer.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+"""Single write path for `tabStock Ledger Entry`.
+
+Every statement that inserts or mutates Stock Ledger Entry rows belongs here,
+so the table has exactly one write address. Business logic (what to write and
+when) stays with the callers; this module owns the writes. This is also where
+event emission and bypass detection attach in later phases.
+"""
+
+from typing import TYPE_CHECKING
+
+import frappe
+from frappe.utils import now
+
+if TYPE_CHECKING:
+	from frappe.model.document import Document
+
+
+def submit_new(
+	args: dict, allow_negative_stock: bool = False, via_landed_cost_voucher: bool = False
+) -> "Document":
+	"""Insert and submit one Stock Ledger Entry — the only insert path."""
+	args["doctype"] = "Stock Ledger Entry"
+	sle = frappe.get_doc(args)
+	sle.flags.ignore_permissions = 1
+	sle.allow_negative_stock = allow_negative_stock
+	sle.via_landed_cost_voucher = via_landed_cost_voucher
+	if args.get("is_cancelled"):
+		sle.flags.ignore_links = True
+	sle.submit()
+
+	# SLEs recreated while reposting a Stock Reconciliation keep their original creation
+	if args.get("creation_time") and args.get("voucher_type") == "Stock Reconciliation":
+		set_fields(sle, {"creation": args.get("creation_time")})
+
+	return sle
+
+
+def set_fields(sle: "Document | str", values: dict, update_modified: bool = True) -> None:
+	"""Update fields on one SLE row; ``sle`` is a Document or a name."""
+	if isinstance(sle, str):
+		frappe.db.set_value("Stock Ledger Entry", sle, values, update_modified=update_modified)
+	else:
+		sle.db_set(values, update_modified=update_modified)
+
+
+def write_valuation(sle: dict) -> None:
+	"""Write back recomputed valuation fields during a repost.
+
+	Full-row UPDATE via ``db_update`` — deliberately no validation and no hooks,
+	matching how reposting has always written.
+	"""
+	frappe.get_doc(sle).db_update()
+
+
+def flag_voucher_cancelled(voucher_type: str, voucher_no: str) -> None:
+	"""Mark all live SLEs of a voucher cancelled.
+
+	Rows are flagged, never deleted; the caller inserts reversal rows via
+	:func:`submit_new` so the ledger stays append-only.
+	"""
+	sle = frappe.qb.DocType("Stock Ledger Entry")
+	(
+		frappe.qb.update(sle)
+		.set(sle.is_cancelled, 1)
+		.set(sle.modified, now())
+		.set(sle.modified_by, frappe.session.user)
+		.where((sle.voucher_type == voucher_type) & (sle.voucher_no == voucher_no) & (sle.is_cancelled == 0))
+	).run()
+
+
+def shift_future_qty(
+	args: dict, qty_shift: float, next_stock_reco_detail=None, standard_rate: float | None = None
+) -> None:
+	"""Shift ``qty_after_transaction`` on every future row of the (item, warehouse).
+
+	``standard_rate`` is passed only for Standard Cost items, whose
+	``stock_value`` is carried at that rate and can be updated in place.
+	"""
+	from erpnext.stock.stock_ledger import get_datetime_limit_condition
+
+	posting_datetime = args["posting_datetime"]
+	sle = frappe.qb.DocType("Stock Ledger Entry")
+
+	future_condition = sle.posting_datetime > posting_datetime
+	if args.get("creation") and not args.get("is_cancelled"):
+		future_condition = future_condition | (
+			(sle.posting_datetime == posting_datetime) & (sle.creation > args.get("creation"))
+		)
+
+	query = frappe.qb.update(sle).where(
+		(sle.item_code == args.get("item_code"))
+		& (sle.warehouse == args.get("warehouse"))
+		& (sle.is_cancelled == 0)
+		& future_condition
+	)
+
+	if next_stock_reco_detail:
+		query = query.where(get_datetime_limit_condition(sle, next_stock_reco_detail[0]))
+
+	new_qty = sle.qty_after_transaction + qty_shift
+
+	if standard_rate is not None:
+		# Set stock_value before qty_after_transaction: MariaDB evaluates SET left-to-right with the
+		# already-updated values, so stock_value must be computed while qty still holds its pre-shift
+		# value. (Postgres uses pre-update values throughout, so the result is the same either way.)
+		query = query.set(sle.stock_value, new_qty * standard_rate)
+
+	query = query.set(sle.qty_after_transaction, new_qty)
+	query.run()

--- a/erpnext/stock/stock_balance.py
+++ b/erpnext/stock/stock_balance.py
@@ -342,10 +342,9 @@ def set_stock_balance_as_per_serial_no(
 			"serial_no": "",
 		}
 
-		sle_doc = frappe.get_doc(sle_dict)
-		sle_doc.flags.ignore_validate = True
-		sle_doc.flags.ignore_links = True
-		sle_doc.insert()
+		from erpnext.stock.services import stock_ledger_writer
+
+		sle_doc = stock_ledger_writer.insert_raw(sle_dict)
 
 		args = sle_dict.copy()
 		args.update({"sle_id": sle_doc.name})

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1937,18 +1937,6 @@ class update_entries_after:
 			else:
 				raise NegativeStockError(message)
 
-	def update_bin_data(self, sle):
-		bin_name = get_or_make_bin(sle.item_code, sle.warehouse)
-		values_to_update = {
-			"actual_qty": sle.qty_after_transaction,
-			"stock_value": sle.stock_value,
-		}
-
-		if sle.valuation_rate is not None:
-			values_to_update["valuation_rate"] = sle.valuation_rate
-
-		frappe.db.set_value("Bin", bin_name, values_to_update)
-
 	def update_bin(self):
 		# update bin for each warehouse
 		for (item_code, warehouse), data in self.prev_sle_dict.items():

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -172,9 +172,10 @@ def make_sl_entries(sl_entries, allow_negative_stock=False, via_landed_cost_vouc
 					)
 					sle["outgoing_rate"] = 0.0
 
-			if sle.get("actual_qty") or sle.get("voucher_type") == "Stock Reconciliation":
-				sle_doc = make_entry(sle, allow_negative_stock, via_landed_cost_voucher)
+			if not (sle.get("actual_qty") or sle.get("voucher_type") == "Stock Reconciliation"):
+				continue
 
+			sle_doc = make_entry(sle, allow_negative_stock, via_landed_cost_voucher)
 			args = sle_doc.as_dict()
 			args["posting_datetime"] = get_combine_datetime(args.posting_date, args.posting_time)
 

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -26,7 +26,7 @@ from frappe.utils import (
 )
 
 import erpnext
-from erpnext.stock.doctype.bin.bin import update_qty as update_bin_qty
+from erpnext.stock.doctype.bin.bin import update_qty_from_sle
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
 from erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle import (
 	get_auto_batch_nos,
@@ -190,7 +190,7 @@ def make_sl_entries(sl_entries, allow_negative_stock=False, via_landed_cost_vouc
 				repost_current_voucher(
 					args, allow_negative_stock, via_landed_cost_voucher, cancelled=cancelled
 				)
-				update_bin_qty(bin_name, args)
+				update_qty_from_sle(bin_name, args)
 			else:
 				frappe.msgprint(
 					_("Item {0} ignored since it is not a stock item").format(args.get("item_code"))

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -35,6 +35,7 @@ from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry impor
 	get_sre_reserved_batch_nos_details,
 	get_sre_reserved_serial_nos_details,
 )
+from erpnext.stock.services import stock_ledger_writer
 from erpnext.stock.utils import (
 	get_combine_datetime,
 	get_incoming_outgoing_rate_for_cancel,
@@ -269,31 +270,11 @@ def validate_cancellation(kargs):
 
 
 def set_as_cancel(voucher_type, voucher_no):
-	sle = frappe.qb.DocType("Stock Ledger Entry")
-	(
-		frappe.qb.update(sle)
-		.set(sle.is_cancelled, 1)
-		.set(sle.modified, now())
-		.set(sle.modified_by, frappe.session.user)
-		.where((sle.voucher_type == voucher_type) & (sle.voucher_no == voucher_no) & (sle.is_cancelled == 0))
-	).run()
+	stock_ledger_writer.flag_voucher_cancelled(voucher_type, voucher_no)
 
 
 def make_entry(args, allow_negative_stock=False, via_landed_cost_voucher=False):
-	args["doctype"] = "Stock Ledger Entry"
-	sle = frappe.get_doc(args)
-	sle.flags.ignore_permissions = 1
-	sle.allow_negative_stock = allow_negative_stock
-	sle.via_landed_cost_voucher = via_landed_cost_voucher
-	if args.get("is_cancelled"):
-		sle.flags.ignore_links = True
-	sle.submit()
-
-	# Added to handle the case when the stock ledger entry is created from the repostig
-	if args.get("creation_time") and args.get("voucher_type") == "Stock Reconciliation":
-		sle.db_set("creation", args.get("creation_time"))
-
-	return sle
+	return stock_ledger_writer.submit_new(args, allow_negative_stock, via_landed_cost_voucher)
 
 
 # A repost waits this long for another repost's per-(item, warehouse) gate before giving up. Kept
@@ -1204,7 +1185,7 @@ class update_entries_after:
 
 		sle.doctype = "Stock Ledger Entry"
 		sle.modified = now()
-		frappe.get_doc(sle).db_update()
+		stock_ledger_writer.write_valuation(sle)
 
 		self.prev_sle_dict[key] = sle
 
@@ -2269,28 +2250,7 @@ def update_qty_in_future_sle(args, allow_negative_stock=False):
 	if args.voucher_type == "Stock Reconciliation":
 		qty_shift = get_stock_reco_qty_shift(args)
 
-	sle = frappe.qb.DocType("Stock Ledger Entry")
-
-	future_condition = sle.posting_datetime > posting_datetime
-	if args.get("creation") and not args.get("is_cancelled"):
-		future_condition = future_condition | (
-			(sle.posting_datetime == posting_datetime) & (sle.creation > args.get("creation"))
-		)
-
-	query = frappe.qb.update(sle).where(
-		(sle.item_code == args.get("item_code"))
-		& (sle.warehouse == args.get("warehouse"))
-		& (sle.is_cancelled == 0)
-		& future_condition
-	)
-
-	# find the next nearest stock reco so that we only recalculate SLEs till that point
-	next_stock_reco_detail = get_next_stock_reco(args)
-	if next_stock_reco_detail:
-		query = query.where(get_datetime_limit_condition(sle, next_stock_reco_detail[0]))
-
-	new_qty = sle.qty_after_transaction + qty_shift
-
+	standard_rate = None
 	if get_valuation_method(args.get("item_code"), args.get("company")) == "Standard Cost":
 		# Standard Cost inventory is always carried at the standard rate, so a backdated entry only
 		# shifts future balances — no full repost is needed. Update qty and value in place:
@@ -2303,13 +2263,10 @@ def update_qty_in_future_sle(args, allow_negative_stock=False):
 			get_item_standard_rate(args.get("item_code"), args.get("company"), args.get("posting_date"))
 		)
 
-		# Set stock_value before qty_after_transaction: MariaDB evaluates SET left-to-right with the
-		# already-updated values, so stock_value must be computed while qty still holds its pre-shift
-		# value. (Postgres uses pre-update values throughout, so the result is the same either way.)
-		query = query.set(sle.stock_value, new_qty * standard_rate)
-
-	query = query.set(sle.qty_after_transaction, new_qty)
-	query.run()
+	# limit the recalculation to the next nearest stock reco
+	stock_ledger_writer.shift_future_qty(
+		args, qty_shift, next_stock_reco_detail=get_next_stock_reco(args), standard_rate=standard_rate
+	)
 
 	validate_negative_qty_in_future_sle(args, allow_negative_stock)
 


### PR DESCRIPTION
Third PR in the stock write-path consolidation series. Builds on #57981
(which builds on #57980); the new work is the last commit.

## What

Routes every remaining direct writer of `tabStock Ledger Entry` through
`stock_ledger_writer` — the side channels living outside the main pipeline:

| primitive | absorbs |
|---|---|
| `set_fields` (existing) | 3 serial/batch bundle-link `db_set` sites in `serial_batch_bundle.py`; the per-row delink in `SerialAndBatchBundle.before_cancel` |
| `set_fields_for_voucher` | Purchase Receipt's `recalculate_rate=1` bulk flag (PI billing adjustment) |
| `clear_bundle_links` | POS Invoice Merge Log's bulk bundle delink |
| `rename_row` | the hourly `rename_gle_sle_docs` job's SLE branch (primary-key rename) |
| `delete_for_voucher` | `AccountsController.on_trash` SLE delete (`delete_linked_ledger_entries`) |
| `delete_rows` | Transaction Deletion Record's per-company SLE wipe |
| `insert_raw` | `set_stock_balance_as_per_serial_no`'s validation-skipping insert (console repair tool) — named for what it is |

With this, outside one-time patches and tests, **no statement in the
codebase writes the table from outside the writer module** (verified by
sweep over `db_set`/`set_value`/`qb.update`/`qb...delete`/`db.delete`/insert
mechanisms).

## Notes

- **No behavior change.** One incidental normalization: the POS delink's
  where-clause `a.isin(...) & b == 1` relied on Python operator precedence
  grouping as `(a.isin(...) & b) == 1`; the writer states the intended
  `isin(...) & (is_cancelled == 1)` explicitly — same result on MariaDB
  booleans, now also unambiguous.
- `recreate_stock_ledger_entries` (Repost Item Valuation) is not touched: it
  composes cancel + resubmit, both already routed.

## How to test

Pure refactor — existing suites:

- `test_gl_entry` (rename job incl. SLE branch) — pass
- `test_serial_and_batch_bundle` (38) — pass
- `test_stock_ledger_entry` (28) — pass
- `test_pos_invoice_merge_log` (10) — pass
- `test_purchase_receipt` — 105/110; the 5 errors (`Company` has no attribute
  `exchange_gain_account`) reproduce identically on current develop without
  this change — pre-existing, unrelated.
