### PR TITLE
fix(manufacturing): preserve BOM Creator item details

### DIFF
--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.js
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.js
@@ -208,13 +208,6 @@ frappe.ui.form.on("BOM Creator", {
 });
 
 frappe.ui.form.on("BOM Creator Item", {
-	item_code(frm, cdt, cdn) {
-		let item = frappe.get_doc(cdt, cdn);
-		if (item.item_code && item.is_root) {
-			frappe.model.set_value(cdt, cdn, "fg_item", item.item_code);
-		}
-	},
-
 	do_not_explode(frm, cdt, cdn) {
 		let item = frappe.get_doc(cdt, cdn);
 		if (!item.do_not_explode) {
@@ -237,6 +230,20 @@ frappe.ui.form.on("BOM Creator Item", {
 });
 
 erpnext.bom.BomConfigurator = class BomConfigurator extends erpnext.TransactionController {
+	item_code(doc, cdt, cdn) {
+		if (cdt !== "BOM Creator Item") {
+			return;
+		}
+
+		let item = frappe.get_doc(cdt, cdn);
+		if (item.item_code && item.is_root) {
+			frappe.model.set_value(cdt, cdn, "fg_item", item.item_code);
+		}
+
+		// BOM Creator does not support TransactionController's server-side item selection.
+		return this.process_item_selection(doc, cdt, cdn);
+	}
+
 	conversion_rate(doc) {
 		if (this.frm.doc.currency === this.get_company_currency()) {
 			this.frm.set_value("conversion_rate", 1.0);

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -79,7 +79,7 @@ def _preprocess_ctx(ctx):
 @erpnext.normalize_ctx_input(ItemDetailsCtx)
 def get_item_details(
 	ctx: ItemDetailsCtx,
-	doc: Document | str | None = None,
+	doc: Document | str | dict | None = None,
 	for_validate: bool | None = False,
 	overwrite_warehouse: bool = True,
 ):


### PR DESCRIPTION
## Problem

Selecting an item in the BOM Creator grid calls the inherited server-side item selection method. `BOMCreator` is a plain `Document`, so it does not implement that method.

Suppressing the inherited handler also suppresses item details, rates, UOM values, and conversion factors.

## Solution

- Override the BOM Creator item handler and ignore the parent item field.
- Use the existing client-side item selection flow for BOM Creator rows.
- Preserve the finished-good mapping for the root row.
- Accept the serialized document dictionary in `get_item_details`.

This PR supersedes #58046.

## Validation

- Prettier
- ESLint
- Ruff import sorter, linter, and formatter
- PostgreSQL compatibility static check
- Manual BOM Creator item selection, rate, UOM, and conversion-factor verification
