### PR TITLE
fix(manufacturing): correct nested BOM Explorer quantities

### DIFF
--- a/erpnext/manufacturing/report/bom_explorer/bom_explorer.py
+++ b/erpnext/manufacturing/report/bom_explorer/bom_explorer.py
@@ -21,7 +21,7 @@ def get_exploded_items(bom, data, indent=0, qty=1):
 	exploded_items = frappe.get_all(
 		"BOM Item",
 		filters={"parent": bom},
-		fields=["qty", "bom_no", "qty", "item_code", "item_name", "description", "uom", "idx"],
+		fields=["qty", "bom_no", "stock_qty", "item_code", "item_name", "description", "uom", "idx"],
 		order_by="idx ASC",
 	)
 
@@ -40,7 +40,13 @@ def get_exploded_items(bom, data, indent=0, qty=1):
 			}
 		)
 		if item.bom_no:
-			get_exploded_items(item.bom_no, data, indent=indent + 1, qty=item.qty)
+			child_bom_qty = frappe.get_cached_value("BOM", item.bom_no, "quantity")
+			get_exploded_items(
+				item.bom_no,
+				data,
+				indent=indent + 1,
+				qty=qty * item.stock_qty / child_bom_qty,
+			)
 
 
 def get_columns():

--- a/erpnext/manufacturing/report/bom_explorer/bom_explorer.py
+++ b/erpnext/manufacturing/report/bom_explorer/bom_explorer.py
@@ -21,7 +21,17 @@ def get_exploded_items(bom, data, indent=0, qty=1):
 	exploded_items = frappe.get_all(
 		"BOM Item",
 		filters={"parent": bom},
-		fields=["qty", "bom_no", "stock_qty", "item_code", "item_name", "description", "uom", "idx"],
+		fields=[
+			"qty",
+			"bom_no",
+			"bom_no.quantity as child_bom_qty",
+			"stock_qty",
+			"item_code",
+			"item_name",
+			"description",
+			"uom",
+			"idx",
+		],
 		order_by="idx ASC",
 	)
 
@@ -40,12 +50,11 @@ def get_exploded_items(bom, data, indent=0, qty=1):
 			}
 		)
 		if item.bom_no:
-			child_bom_qty = frappe.get_cached_value("BOM", item.bom_no, "quantity")
 			get_exploded_items(
 				item.bom_no,
 				data,
 				indent=indent + 1,
-				qty=qty * item.stock_qty / child_bom_qty,
+				qty=qty * item.stock_qty / item.child_bom_qty,
 			)
 
 

--- a/erpnext/manufacturing/report/bom_explorer/test_bom_explorer.py
+++ b/erpnext/manufacturing/report/bom_explorer/test_bom_explorer.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from erpnext.manufacturing.report.bom_explorer.bom_explorer import get_exploded_items
+
+
+class TestBOMExplorer(unittest.TestCase):
+	def test_nested_bom_normalizes_and_accumulates_qty(self):
+		def item(item_code, qty, stock_qty, bom_no="", uom="Nos"):
+			return frappe._dict(
+				item_code=item_code,
+				item_name=item_code,
+				description="",
+				qty=qty,
+				stock_qty=stock_qty,
+				bom_no=bom_no,
+				uom=uom,
+				idx=1,
+			)
+
+		children = {
+			"root": [item("parent", 2, 20, "parent-bom", "Box")],
+			"parent-bom": [item("child", 3, 12, "child-bom", "Pack")],
+			"child-bom": [item("raw-material", 2, 2, uom="Kg")],
+		}
+		bom_quantities = {"parent-bom": 5, "child-bom": 4}
+
+		def get_items(_doctype, filters, **kwargs):
+			return children[filters["parent"]]
+
+		def get_bom_quantity(_doctype, name, _fieldname):
+			return bom_quantities[name]
+
+		data = []
+		with (
+			patch.object(frappe, "get_all", side_effect=get_items),
+			patch.object(frappe, "get_cached_value", side_effect=get_bom_quantity),
+		):
+			get_exploded_items("root", data)
+
+		self.assertEqual([row["qty"] for row in data], [2, 12, 24])

--- a/erpnext/manufacturing/report/bom_explorer/test_bom_explorer.py
+++ b/erpnext/manufacturing/report/bom_explorer/test_bom_explorer.py
@@ -11,7 +11,7 @@ from erpnext.manufacturing.report.bom_explorer.bom_explorer import get_exploded_
 
 class TestBOMExplorer(unittest.TestCase):
 	def test_nested_bom_normalizes_and_accumulates_qty(self):
-		def item(item_code, qty, stock_qty, bom_no="", uom="Nos"):
+		def item(item_code, qty, stock_qty, bom_no="", uom="Nos", child_bom_qty=None):
 			return frappe._dict(
 				item_code=item_code,
 				item_name=item_code,
@@ -19,28 +19,23 @@ class TestBOMExplorer(unittest.TestCase):
 				qty=qty,
 				stock_qty=stock_qty,
 				bom_no=bom_no,
+				child_bom_qty=child_bom_qty,
 				uom=uom,
 				idx=1,
 			)
 
 		children = {
-			"root": [item("parent", 2, 20, "parent-bom", "Box")],
-			"parent-bom": [item("child", 3, 12, "child-bom", "Pack")],
+			"root": [item("parent", 2, 20, "parent-bom", "Box", 5)],
+			"parent-bom": [item("child", 3, 12, "child-bom", "Pack", 4)],
 			"child-bom": [item("raw-material", 2, 2, uom="Kg")],
 		}
-		bom_quantities = {"parent-bom": 5, "child-bom": 4}
 
 		def get_items(_doctype, filters, **kwargs):
+			self.assertIn("bom_no.quantity as child_bom_qty", kwargs["fields"])
 			return children[filters["parent"]]
 
-		def get_bom_quantity(_doctype, name, _fieldname):
-			return bom_quantities[name]
-
 		data = []
-		with (
-			patch.object(frappe, "get_all", side_effect=get_items),
-			patch.object(frappe, "get_cached_value", side_effect=get_bom_quantity),
-		):
+		with patch.object(frappe, "get_all", side_effect=get_items):
 			get_exploded_items("root", data)
 
 		self.assertEqual([row["qty"] for row in data], [2, 12, 24])


### PR DESCRIPTION
Backport of #57963 for `version-15-hotfix`.

## Problem

BOM Explorer reset the accumulated quantity when it entered a deeper BOM level. This caused incorrect component quantities in nested BOM trees.

A child BOM can also use a different output quantity and stock UOM. The calculation must normalize each child batch with compatible units.

## Solution

- Fetch `BOM Item.stock_qty` in the existing query-per-BOM walker.
- Read the child BOM output quantity from the document cache.
- Pass the normalized cumulative multiplier to the next BOM level.
- Keep the displayed quantity in the BOM Item row UOM.

## Tests

- `erpnext.manufacturing.report.bom_explorer.test_bom_explorer`
- 1 focused regression test passed.
- Commit hooks passed, including Ruff.
