### PR TITLE
fix: set auto reserve stock flag before packing list generation

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -238,6 +238,9 @@ class SalesOrder(SellingController):
 
 			validate_coupon_code(self.coupon_code)
 
+		if not self.get("is_subcontracted"):
+			SalesOrderStockReservation(self).enable_auto_reserve_stock()
+
 		make_packing_list(self)
 
 		self.validate_with_previous_doc()
@@ -247,8 +250,6 @@ class SalesOrder(SellingController):
 		StatusService(self).set_default_statuses()
 
 		self.reset_default_field_value("set_warehouse", "items", "warehouse")
-		if not self.get("is_subcontracted"):
-			SalesOrderStockReservation(self).enable_auto_reserve_stock()
 
 	def set_has_unit_price_items(self):
 		"""


### PR DESCRIPTION
With `auto_reserve_stock` enabled, saving a new Sales Order containing a Product Bundle checked `reserve_stock` on the order and its items, but not on the packed items.

`enable_auto_reserve_stock` ran at the end of `validate`, after `make_packing_list`, so packed rows were stamped while the parent flag was still unset. Since the stamping in `packed_item.py` is gated on `doc.is_new()`, later saves could not repair the rows either — only the client-side toggle propagated the flag. Moving the auto-enable ahead of packing list generation stamps packed rows correctly on first save.