### PR TITLE
refactor(projects)!: remove is_active field and update status options

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -494,7 +494,7 @@ def get_project_name(
 		if filters.get("company"):
 			qb_filter_and_conditions.append(proj.company == filters.get("company"))
 
-	qb_filter_and_conditions.append(proj.status.notin(["Completed", "Cancelled", "On hold"]))
+	qb_filter_and_conditions.append(proj.status.notin(["Completed", "Cancelled", "On hold", "Disabled"]))
 
 	q = qb.from_(proj)
 

--- a/erpnext/controllers/tests/test_queries.py
+++ b/erpnext/controllers/tests/test_queries.py
@@ -79,6 +79,23 @@ class TestQueries(ERPNextTestSuite):
 
 		self.assertGreaterEqual(len(query(txt="_Test Project")), 1)
 
+		# Verify that Disabled projects are excluded from query results
+		# Create a test project with Disabled status if it doesn't exist
+		disabled_project_name = "_Test Disabled Project"
+		if not frappe.db.exists("Project", {"project_name": disabled_project_name}):
+			frappe.get_doc(
+				{
+					"doctype": "Project",
+					"project_name": disabled_project_name,
+					"status": "Disabled",
+					"company": "_Test Company",
+				}
+			).insert()
+
+		# Search for the disabled project - it should not appear in results
+		results = query(txt=disabled_project_name)
+		self.assertEqual(len([r for r in results if disabled_project_name in str(r)]), 0)
+
 	def test_account_query(self):
 		query = add_default_params(queries.get_account_list, "Account")
 

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -521,3 +521,4 @@ erpnext.patches.v16_0.set_secondary_item_valuation_type
 erpnext.patches.v16_0.append_fieldname_to_pos_search_fields
 erpnext.patches.v16_0.set_supplier_quotation_order_status
 erpnext.patches.v16_0.recalculate_holiday_list_totals
+erpnext.patches.v16_0.migrate_project_is_active_to_status

--- a/erpnext/patches/v16_0/migrate_project_is_active_to_status.py
+++ b/erpnext/patches/v16_0/migrate_project_is_active_to_status.py
@@ -1,0 +1,21 @@
+import frappe
+
+
+def execute():
+	"""
+	Migrate Project is_active field to status field.
+	Sets status = 'Disabled' for Projects where is_active = 'No' AND status is 'Open' or 'On hold'
+	"""
+	# Check if the column exists before migration
+	if not frappe.db.has_column("Project", "is_active"):
+		return
+
+	project = frappe.qb.DocType("Project")
+
+	(
+		frappe.qb.update(project)
+		.set(project.status, "Disabled")
+		.where(project.is_active == "No")
+		.where((project.status == "Open") | (project.status == "On hold"))
+		.run()
+	)

--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -17,7 +17,6 @@
   "project_template",
   "priority",
   "department",
-  "is_active",
   "percent_complete",
   "section_break_18",
   "expected_start_date",
@@ -86,7 +85,7 @@
    "no_copy": 1,
    "oldfieldname": "status",
    "oldfieldtype": "Select",
-   "options": "Open\nOn hold\nCompleted\nCancelled",
+   "options": "Open\nOn hold\nCompleted\nDisabled\nCancelled",
    "search_index": 1
   },
   {
@@ -98,14 +97,6 @@
    "oldfieldname": "project_type",
    "oldfieldtype": "Data",
    "options": "Project Type"
-  },
-  {
-   "fieldname": "is_active",
-   "fieldtype": "Select",
-   "label": "Is Active",
-   "oldfieldname": "is_active",
-   "oldfieldtype": "Select",
-   "options": "Yes\nNo"
   },
   {
    "default": "Task Completion",
@@ -484,7 +475,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "max_attachments": 4,
- "modified": "2026-08-21 23:11:46.332012",
+ "modified": "2026-09-09 12:52:14.056895",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project",
@@ -624,7 +615,7 @@
  ],
  "quick_entry": 1,
  "row_format": "Dynamic",
- "search_fields": "project_name,customer, status, priority, is_active",
+ "search_fields": "project_name,customer, status, priority",
  "show_name_in_global_search": 1,
  "show_title_field_in_link": 1,
  "sort_field": "creation",

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -46,7 +46,6 @@ class Project(Document):
 		from_time: DF.Time | None
 		gross_margin: DF.Currency
 		holiday_list: DF.Link | None
