### PR TITLE
fix: make Default Inventory Account mandatory when Perpetual Inventory is enabled

### DIFF
--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -96,6 +96,10 @@ frappe.ui.form.on("Company", {
 		});
 	},
 
+	enable_perpetual_inventory: function (frm) {
+		frm.toggle_reqd("default_inventory_account", frm.doc.enable_perpetual_inventory);
+	},
+
 	company_name: function (frm) {
 		if (frm.doc.__islocal) {
 			// add missing " " arg in split method
@@ -127,6 +131,7 @@ frappe.ui.form.on("Company", {
 		erpnext.company.setup_queries(frm);
 
 		frm.toggle_display("address_html", !frm.is_new());
+		frm.toggle_reqd("default_inventory_account", frm.doc.enable_perpetual_inventory);
 
 		if (!frm.is_new()) {
 			frm.doc.abbr && frm.set_df_property("abbr", "read_only", 1);

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -662,8 +662,9 @@ class Company(NestedSet):
 	def validate_perpetual_inventory(self):
 		if not self.get("__islocal"):
 			if cint(self.enable_perpetual_inventory) == 1 and not self.default_inventory_account:
-				frappe.msgprint(
-					_("Set default inventory account for perpetual inventory"), alert=True, indicator="orange"
+				frappe.throw(
+					_("Please set Default Inventory Account for perpetual inventory to work correctly"),
+					title=_("Default Inventory Account Missing"),
 				)
 
 		doc_before_save = self.get_doc_before_save()


### PR DESCRIPTION
## Summary
- `Company.validate_perpetual_inventory` only showed a non-blocking `frappe.msgprint(alert=True)` when **Enable Perpetual Inventory** was checked without a **Default Inventory Account** set, so the Company could still be saved in this inconsistent state.
- Changed it to `frappe.throw` so saving is blocked until the account is set.
- Added a client-side `toggle_reqd` on `default_inventory_account` (on `refresh` and on the `enable_perpetual_inventory` field change) so the field shows as mandatory immediately in the form, not only after a failed save.

## Test plan
- [ ] Enable Perpetual Inventory on a Company with Default Inventory Account blank and Save — expect a blocking validation error instead of a silent/soft alert.
- [ ] Set Default Inventory Account and Save — expect Company saves normally.
- [ ] Disable Perpetual Inventory — Default Inventory Account should no longer be marked mandatory.
- [ ] Creating a brand-new Company is unaffected (validation still skips `__islocal` docs, consistent with existing auto-fill behavior in `set_default_accounts`).