### PR TITLE
perf: rewrite customer and supplier naming setters only on change

### DIFF
--- a/erpnext/buying/doctype/buying_settings/buying_settings.py
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.py
@@ -53,6 +53,15 @@ class BuyingSettings(Document):
 		for key in ["supplier_group", "supp_master_name", "maintain_same_rate", "buying_price_list"]:
 			frappe.db.set_default(key, self.get(key, ""))
 
+		self.update_supplier_naming_settings()
+
+		if not self.bill_for_rejected_quantity_in_purchase_invoice:
+			self.set_valuation_rate_for_rejected_materials = 0
+
+	def update_supplier_naming_settings(self):
+		if not self.has_value_changed("supp_master_name"):
+			return
+
 		from erpnext.utilities.naming import set_by_naming_series
 
 		set_by_naming_series(
@@ -61,9 +70,6 @@ class BuyingSettings(Document):
 			self.get("supp_master_name") == "Naming Series",
 			hide_name_field=False,
 		)
-
-		if not self.bill_for_rejected_quantity_in_purchase_invoice:
-			self.set_valuation_rate_for_rejected_materials = 0
 
 	def before_save(self):
 		self.check_maintain_same_rate()

--- a/erpnext/buying/doctype/buying_settings/test_buying_settings.py
+++ b/erpnext/buying/doctype/buying_settings/test_buying_settings.py
@@ -1,9 +1,30 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-# import frappe
+
+from unittest.mock import patch
+
+import frappe
 
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestBuyingSettings(ERPNextTestSuite):
-	pass
+	def test_unrelated_change_does_not_update_supplier_metadata(self):
+		settings = frappe.get_single("Buying Settings")
+		settings.allow_multiple_items = not settings.allow_multiple_items
+
+		with patch("erpnext.utilities.naming.set_by_naming_series") as set_by_naming_series:
+			settings.save()
+
+		set_by_naming_series.assert_not_called()
+
+	def test_supplier_metadata_updates_when_related_settings_change(self):
+		settings = frappe.get_single("Buying Settings")
+		settings.supp_master_name = (
+			"Supplier Name" if settings.supp_master_name == "Naming Series" else "Naming Series"
+		)
+
+		with patch("erpnext.utilities.naming.set_by_naming_series") as set_by_naming_series:
+			settings.save()
+
+		set_by_naming_series.assert_called_once()

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -84,14 +84,7 @@ class SellingSettings(Document):
 		]:
 			frappe.db.set_default(key, self.get(key, ""))
 
-		from erpnext.utilities.naming import set_by_naming_series
-
-		set_by_naming_series(
-			"Customer",
-			"customer_name",
-			self.get("cust_master_name") == "Naming Series",
-			hide_name_field=False,
-		)
+		self.update_customer_naming_settings()
 
 		self.validate_fallback_to_default_price_list()
 
@@ -100,6 +93,19 @@ class SellingSettings(Document):
 
 		if old_doc and old_doc.enable_utm != self.enable_utm:
 			toggle_utm_analytics_section(not self.enable_utm)
+
+	def update_customer_naming_settings(self):
+		if not self.has_value_changed("cust_master_name"):
+			return
+
+		from erpnext.utilities.naming import set_by_naming_series
+
+		set_by_naming_series(
+			"Customer",
+			"customer_name",
+			self.get("cust_master_name") == "Naming Series",
+			hide_name_field=False,
+		)
 
 	def validate_fallback_to_default_price_list(self):
 		if (

--- a/erpnext/selling/doctype/selling_settings/test_selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/test_selling_settings.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
 
 from erpnext.tests.utils import ERPNextTestSuite
@@ -12,3 +14,23 @@ class TestSellingSettings(ERPNextTestSuite):
 		# if setup was completed correctly
 		default = frappe.db.get_single_value("Selling Settings", "maintain_same_rate_action")
 		self.assertEqual("Stop", default)
+
+	def test_unrelated_change_does_not_update_customer_metadata(self):
+		settings = frappe.get_single("Selling Settings")
+		settings.allow_multiple_items = not settings.allow_multiple_items
+
+		with patch("erpnext.utilities.naming.set_by_naming_series") as set_by_naming_series:
+			settings.save()
+
+		set_by_naming_series.assert_not_called()
+
+	def test_customer_metadata_updates_when_related_settings_change(self):
+		settings = frappe.get_single("Selling Settings")
+		settings.cust_master_name = (
+			"Customer Name" if settings.cust_master_name == "Naming Series" else "Naming Series"
+		)
+
+		with patch("erpnext.utilities.naming.set_by_naming_series") as set_by_naming_series:
+			settings.save()
+
+		set_by_naming_series.assert_called_once()


### PR DESCRIPTION
## What changed

- Rewrite Customer naming metadata only when `cust_master_name` changes.
- Rewrite Supplier naming metadata only when `supp_master_name` changes.
- Add tests for changed and unchanged settings.

## Why

Same optimization as #58018, applied to the two remaining callers. Every Selling Settings or Buying Settings save reran `set_by_naming_series`, rewriting the `naming_series` Property Setters (with their cache clears) and running the backfill `UPDATE` on `tabCustomer` / `tabSupplier`.

## Behaviour note

Re-saving the settings without changing the naming field no longer rewrites the Property Setters, so a plain re-save does not repair manually deleted or drifted ones; toggling the setting does. Naming itself is unaffected: `Customer.autoname` / `Supplier.autoname` and the forms read the master-name default, which is still set on every save.

## Tests

- `pilot -b postgres --site testing.localhost run-tests --module erpnext.selling.doctype.selling_settings.test_selling_settings`
- `pilot -b postgres --site testing.localhost run-tests --module erpnext.buying.doctype.buying_settings.test_buying_settings`
- Commit hooks, Ruff, formatting, and PostgreSQL compatibility checks
