### PR TITLE
fix: preserve original operation idx in manually created Job Cards

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/mapper.py
+++ b/erpnext/manufacturing/doctype/work_order/mapper.py
@@ -312,6 +312,7 @@ def get_operation_details(name, work_order, parent_bom):
 	for row in work_order.operations:
 		if row.name == name:
 			return {
+				"idx": row.idx,
 				"workstation": row.workstation,
 				"workstation_type": row.workstation_type,
 				"source_warehouse": row.source_warehouse,


### PR DESCRIPTION
The Create Job Card dialog on Work Order lists only pending operations, so the row `idx` it sends to `make_job_card` is the dialog position, not the Work Order Operation idx. `create_job_card` stamped that dialog idx into `operation_row_id`, and `get_required_items` then matched raw materials by row id against the wrong operation — e.g. after completing operation 1, a Job Card recreated for operation 2 silently got operation 1's raw materials.

`get_operation_details` already resolves the Work Order Operation row by name; it now also returns that row's `idx`, overwriting the dialog idx before `operation_row_id` is set.

Fixes #57985