### PR TITLE
fix(manufacturing): show full date range in MRP chart

### DIFF
--- a/erpnext/manufacturing/report/material_requirements_planning_report/material_requirements_planning_report.py
+++ b/erpnext/manufacturing/report/material_requirements_planning_report/material_requirements_planning_report.py
@@ -267,22 +267,17 @@ class MaterialRequirementsPlanningReport:
 
 	def get_detailed_view_chart_data(self, data):
 		chart_data = frappe._dict({})
-		i = 0
 
 		sorted_data = sorted(data, key=lambda x: getdate(x.get("delivery_date")))
 		for row in sorted_data:
-			if getdate(row.deliver_date) < getdate(today()):
-				continue
-
 			if not row.delivery_date:
 				continue
 
-			if i == 10:
-				break
+			if getdate(row.delivery_date) < getdate(today()):
+				continue
 
 			delivery_date = formatdate(row.delivery_date, "dd MMM")
 			if delivery_date not in chart_data:
-				i += 1
 				chart_data[delivery_date] = frappe._dict(
 					{
 						"demand": 0.0,


### PR DESCRIPTION
## Problem

The non-bucket Material Requirements Planning chart does not match the report data. The chart stops after the first 10 delivery dates. It can also include past delivery dates.

## Root cause

The detailed chart loop stops when its date counter reaches 10. This truncates the selected date range and can stop before it aggregates every row for the tenth date.

The past-date check reads `row.deliver_date` instead of `row.delivery_date`. A missing key on `frappe._dict` returns `None`, and `getdate(None)` returns the current date. The check therefore does not exclude past delivery dates. The typo does not change the chart label because the label already uses `row.delivery_date`.

## Fix

- Remove the 10-date limit from the detailed chart.
- Check that `delivery_date` exists before comparing it.
- Use `delivery_date` in the past-date check.

## Tests

A regression test will follow in this PR.

Closes #52632