### PR TITLE
fix(selling): reset stale item details on item change

### DIFF
--- a/erpnext/controllers/tests/test_reactivity.py
+++ b/erpnext/controllers/tests/test_reactivity.py
@@ -46,3 +46,39 @@ class TestReactivity(ERPNextTestSuite):
 			with self.subTest(field=field):
 				self.assertIsNotNone(itm.get(field[0]))
 		si.save().submit()
+
+	def test_item_change_clears_stale_item_details(self):
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		old_item = make_item(properties={"is_stock_item": 0, "stock_uom": "Nos"})
+		new_item = make_item(
+			properties={
+				"is_stock_item": 0,
+				"stock_uom": "Kg",
+				"weight_per_unit": 2,
+				"weight_uom": "Kg",
+			}
+		)
+		sales_order = make_sales_order(item_code=old_item.name, do_not_submit=True)
+
+		item = sales_order.items[0]
+		self.assertEqual(item.uom, "Nos")
+		row_state = (item.qty, item.warehouse, item.delivery_date)
+
+		sales_order.ignore_pricing_rule = 1
+		item.weight_per_unit = 10
+		item.weight_uom = "Nos"
+		item.barcode = "OLD-BARCODE"
+		item.pricing_rules = "OLD-PRICING-RULE"
+		item.item_code = new_item.name
+		sales_order.process_item_selection(item.idx)
+
+		self.assertEqual(item.uom, "Kg")
+		self.assertEqual(item.stock_uom, "Kg")
+		self.assertEqual(item.conversion_factor, 1)
+		self.assertEqual(item.weight_per_unit, 2)
+		self.assertEqual(item.weight_uom, "Kg")
+		self.assertIsNone(item.barcode)
+		self.assertFalse(item.pricing_rules)
+		self.assertEqual((item.qty, item.warehouse, item.delivery_date), row_state)

--- a/erpnext/controllers/tests/test_reactivity.py
+++ b/erpnext/controllers/tests/test_reactivity.py
@@ -72,7 +72,7 @@ class TestReactivity(ERPNextTestSuite):
 		item.barcode = "OLD-BARCODE"
 		item.pricing_rules = "OLD-PRICING-RULE"
 		item.item_code = new_item.name
-		sales_order.process_item_selection(item.idx)
+		sales_order.process_item_selection(item.idx, reset_item_details=True)
 
 		self.assertEqual(item.uom, "Kg")
 		self.assertEqual(item.stock_uom, "Kg")
@@ -82,3 +82,25 @@ class TestReactivity(ERPNextTestSuite):
 		self.assertIsNone(item.barcode)
 		self.assertFalse(item.pricing_rules)
 		self.assertEqual((item.qty, item.warehouse, item.delivery_date), row_state)
+
+	def test_programmatic_item_selection_preserves_explicit_uom(self):
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		item = make_item(
+			properties={
+				"is_stock_item": 0,
+				"stock_uom": "Kg",
+				"sales_uom": "Nos",
+				"weight_per_unit": 2,
+				"weight_uom": "Kg",
+			},
+			uoms=[{"uom": "Nos", "conversion_factor": 10}],
+		)
+		sales_invoice = create_sales_invoice(item_code=item.name, uom="Kg", do_not_save=True)
+
+		sales_invoice.process_item_selection(sales_invoice.items[0].idx)
+
+		self.assertEqual(sales_invoice.items[0].uom, "Kg")
+		self.assertEqual(sales_invoice.items[0].conversion_factor, 1)
+		self.assertEqual(sales_invoice.items[0].stock_qty, sales_invoice.items[0].qty)

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -783,6 +783,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				method: "process_item_selection",
 				args: {
 					item_idx: item.idx,
+					reset_item_details: true,
 				},
 				callback: function (r) {
 					if (!r.exc) {

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -356,6 +356,17 @@ class TransactionBase(StatusUpdater):
 		if not item_obj.item_code:
 			return
 
+		# Do not carry item-specific values from the previously selected item.
+		for fieldname in (
+			"weight_per_unit",
+			"weight_uom",
+			"uom",
+			"conversion_factor",
+			"barcode",
+			"pricing_rules",
+		):
+			item_obj.set(fieldname, None)
+
 		# 'item_details' has latest item related values
 		item_details = self.fetch_item_details(item_obj)
 

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -349,23 +349,24 @@ class TransactionBase(StatusUpdater):
 		)
 
 	@frappe.whitelist()
-	def process_item_selection(self, item_idx: int):
+	def process_item_selection(self, item_idx: int, reset_item_details: bool = False):
 		# Server side 'item' doc. Update this to reflect in UI
 		item_obj = self.get("items", {"idx": item_idx})[0]
 
 		if not item_obj.item_code:
 			return
 
-		# Do not carry item-specific values from the previously selected item.
-		for fieldname in (
-			"weight_per_unit",
-			"weight_uom",
-			"uom",
-			"conversion_factor",
-			"barcode",
-			"pricing_rules",
-		):
-			item_obj.set(fieldname, None)
+		if cint(reset_item_details):
+			# Do not carry item-specific values from the previously selected item.
+			for fieldname in (
+				"weight_per_unit",
+				"weight_uom",
+				"uom",
+				"conversion_factor",
+				"barcode",
+				"pricing_rules",
+			):
+				item_obj.set(fieldname, None)
 
 		# 'item_details' has latest item related values
 		item_details = self.fetch_item_details(item_obj)


### PR DESCRIPTION
## What changed

- Clear stale item values before the server fetches details for a newly selected item.
- Reset the UOM, conversion factor, weight, barcode, and pricing rules.
- Add a regression test for changing an item on a saved Sales Order.
- Preserve the row quantity, warehouse, and delivery date during the item change.

## Why

The server item-selection path reused values from the previously selected item. `get_item_details` treated the old UOM as an explicit choice and kept it.

The legacy client path already clears these values. This change gives the server path the same behavior.

Forum report: https://discuss.frappe.io/t/uom-not-updating-when-item-is-changed-in-sales-order/139963

## Tests

- `pilot frappe --site testing.localhost run-tests --module erpnext.controllers.tests.test_reactivity`
- `pilot frappe --site testing.localhost run-tests --module erpnext.stock.tests.test_get_item_details`
- `pre-commit run --files erpnext/utilities/transaction_base.py erpnext/controllers/tests/test_reactivity.py`
