### PR TITLE
fix: require material transfer before job card time logs (v15)

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -296,7 +296,16 @@ frappe.ui.form.on("Job Card", {
 	prepare_timer_buttons: function (frm) {
 		frm.trigger("make_dashboard");
 
+		const transfer_pending =
+			!frm.doc.is_corrective_job_card &&
+			(frm.doc.items || []).length &&
+			flt(frm.doc.transferred_qty) < flt(frm.doc.for_quantity);
+
 		if (!frm.doc.started_time && !frm.doc.current_time) {
+			if (transfer_pending) {
+				return;
+			}
+
 			frm.add_custom_button(__("Start Job"), () => {
 				if ((frm.doc.employee && !frm.doc.employee.length) || !frm.doc.employee) {
 					frappe.prompt(

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -513,6 +513,8 @@ class JobCard(Document):
 			)
 
 	def add_time_log(self, args):
+		self.validate_transfer_qty()
+
 		last_row = []
 		employees = args.employees
 		if isinstance(employees, str):

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -249,6 +249,26 @@ class TestJobCard(FrappeTestCase):
 		# JC is Completed with excess transfer
 		self.assertEqual(job_card.status, "Completed")
 
+	def test_job_card_time_log_blocked_until_material_transfer(self):
+		"Time logs must wait for the transfer when RMs move against Job Card."
+		self.transfer_material_against = "Job Card"
+		self.source_warehouse = "Stores - _TC"
+
+		self.generate_required_stock(self.work_order)
+		job_card = frappe.get_last_doc("Job Card", {"work_order": self.work_order.name})
+
+		self.assertRaises(
+			frappe.ValidationError, job_card.add_time_log, frappe._dict(start_time=now(), employees=[])
+		)
+
+		transfer_entry = make_stock_entry_from_jc(job_card.name)
+		transfer_entry.insert()
+		transfer_entry.submit()
+
+		job_card.reload()
+		job_card.add_time_log(frappe._dict(start_time=now(), employees=[]))
+		self.assertTrue(job_card.time_logs)
+
 	@change_settings("Manufacturing Settings", {"job_card_excess_transfer": 0})
 	def test_job_card_excess_material_transfer_block(self):
 		self.transfer_material_against = "Job Card"


### PR DESCRIPTION
v15 adaptation of #58009, replacing the automatic backport #58013 — the cherry-pick dragged in develop's job card dashboard rewrite because v15 has none of the methods the original fix touched.

On v15 the Start/Complete flow runs through `add_time_log` (via the whitelisted `make_time_log`), so the transfer gate goes there, and the Start Job button hides while transfer is pending. Corrective job cards and job cards without items (transfer against Work Order) stay exempt, matching the existing submit-time `validate_transfer_qty`.