### PR TITLE
fix: pass finished goods as list to subcontracting BOM lookup

### DIFF
--- a/erpnext/buying/doctype/purchase_order/services/subcontracting.py
+++ b/erpnext/buying/doctype/purchase_order/services/subcontracting.py
@@ -51,9 +51,9 @@ class SubcontractingService:
 		if not doc.is_subcontracted:
 			return
 
-		finished_goods_without_service_item = {
-			d.fg_item for d in doc.items if (not d.item_code and d.fg_item)
-		}
+		finished_goods_without_service_item = list(
+			{d.fg_item for d in doc.items if (not d.item_code and d.fg_item)}
+		)
 
 		if subcontracting_boms := get_subcontracting_boms_for_finished_goods(
 			finished_goods_without_service_item


### PR DESCRIPTION
`set_service_items_for_finished_goods` passes a `set` to `get_subcontracting_boms_for_finished_goods`, which only handles `str` and `list`. Whitelist type coercion hides the mismatch during requests and tests; from console/`bench execute`/background contexts the set is inlined into the SQL and the query fails on both MariaDB and PostgreSQL. Pass a list instead.

Ref #57996