### PR TITLE
fix(setup): fetch driver address by supplier link

### DIFF
--- a/erpnext/setup/doctype/driver/driver.js
+++ b/erpnext/setup/doctype/driver/driver.js
@@ -23,15 +23,20 @@ frappe.ui.form.on("Driver", {
 	},
 
 	transporter: function (frm, cdt, cdn) {
-		// this assumes that supplier's address has same title as supplier's name
 		if (!frm.doc.transporter) return;
-		frappe.db
-			.get_doc("Address", null, { address_title: frm.doc.transporter })
-			.then((r) => {
-				frappe.model.set_value(cdt, cdn, "address", r.name);
-			})
-			.catch((err) => {
-				console.log(err);
-			});
+
+		const transporter = frm.doc.transporter;
+		frappe.call({
+			method: "frappe.contacts.doctype.address.address.get_default_address",
+			args: {
+				doctype: "Supplier",
+				name: transporter,
+			},
+			callback: function (r) {
+				if (frm.doc.transporter === transporter) {
+					frappe.model.set_value(cdt, cdn, "address", r.message);
+				}
+			},
+		});
 	},
 });


### PR DESCRIPTION
## Problem

The Driver form looked up the transporter Address by its title. A Supplier naming series makes the Supplier ID differ from the name used in the Address title.

## Solution

Fetch the default Address through the Supplier Dynamic Link. Ignore the response if the user changes the transporter before the request completes.

## Impact

The Driver form now fills the transporter Address for every Supplier naming method. This change does not modify the database schema.

## Tests

- Prettier
- ESLint
- Driver address lookup behavior smoke test

closes #57653
