### PR TITLE
fix: run Lead lifecycle during transaction deletion

### DIFF
--- a/erpnext/setup/doctype/transaction_deletion_record/test_transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/test_transaction_deletion_record.py
@@ -72,6 +72,67 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 		tasks_containing_company = frappe.get_all("Task", filters={"company": "_Test Company 7"})
 		self.assertEqual(tasks_containing_company, [])
 
+	def test_lead_deletion_uses_document_lifecycle(self):
+		company = "_Test Company 7"
+		lead = frappe.get_doc(
+			{"doctype": "Lead", "first_name": "_Test Transaction Deletion Lead", "company": company}
+		).insert()
+		contact = frappe.get_doc(
+			{
+				"doctype": "Contact",
+				"first_name": "_Test Transaction Deletion Contact",
+				"links": [
+					{"link_doctype": "Lead", "link_name": lead.name},
+					{"link_doctype": "Customer", "link_name": "_Test Customer"},
+				],
+			}
+		).insert()
+		address = frappe.get_doc(
+			{
+				"doctype": "Address",
+				"address_title": "_Test Transaction Deletion Address",
+				"address_type": "Office",
+				"address_line1": "_Test Address Line",
+				"city": "_Test City",
+				"country": "India",
+				"links": [{"link_doctype": "Lead", "link_name": lead.name}],
+			}
+		).insert()
+
+		create_and_submit_transaction_deletion_doc(company)
+
+		self.assertFalse(frappe.db.exists("Lead", lead.name))
+		self.assertFalse(frappe.db.exists("Address", address.name))
+		self.assertTrue(frappe.db.exists("Contact", contact.name))
+		self.assertFalse(
+			frappe.db.exists(
+				"Dynamic Link",
+				{
+					"parent": contact.name,
+					"parenttype": "Contact",
+					"link_doctype": "Lead",
+					"link_name": lead.name,
+				},
+			)
+		)
+		self.assertTrue(
+			frappe.db.exists(
+				"Dynamic Link",
+				{
+					"parent": contact.name,
+					"parenttype": "Contact",
+					"link_doctype": "Customer",
+					"link_name": "_Test Customer",
+				},
+			)
+		)
+		self.assertTrue(
+			frappe.db.exists("Deleted Document", {"deleted_doctype": "Lead", "deleted_name": lead.name})
+		)
+		self.assertTrue(
+			frappe.db.exists("Deleted Document", {"deleted_doctype": "Address", "deleted_name": address.name})
+		)
+
 	def test_company_transaction_deletion_request(self):
 		"""Test creation via company deletion request method"""
 		from erpnext.setup.doctype.company.company import create_transaction_deletion_request

--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
@@ -687,7 +687,6 @@ class TransactionDeletionRecord(Document):
 		self.enqueue_task(task="Delete Leads and Addresses")
 
 	def delete_lead_addresses(self):
-		"""Delete addresses to which leads are linked"""
 		self.validate_doc_status()
 		if self.delete_leads_and_addresses_status == "Pending":
 			if not self._is_any_doctype_in_deletion_list(["Lead"]):
@@ -696,36 +695,7 @@ class TransactionDeletionRecord(Document):
 				return
 
 			leads = frappe.db.get_all("Lead", filters={"company": self.company}, pluck="name")
-			addresses = []
 			if leads:
-				addresses = frappe.db.get_all(
-					"Dynamic Link", filters={"link_name": ("in", leads)}, pluck="parent"
-				)
-				if addresses:
-					address = qb.DocType("Address")
-					dl1 = qb.DocType("Dynamic Link")
-					dl2 = qb.DocType("Dynamic Link")
-
-					qb.from_(address).delete().where(
-						(address.name.isin(addresses))
-						& (
-							address.name.notin(
-								qb.from_(dl1)
-								.join(dl2)
-								.on((dl1.parent == dl2.parent) & (dl1.link_doctype != dl2.link_doctype))
-								.select(dl1.parent)
-								.distinct()
-							)
-						)
-					).run()
-
-					dynamic_link = qb.DocType("Dynamic Link")
-					qb.from_(dynamic_link).delete().where(
-						(dynamic_link.link_doctype == "Lead")
-						& (dynamic_link.parenttype == "Address")
-						& (dynamic_link.link_name.isin(leads))
-					).run()
-
 				customer = qb.DocType("Customer")
 				qb.update(customer).set(customer.lead_name, None).where(customer.lead_name.isin(leads)).run()
 
@@ -820,14 +790,17 @@ class TransactionDeletionRecord(Document):
 
 						reference_doc_names = [r.name for r in reference_docs]
 
-						self.delete_version_log(docfield.doctype_name, reference_doc_names)
-						self.delete_communications(docfield.doctype_name, reference_doc_names)
-						self.delete_comments(docfield.doctype_name, reference_doc_names)
-						self.unlink_attachments(docfield.doctype_name, reference_doc_names)
-						self.delete_child_tables(docfield.doctype_name, reference_doc_names)
-						self.delete_docs_linked_with_specified_company(
-							docfield.doctype_name, reference_doc_names
-						)
+						if docfield.doctype_name == "Lead":
+							frappe.delete_doc("Lead", reference_doc_names, ignore_permissions=True)
+						else:
+							self.delete_version_log(docfield.doctype_name, reference_doc_names)
+							self.delete_communications(docfield.doctype_name, reference_doc_names)
+							self.delete_comments(docfield.doctype_name, reference_doc_names)
+							self.unlink_attachments(docfield.doctype_name, reference_doc_names)
+							self.delete_child_tables(docfield.doctype_name, reference_doc_names)
+							self.delete_docs_linked_with_specified_company(
+								docfield.doctype_name, reference_doc_names
+							)
 						processed = int(docfield.no_of_docs) + len(reference_doc_names)
 						frappe.db.set_value(docfield.doctype, docfield.name, "no_of_docs", processed)
 					else:


### PR DESCRIPTION
## Summary

Use the standard Lead deletion lifecycle during company transaction deletion so linked Contacts and Addresses are cleaned up correctly and deleted Leads are recorded in Deleted Document.

Ticket: https://support.frappe.io/helpdesk/tickets/74860?view=VIEW-HD+Ticket-1547