### PR TITLE
perf: rewrite selling settings toggle setters only on change

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -297,7 +297,6 @@
    "hide_days": 1,
    "hide_seconds": 1,
    "label": "Tax Id",
-   "print_hide": 1,
    "read_only": 1
   },
   {
@@ -1940,6 +1939,7 @@
    "allow_on_submit": 1,
    "fieldname": "additional_discount_account",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Discount Account",
    "options": "Account"
   },
@@ -2360,7 +2360,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2026-06-21 12:46:13.250145",
+ "modified": "2026-08-11 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -887,6 +887,7 @@
    "allow_on_submit": 1,
    "fieldname": "discount_account",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Discount Account",
    "options": "Account"
   },
@@ -1067,7 +1068,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-08-07 17:31:31.732720",
+ "modified": "2026-08-11 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",

--- a/erpnext/buying/doctype/buying_settings/buying_settings.py
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.py
@@ -53,6 +53,15 @@ class BuyingSettings(Document):
 		for key in ["supplier_group", "supp_master_name", "maintain_same_rate", "buying_price_list"]:
 			frappe.db.set_default(key, self.get(key, ""))
 
+		self.update_supplier_naming_settings()
+
+		if not self.bill_for_rejected_quantity_in_purchase_invoice:
+			self.set_valuation_rate_for_rejected_materials = 0
+
+	def update_supplier_naming_settings(self):
+		if not self.has_value_changed("supp_master_name"):
+			return
+
 		from erpnext.utilities.naming import set_by_naming_series
 
 		set_by_naming_series(
@@ -61,9 +70,6 @@ class BuyingSettings(Document):
 			self.get("supp_master_name") == "Naming Series",
 			hide_name_field=False,
 		)
-
-		if not self.bill_for_rejected_quantity_in_purchase_invoice:
-			self.set_valuation_rate_for_rejected_materials = 0
 
 	def before_save(self):
 		self.check_maintain_same_rate()

--- a/erpnext/buying/doctype/buying_settings/test_buying_settings.py
+++ b/erpnext/buying/doctype/buying_settings/test_buying_settings.py
@@ -1,9 +1,30 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-# import frappe
+
+from unittest.mock import patch
+
+import frappe
 
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestBuyingSettings(ERPNextTestSuite):
-	pass
+	def test_unrelated_change_does_not_update_supplier_metadata(self):
+		settings = frappe.get_single("Buying Settings")
+		settings.allow_multiple_items = not settings.allow_multiple_items
+
+		with patch("erpnext.utilities.naming.set_by_naming_series") as set_by_naming_series:
+			settings.save()
+
+		set_by_naming_series.assert_not_called()
+
+	def test_supplier_metadata_updates_when_related_settings_change(self):
+		settings = frappe.get_single("Buying Settings")
+		settings.supp_master_name = (
+			"Supplier Name" if settings.supp_master_name == "Naming Series" else "Naming Series"
+		)
+
+		with patch("erpnext.utilities.naming.set_by_naming_series") as set_by_naming_series:
+			settings.save()
+
+		set_by_naming_series.assert_called_once()

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -84,14 +84,7 @@ class SellingSettings(Document):
 		]:
 			frappe.db.set_default(key, self.get(key, ""))
 
-		from erpnext.utilities.naming import set_by_naming_series
-
-		set_by_naming_series(
-			"Customer",
-			"customer_name",
-			self.get("cust_master_name") == "Naming Series",
-			hide_name_field=False,
-		)
+		self.update_customer_naming_settings()
 
 		self.validate_fallback_to_default_price_list()
 
@@ -100,6 +93,19 @@ class SellingSettings(Document):
 
 		if old_doc and old_doc.enable_utm != self.enable_utm:
 			toggle_utm_analytics_section(not self.enable_utm)
+
+	def update_customer_naming_settings(self):
+		if not self.has_value_changed("cust_master_name"):
+			return
+
+		from erpnext.utilities.naming import set_by_naming_series
+
+		set_by_naming_series(
+			"Customer",
+			"customer_name",
+			self.get("cust_master_name") == "Naming Series",
+			hide_name_field=False,
+		)
 
 	def validate_fallback_to_default_price_list(self):
 		if (

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -125,6 +125,9 @@ class SellingSettings(Document):
 			)
 
 	def toggle_hide_tax_id(self):
+		if not self.has_value_changed("hide_tax_id"):
+			return
+
 		_hide_tax_id = cint(self.hide_tax_id)
 
 		# Make property setters to hide tax_id fields
