### PR TITLE
fix: preserve original operation idx in manually created Job Cards (backport #58016)

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -2825,6 +2825,7 @@ def get_operation_details(name, work_order, parent_bom):
 	for row in work_order.operations:
 		if row.name == name:
 			return {
+				"idx": row.idx,
 				"workstation": row.workstation,
 				"workstation_type": row.workstation_type,
 				"source_warehouse": row.source_warehouse,


### PR DESCRIPTION
Backport of #58016 to `version-16-hotfix` (`get_operation_details` lives in `work_order.py` here; same one-line change).

The Create Job Card dialog on Work Order lists only pending operations, so the row `idx` it sends to `make_job_card` is the dialog position, not the Work Order Operation idx. `create_job_card` stamped that dialog idx into `operation_row_id`, and `get_required_items` then matched raw materials by row id against the wrong operation.

`get_operation_details` now also returns the resolved row's `idx`, overwriting the dialog idx before `operation_row_id` is set.

Fixes #57985