-		is_active: DF.Literal["Yes", "No"]
 		message: DF.Text | None
 		naming_series: DF.Literal["PROJ-.####"]
 		notes: DF.TextEditor | None
@@ -59,7 +58,7 @@ class Project(Document):
 		project_type: DF.Link | None
 		sales_order: DF.Link | None
 		second_email: DF.Time | None
-		status: DF.Literal["Open", "On hold", "Completed", "Cancelled"]
+		status: DF.Literal["Open", "On hold", "Completed", "Cancelled", "Disabled"]
 		subject: DF.Data | None
 		to_time: DF.Time | None
 		total_billable_amount: DF.Currency
@@ -315,8 +314,8 @@ class Project(Document):
 					pct_complete += row["progress"] * frappe.utils.safe_div(row["task_weight"], weight_sum)
 				self.percent_complete = flt(flt(pct_complete), 2)
 
-		# don't update status if it is manually set to cancelled or on hold
-		if self.status in ("Cancelled", "On hold"):
+		# don't update status if it is manually set to cancelled, on hold, or disabled
+		if self.status in ("Cancelled", "On hold", "Disabled"):
 			return
 
 		self.status = "Completed" if self.percent_complete == 100 else "Open"

--- a/erpnext/projects/doctype/project/project_list.js
+++ b/erpnext/projects/doctype/project/project_list.js
@@ -1,11 +1,13 @@
 frappe.listview_settings["Project"] = {
-	add_fields: ["status", "priority", "is_active", "percent_complete", "expected_end_date", "project_name"],
+	add_fields: ["status", "priority", "percent_complete", "expected_end_date", "project_name"],
 	filters: [["status", "=", "Open"]],
 	get_indicator: function (doc) {
 		if (doc.status == "Open" && doc.percent_complete) {
 			return [__("{0}%", [cint(doc.percent_complete)]), "orange", "percent_complete,>,0|status,=,Open"];
 		} else if (doc.status == "On hold") {
 			return [__("On hold"), "blue", "status,=,On hold"];
+		} else if (doc.status == "Disabled") {
+			return [__("Disabled"), "grey", "status,=,Disabled"];
 		} else {
 			return [__(doc.status), frappe.utils.guess_colour(doc.status), "status,=," + doc.status];
 		}

--- a/erpnext/projects/report/project_summary/project_summary.js
+++ b/erpnext/projects/report/project_summary/project_summary.js
@@ -12,17 +12,10 @@ frappe.query_reports["Project Summary"] = {
 			reqd: 1,
 		},
 		{
-			fieldname: "is_active",
-			label: __("Is Active"),
-			fieldtype: "Select",
-			options: "\nYes\nNo",
-			default: "Yes",
-		},
-		{
 			fieldname: "status",
 			label: __("Status"),
 			fieldtype: "Select",
-			options: "\nOpen\nOn hold\nCompleted\nCancelled",
+			options: "\nOpen\nOn hold\nCompleted\nCancelled\nDisabled",
 			default: "Open",
 		},
 		{


### PR DESCRIPTION
**Issue:**
Project carries both an "Is Active" (Yes/No) select and a "Status" select, which overlap and let a project be Status = Open while Is Active = No.

Nothing in ERPNext reads Project.is_active: it is never written by any code path, it does not filter the Project link search (erpnext/controllers/queries.py, get_project_name), and it does not block tasks, timesheets or billing. The only places it appears are the list view fields and the Project Summary report filter, so marking a project inactive changes nothing except that label.

**Proposal:** drop the is_active field and add "Disabled" to the Status options, so a single field expresses the project state, with a patch migrating is_active = "No" projects that are Open or On hold to status "Disabled".

**Before:**
<img width="1232" height="770" alt="image" src="https://github.com/user-attachments/assets/905278d8-e887-4159-8e0f-28a4a3b4a365" />


**After:**
<img width="1232" height="772" alt="image" src="https://github.com/user-attachments/assets/5c59a3b5-2ffd-4043-8c7a-26be185f99ca" />


**Backport Needed for v15 & v16**