### PR TITLE
feat(stock): multi select item and warehouse filters in warehouse wise item balance

### DIFF
--- a/erpnext/stock/report/stock_analytics/stock_analytics.py
+++ b/erpnext/stock/report/stock_analytics/stock_analytics.py
@@ -270,7 +270,7 @@ def get_chart_data(period_columns):
 def get_items(filters):
 	"Get items based on item code, item group or brand."
 	if item_code := filters.get("item_code"):
-		return [item_code]
+		return [item_code] if isinstance(item_code, str) else list(item_code)
 	else:
 		item_filters = {"is_stock_item": 1}
 		if item_group := filters.get("item_group"):

--- a/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/test_warehouse_wise_item_balance_age_and_value.py
+++ b/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/test_warehouse_wise_item_balance_age_and_value.py
@@ -3,7 +3,9 @@
 
 import frappe
 
+from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 from erpnext.stock.report.warehouse_wise_item_balance_age_and_value.warehouse_wise_item_balance_age_and_value import (
 	execute,
 )
@@ -22,6 +24,17 @@ class TestWarehouseWiseItemBalanceAgeAndValue(ERPNextTestSuite):
 		)
 		filters.update(extra)
 		return execute(filters)[1]
+
+	def run_report_with_columns(self, **extra):
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"from_date": "2026-01-01",
+				"to_date": "2026-12-31",
+			}
+		)
+		filters.update(extra)
+		return execute(filters)
 
 	def test_balance_qty_and_value(self):
 		item_code = "_Test Item"
@@ -53,3 +66,58 @@ class TestWarehouseWiseItemBalanceAgeAndValue(ERPNextTestSuite):
 		self.assertEqual(row[6], 6)
 		# index 4 -> total stock value (6 units @ 100)
 		self.assertEqual(row[4], 600)
+
+	def test_multiple_warehouse_filter(self):
+		item_code = make_item(properties={"is_stock_item": 1}).name
+		wh_a = create_warehouse("_Test Multi Balance WH A")
+		wh_b = create_warehouse("_Test Multi Balance WH B")
+
+		make_stock_entry(item_code=item_code, to_warehouse=wh_a, qty=10, rate=100, posting_date="2026-06-01")
+		make_stock_entry(item_code=item_code, to_warehouse=wh_b, qty=25, rate=100, posting_date="2026-06-01")
+
+		columns, data = self.run_report_with_columns(item_code=item_code, warehouse=[wh_a, wh_b])
+
+		# a column per selected warehouse, preceded by the total qty column
+		self.assertEqual(columns[-3:], ["Total Qty:Int:120", f"{wh_a}:Int:100", f"{wh_b}:Int:100"])
+
+		rows = [row for row in data if row[0] == item_code]
+		self.assertEqual(len(rows), 1)
+
+		# [item, item_name, item_group, brand, value, age, total_qty, qty_wh_a, qty_wh_b]
+		row = rows[0]
+		self.assertEqual(row[4], 3500)
+		self.assertEqual(row[-3:], [35, 10, 25])
+
+	def test_group_warehouse_filter_expands_to_children(self):
+		item_code = make_item(properties={"is_stock_item": 1}).name
+		wh_a = create_warehouse("_Test Multi Balance WH A")
+
+		make_stock_entry(item_code=item_code, to_warehouse=wh_a, qty=10, rate=100, posting_date="2026-06-01")
+
+		columns, data = self.run_report_with_columns(
+			item_code=item_code, warehouse=["_Test Warehouse Group - _TC"]
+		)
+
+		self.assertIn(f"{wh_a}:Int:100", columns)
+
+		rows = [row for row in data if row[0] == item_code]
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0][columns.index(f"{wh_a}:Int:100")], 10)
+
+	def test_multiple_item_filter(self):
+		item_a = make_item(properties={"is_stock_item": 1}).name
+		item_b = make_item(properties={"is_stock_item": 1}).name
+		item_c = make_item(properties={"is_stock_item": 1}).name
+		warehouse = create_warehouse("_Test Multi Balance WH A")
+
+		for item_code, qty in ((item_a, 10), (item_b, 25), (item_c, 7)):
+			make_stock_entry(
+				item_code=item_code, to_warehouse=warehouse, qty=qty, rate=100, posting_date="2026-06-01"
+			)
+
+		data = self.run_report(item_code=[item_a, item_b], warehouse=warehouse)
+
+		balances = {row[0]: row[-1] for row in data}
+		self.assertEqual(balances.get(item_a), 10)
+		self.assertEqual(balances.get(item_b), 25)
+		self.assertNotIn(item_c, balances)