@@ -137,6 +140,9 @@ class SellingSettings(Document):
 			)
 
 	def toggle_editable_rate_for_bundle_items(self):
+		if not self.has_value_changed("editable_bundle_item_rates"):
+			return
+
 		editable_bundle_item_rates = cint(self.editable_bundle_item_rates)
 
 		make_property_setter(
@@ -149,6 +155,9 @@ class SellingSettings(Document):
 		)
 
 	def toggle_discount_accounting_fields(self):
+		if not self.has_value_changed("enable_discount_accounting"):
+			return
+
 		enable_discount_accounting = cint(self.enable_discount_accounting)
 
 		make_property_setter(

--- a/erpnext/selling/doctype/selling_settings/test_selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/test_selling_settings.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
 
 from erpnext.tests.utils import ERPNextTestSuite
@@ -12,3 +14,23 @@ class TestSellingSettings(ERPNextTestSuite):
 		# if setup was completed correctly
 		default = frappe.db.get_single_value("Selling Settings", "maintain_same_rate_action")
 		self.assertEqual("Stop", default)
+
+	def test_unrelated_change_does_not_update_customer_metadata(self):
+		settings = frappe.get_single("Selling Settings")
+		settings.allow_multiple_items = not settings.allow_multiple_items
+
+		with patch("erpnext.utilities.naming.set_by_naming_series") as set_by_naming_series:
+			settings.save()
+
+		set_by_naming_series.assert_not_called()
+
+	def test_customer_metadata_updates_when_related_settings_change(self):
+		settings = frappe.get_single("Selling Settings")
+		settings.cust_master_name = (
+			"Customer Name" if settings.cust_master_name == "Naming Series" else "Naming Series"
+		)
+
+		with patch("erpnext.utilities.naming.set_by_naming_series") as set_by_naming_series:
+			settings.save()
+
+		set_by_naming_series.assert_called_once()

--- a/erpnext/selling/doctype/selling_settings/test_selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/test_selling_settings.py
@@ -34,3 +34,27 @@ class TestSellingSettings(ERPNextTestSuite):
 			settings.save()
 
 		set_by_naming_series.assert_called_once()
+
+	def test_unrelated_change_does_not_rewrite_toggle_setters(self):
+		settings = frappe.get_single("Selling Settings")
+		settings.allow_multiple_items = not settings.allow_multiple_items
+
+		with patch(
+			"erpnext.selling.doctype.selling_settings.selling_settings.make_property_setter"
+		) as make_property_setter:
+			settings.save()
+
+		make_property_setter.assert_not_called()
+
+	def test_toggle_setters_rewritten_when_related_settings_change(self):
+		settings = frappe.get_single("Selling Settings")
+		settings.hide_tax_id = not settings.hide_tax_id
+		settings.editable_bundle_item_rates = not settings.editable_bundle_item_rates
+		settings.enable_discount_accounting = not settings.enable_discount_accounting
+
+		with patch(
+			"erpnext.selling.doctype.selling_settings.selling_settings.make_property_setter"
+		) as make_property_setter:
+			settings.save()
+
+		self.assertEqual(make_property_setter.call_count, 11)


### PR DESCRIPTION
## What changed

- Rewrite the tax_id, bundle-rate, and discount-account Property Setters only when their driving setting changes.
- Align `sales_invoice.json` and `sales_invoice_item.json` with the state the toggles wrote at default values.
- Add tests for changed and unchanged settings.

## Why

Follows #58018 and #58031. Every Selling Settings save reran the three `on_update` toggles, rewriting 11 Property Setters and clearing the meta cache of five DocTypes.

Builds on #58031 — merge that first; this diff reduces to the last two commits once it lands.

## Behaviour note

Fresh installs save Selling Settings with pure defaults (`set_single_defaults`), and a Single's first save compares against the defaults doc, so the gated toggles skip there. Two targets disagreed with the JSON at defaults, so the JSONs now carry that state: `tax_id` prints when `hide_tax_id` is off (the toggle has written `print_hide=0` on every saved site since it exists), and both discount account fields are hidden while discount accounting is disabled. Existing sites are unaffected — their Property Setters override the JSON either way.

## Tests

- `pilot -b postgres --site testing.localhost run-tests --module erpnext.selling.doctype.selling_settings.test_selling_settings`
- Commit hooks, Ruff, formatting, and PostgreSQL compatibility checks
