### PR TITLE
fix(journal_entry): reset `pay_to_recd_from` on change of account

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -821,10 +821,13 @@ class JournalEntry(AccountsController):
 				amounts.pay_to_recd_from,
 				"customer_name" if amounts.party_type == "Customer" else "supplier_name",
 			)
-			if amounts.bank_amount:
-				total_amount, currency = amounts.bank_amount, amounts.bank_account_currency
-			else:
-				total_amount, currency = amounts.party_amount, amounts.party_account_currency
+		else:
+			self.pay_to_recd_from = None
+
+		if amounts.bank_amount:
+			total_amount, currency = amounts.bank_amount, amounts.bank_account_currency
+		else:
+			total_amount, currency = amounts.party_amount, amounts.party_account_currency
 
 		self.set_total_amount(total_amount, currency)
 


### PR DESCRIPTION
Reset `pay_to_recd_from` on Journal Entry on removal of accounts that have dependencies with "Party Type" and "Party".