--- a/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.js
+++ b/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.js
@@ -38,21 +38,49 @@ frappe.query_reports["Warehouse wise Item Balance Age and Value"] = {
 		{
 			fieldname: "item_code",
 			label: __("Item"),
-			fieldtype: "Link",
+			fieldtype: "MultiSelectList",
 			width: "80",
 			options: "Item",
+			get_data: async function (txt) {
+				const item_group = frappe.query_report.get_filter_value("item_group");
+
+				let { message: data } = await frappe.call({
+					method: "erpnext.controllers.queries.item_query",
+					args: {
+						doctype: "Item",
+						txt: txt,
+						searchfield: "name",
+						start: 0,
+						page_len: 10,
+						filters: {
+							...(item_group && { item_group }),
+							is_stock_item: 1,
+						},
+						as_dict: 1,
+					},
+				});
+
+				data = data.map(({ name, ...rest }) => {
+					return {
+						value: name,
+						description: Object.values(rest),
+					};
+				});
+
+				return data || [];
+			},
 		},
 		{
 			fieldname: "warehouse",
 			label: __("Warehouse"),
-			fieldtype: "Link",
+			fieldtype: "MultiSelectList",
 			width: "80",
 			options: "Warehouse",
-			get_query: function () {
+			get_data: function (txt) {
 				const company = frappe.query_report.get_filter_value("company");
-				return {
-					filters: { company: company },
-				};
+				return frappe.db.get_link_options("Warehouse", txt, {
+					...(company && { company }),
+				});
 			},
 		},
 		{

--- a/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.py
+++ b/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.py
@@ -7,6 +7,7 @@
 
 import frappe
 from frappe import _
+from frappe.query_builder import Criterion
 from frappe.query_builder.functions import Count
 from frappe.utils import cint, flt, getdate
 
@@ -115,7 +116,8 @@ def validate_filters(filters):
 
 
 def get_warehouse_list(filters):
-	if not filters.get("warehouse"):
+	warehouses = filters.get("warehouse")
+	if not warehouses:
 		return frappe.get_all(
 			"Warehouse",
 			filters={"company": filters.get("company"), "is_group": 0},
@@ -123,13 +125,22 @@ def get_warehouse_list(filters):
 			order_by="name",
 		)
 
+	if isinstance(warehouses, str):
+		warehouses = [warehouses]
+
+	# columns cover every selected warehouse along with its descendants
+	subtrees = frappe.get_all("Warehouse", filters={"name": ("in", warehouses)}, fields=["lft", "rgt"])
+	if not subtrees:
+		return []
+
 	warehouse = frappe.qb.DocType("Warehouse")
-	lft, rgt = frappe.db.get_value("Warehouse", filters.get("warehouse"), ["lft", "rgt"])
+	condition = Criterion.any([(warehouse.lft >= row.lft) & (warehouse.rgt <= row.rgt) for row in subtrees])
 
 	return (
 		frappe.qb.from_(warehouse)
-		.select("name")
-		.where((warehouse.lft >= lft) & (warehouse.rgt <= rgt))
+		.select(warehouse.name)
+		.where(condition)
+		.orderby(warehouse.name)
 		.run(as_dict=True)
 	)
 


### PR DESCRIPTION
**Description:**
The item and warehouse filters on Warehouse wise Item Balance Age and Value accepted one value at a time, so comparing a few warehouses meant re-running the report per warehouse.

Both are MultiSelectList now, matching the Stock Balance report. The warehouse column list unions the subtree of every selected warehouse, and get_items() passes a list through instead of wrapping it. Plain string values still work, so saved filters and existing callers are unaffected.

Closes #57858

<img width="1652" height="408" alt="image" src="https://github.com/user-attachments/assets/aa546481-a793-4fcb-a3a3-65eaaaa79cb4" />

<img width="1652" height="415" alt="image" src="https://github.com/user-attachments/assets/d8580815-c2d2-41f0-afc9-3e0e78d50e3a" />

no-docs