### PR TITLE
fix: mirror rounding adjustment on distributed_discount_amount

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -938,8 +938,9 @@ class calculate_taxes_and_totals:
 						item.net_amount = flt(
 							item.net_amount + rounding_difference, item.precision("net_amount")
 						)
+						# net_amount went up by rounding_difference, so its discount share goes down
 						item.distributed_discount_amount = flt(
-							distributed_amount + rounding_difference,
+							distributed_amount - rounding_difference,
 							item.precision("distributed_discount_amount"),
 						)
 						net_total += rounding_difference

--- a/erpnext/controllers/tests/test_distributed_discount.py
+++ b/erpnext/controllers/tests/test_distributed_discount.py
@@ -60,6 +60,30 @@ class TestTaxesAndTotals(ERPNextTestSuite):
 		self.assertAlmostEqual(so.net_total, 1272.73, places=2)
 		self.assertEqual(so.grand_total, 1400)
 
+	@ERPNextTestSuite.change_settings("Selling Settings", {"allow_multiple_items": 1})
+	def test_distributed_discount_amount_with_rounding_adjustment(self):
+		so = make_sales_order(do_not_save=1)
+		so.apply_discount_on = "Net Total"
+		so.discount_amount = 10
+		so.items[0].qty = 1
+		so.items[0].rate = 100
+		so.append("items", so.items[0].as_dict())
+		so.append("items", so.items[0].as_dict())
+		so.save()
+
+		calculate_taxes_and_totals(so)
+
+		# the rounding adjustment lands on the second line
+		self.assertAlmostEqual(so.items[1].net_amount, 96.66, places=2)
+		self.assertAlmostEqual(so.items[1].distributed_discount_amount, 3.34, places=2)
+
+		for item in so.items:
+			self.assertAlmostEqual(item.amount - item.distributed_discount_amount, item.net_amount, places=2)
+		self.assertAlmostEqual(
+			sum(i.distributed_discount_amount for i in so.items), so.discount_amount, places=2
+		)
+		self.assertEqual(so.net_total, 290)
+
 	def test_100_percent_discount_with_inclusive_tax(self):
 		"""Test that 100% discount with inclusive taxes results in zero net_total"""
 		so = make_sales_order(do_not_save=1)


### PR DESCRIPTION
## Summary
- When distributing a document-level discount, the per-line rounding adjustment was added to both `net_amount` and `distributed_discount_amount`. Those fields are linked by subtraction (`net_amount = amount − distributed_discount_amount`), so the discount share must move the opposite way.
- Fixes the stored discount shares (and GL income when Discount Accounting is enabled) while leaving `net_amount` / taxes / totals unchanged.
- Adds a regression test for the three equal-line case that hits the rounding-adjustment path (existing tests never did).

Closes https://github.com/frappe/erpnext/issues/58042

Credit: @HenningWendtland for the diagnosis and proposed fix.

## Test plan
- [x] `bench --site test-site-dev run-tests --app erpnext --module erpnext.controllers.tests.test_distributed_discount`
- [x] Manual: Sales Invoice with 3 items @ qty 1 / rate 100, Apply Discount On = Net Total, Discount Amount = 10 → item discounts `3.33 / 3.34 / 3.33`, each satisfying `amount − distributed_discount_amount == net_amount`, shares sum to 10
- [x] With Discount Accounting + Additional Discount Account: income GL credits full pre-discount amount (no cents absorbed by Round Off from this field)