### PR TITLE
fix: block disabled/frozen party on Opportunity and Request for Quotation

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
@@ -22,6 +22,10 @@ frappe.ui.form.on("Request for Quotation", {
 			};
 		};
 
+		frm.set_query("supplier", "suppliers", function () {
+			return { filters: { disabled: 0 } };
+		});
+
 		frm.set_query("warehouse", "items", () => ({
 			filters: {
 				company: frm.doc.company,

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
@@ -22,10 +22,6 @@ frappe.ui.form.on("Request for Quotation", {
 			};
 		};
 
-		frm.set_query("supplier", "suppliers", function () {
-			return { filters: { disabled: 0 } };
-		});
-
 		frm.set_query("warehouse", "items", () => ({
 			filters: {
 				company: frm.doc.company,

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -13,6 +13,7 @@ from frappe.utils import get_url
 from frappe.utils.print_format import download_pdf
 from frappe.utils.user import get_user_fullname
 
+from erpnext.accounts.party import validate_party_frozen_disabled
 from erpnext.buying.utils import validate_for_items
 from erpnext.controllers.buying_controller import BuyingController
 
@@ -122,6 +123,8 @@ class RequestforQuotation(BuyingController):
 
 	def validate_supplier_list(self):
 		for d in self.suppliers:
+			validate_party_frozen_disabled(self.company, "Supplier", d.supplier)
+
 			prevent_rfqs = frappe.db.get_value("Supplier", d.supplier, "prevent_rfqs")
 			if prevent_rfqs:
 				standing = frappe.db.get_value("Supplier Scorecard", d.supplier, "status")

--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -18,6 +18,7 @@ from erpnext.buying.doctype.request_for_quotation.request_for_quotation import (
 from erpnext.controllers.accounts_controller import InvalidQtyError
 from erpnext.crm.doctype.opportunity.mapper import make_request_for_quotation as make_rfq
 from erpnext.crm.doctype.opportunity.test_opportunity import make_opportunity
+from erpnext.exceptions import PartyDisabled
 from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.material_request.test_material_request import make_material_request
 from erpnext.templates.pages.rfq import check_supplier_has_docname_access
@@ -88,6 +89,17 @@ class TestRequestforQuotation(ERPNextTestSuite):
 			do_not_save=True,
 		)
 		self.assertRaises(frappe.ValidationError, rfq.save)
+
+	def test_rfq_blocked_for_disabled_supplier(self):
+		frappe.db.set_value("Supplier", "_Test Supplier", "disabled", 1)
+		rfq = make_request_for_quotation(
+			supplier_data=[{"supplier": "_Test Supplier", "supplier_name": "_Test Supplier"}],
+			do_not_save=True,
+		)
+		self.assertRaises(PartyDisabled, rfq.save)
+
+		frappe.db.set_value("Supplier", "_Test Supplier", "disabled", 0)
+		rfq.save()
 
 	def test_rfq_status_lifecycle(self):
 		rfq = make_request_for_quotation()

--- a/erpnext/buying/doctype/request_for_quotation_supplier/request_for_quotation_supplier.json
+++ b/erpnext/buying/doctype/request_for_quotation_supplier/request_for_quotation_supplier.json
@@ -40,6 +40,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Supplier",
+   "link_filters": "[[\"Supplier\",\"disabled\",\"=\",0]]",
    "options": "Supplier",
    "reqd": 1
   },

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -358,7 +358,8 @@ class Opportunity(TransactionBase, CRMNote):
 			return True
 
 	def validate_party(self) -> None:
-		validate_party_frozen_disabled(self.company, self.opportunity_from, self.party_name)
+		if self.opportunity_from == "Customer":
+			validate_party_frozen_disabled(self.company, "Customer", self.party_name)
 
 	def validate_cust_name(self):
 		if self.party_name:

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -12,6 +12,7 @@ from frappe.query_builder import DocType, Interval
 from frappe.query_builder.functions import Now
 from frappe.utils import flt, get_fullname
 
+from erpnext.accounts.party import validate_party_frozen_disabled
 from erpnext.crm.utils import (
 	CRMNote,
 	copy_comments,
@@ -132,6 +133,7 @@ class Opportunity(TransactionBase, CRMNote):
 		self.validate_item_details()
 		self.validate_uom_is_integer("uom", "qty")
 		self.validate_cust_name()
+		self.validate_party()
 		self.map_fields()
 		self.validate_qty()
 		self.set_exchange_rate()
@@ -354,6 +356,9 @@ class Opportunity(TransactionBase, CRMNote):
 			if self.has_active_quotation():
 				return False
 			return True
+
+	def validate_party(self) -> None:
+		validate_party_frozen_disabled(self.company, self.opportunity_from, self.party_name)
 
 	def validate_cust_name(self):
 		if self.party_name:

--- a/erpnext/crm/doctype/opportunity/test_opportunity.py
+++ b/erpnext/crm/doctype/opportunity/test_opportunity.py
@@ -80,6 +80,15 @@ class TestOpportunity(ERPNextTestSuite):
 		frappe.db.set_value("Customer", "_Test Customer", "disabled", 0)
 		make_opportunity(with_items=0)
 
+	def test_disabled_lead_not_blocked(self):
+		# Lead.disabled isn't enforced anywhere else (e.g. the Lead picker query only
+		# excludes Converted leads), so it shouldn't block Opportunity creation either.
+		lead_doc = make_lead()
+		frappe.db.set_value("Lead", lead_doc.name, "disabled", 1)
+
+		opp_doc = make_opportunity(opportunity_from="Lead", lead=lead_doc.name)
+		self.assertEqual(opp_doc.party_name, lead_doc.name)
+
 	def test_carry_forward_of_email_and_comments(self):
 		frappe.db.set_single_value("CRM Settings", "carry_forward_communication_and_comments", 1)
 		lead_doc = make_lead()

--- a/erpnext/crm/doctype/opportunity/test_opportunity.py
+++ b/erpnext/crm/doctype/opportunity/test_opportunity.py
@@ -9,6 +9,7 @@ from erpnext.crm.doctype.lead.test_lead import make_lead
 from erpnext.crm.doctype.opportunity.mapper import make_quotation
 from erpnext.crm.doctype.opportunity.opportunity import auto_close_opportunity, get_item_details
 from erpnext.crm.utils import get_linked_communication_list
+from erpnext.exceptions import PartyDisabled
 from erpnext.tests.utils import ERPNextTestSuite
 
 
@@ -70,6 +71,14 @@ class TestOpportunity(ERPNextTestSuite):
 	def test_opportunity_item(self):
 		opportunity_doc = make_opportunity(with_items=1, rate=1100, qty=2)
 		self.assertEqual(opportunity_doc.total, 2200)
+
+	def test_disabled_customer_not_allowed(self):
+		frappe.db.set_value("Customer", "_Test Customer", "disabled", 1)
+
+		self.assertRaises(PartyDisabled, make_opportunity, with_items=0)
+
+		frappe.db.set_value("Customer", "_Test Customer", "disabled", 0)
+		make_opportunity(with_items=0)
 
 	def test_carry_forward_of_email_and_comments(self):
 		frappe.db.set_single_value("CRM Settings", "carry_forward_communication_and_comments", 1)

--- a/erpnext/public/js/queries.js
+++ b/erpnext/public/js/queries.js
@@ -12,6 +12,10 @@ $.extend(erpnext.queries, {
 		return { query: "erpnext.controllers.queries.lead_query" };
 	},
 
+	customer: function () {
+		return { filters: { disabled: 0 } };
+	},
+
 	item: function (filters) {
 		var args = { query: "erpnext.controllers.queries.item_query" };
 		if (filters) args["filters"] = filters;


### PR DESCRIPTION
## Summary
- `Opportunity` inherits `TransactionBase`, not `AccountsController`, so it never ran `validate_party_frozen_disabled` the way `Quotation`/`Sales Order`/`Sales Invoice` do. A disabled or frozen Customer could be saved as an Opportunity's party, only getting caught later at Quotation stage. Added a `validate_party` step that reuses the same shared check.
- The `party_name` Link field's client-side query referenced `erpnext.queries.customer`, which was never defined anywhere in the codebase, so disabled customers still showed up in the picker. Added the missing `customer` query with a `disabled: 0` filter.
- `Request for Quotation` overrides `validate()` entirely without calling `super().validate()`, so it never goes through `AccountsController`'s party validation either. Its suppliers also live in a child table, so the shared `PartyValidator` wouldn't catch it even if `super().validate()` were called (it only checks a single top-level party field). Added the same disabled/frozen check per supplier row in `validate_supplier_list`, plus a matching `disabled: 0` filter on the suppliers grid's Link field.

## Test plan
- [x] Added `test_disabled_customer_not_allowed` to `test_opportunity.py`
- [x] Added `test_rfq_blocked_for_disabled_supplier` to `test_request_for_quotation.py`
- [x] `bench --site test.site run-tests --app erpnext --module erpnext.crm.doctype.opportunity.test_opportunity` — 11 passed
- [x] `bench --site test.site run-tests --app erpnext --module erpnext.buying.doctype.request_for_quotation.test_request_for_quotation` — 21 passed (1 pre-existing, unrelated `test_get_pdf` failure confirmed present on `develop` before this change, due to local PDF generation setup)