### PR TITLE
fix: keep item code searchable when a barcode matches the same text

### DIFF
--- a/erpnext/manufacturing/doctype/bom/mapper.py
+++ b/erpnext/manufacturing/doctype/bom/mapper.py
@@ -158,9 +158,9 @@ def _item_query_filters(filters):
 
 def _item_query_or_filters(txt, searchfields, query_filters):
 	if not txt:
-		return {}
+		return []
 
-	or_filters = {s_field: ("like", f"%{txt}%") for s_field in searchfields}
+	or_filters = [[s_field, "like", f"%{txt}%"] for s_field in searchfields]
 	barcodes = frappe.get_all(
 		"Item Barcode",
 		fields=["parent as item_code"],
@@ -169,7 +169,7 @@ def _item_query_or_filters(txt, searchfields, query_filters):
 	)
 	barcode_codes = [d.item_code for d in barcodes]
 	if barcode_codes:
-		or_filters["name"] = ("in", barcode_codes)
+		or_filters.append(["name", "in", barcode_codes])
 	return or_filters
 
 

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -531,6 +531,29 @@ class TestBOM(ERPNextTestSuite):
 		self.assertTrue(0 < len(filtered) <= 3, msg="Item filtering showing excessive results")
 
 	@timeout
+	def test_bom_item_query_matches_item_code_colliding_with_another_barcode(self):
+		item = make_item(
+			"_Test BOM Query 2.5MM",
+			{"is_stock_item": 1, "item_name": "_Test BOM Query Sheet", "description": "sheet"},
+		)
+		make_item(
+			"_Test BOM Query Barcode Holder",
+			{"is_stock_item": 1},
+			barcode=f"90{item.name}90",
+		)
+
+		results = item_query(
+			doctype="Item",
+			txt=item.name,
+			searchfield="name",
+			start=0,
+			page_len=20,
+			filters={"is_stock_item": 1},
+		)
+
+		self.assertIn(item.name, [d[0] for d in results])
+
+	@timeout
 	def test_exclude_exploded_items_from_bom(self):
 		bom_no = get_default_bom()
 		new_bom = frappe.copy_doc(frappe.get_doc("BOM", bom_no))


### PR DESCRIPTION
## Description

`item_query` builds `or_filters` as a dict, so the barcode condition overwrites the existing `name LIKE %txt%` filter from `get_search_fields()`. This causes exact item-code matches to disappear when the code overlaps another item's barcode.

On v16, this can also cause the Link field to clear after selecting an item because the custom query does not add the standard exact-match filter.

Changed `or_filters` to the list-of-conditions format so the barcode condition is added as an additional OR branch instead of replacing the `name` filter.

---

Ref: https://support.frappe.io/helpdesk/tickets/75186?view=VIEW-HD+Ticket-1242