### PR TITLE
fix(manufacturing): show full date range in MRP chart

### DIFF
--- a/erpnext/manufacturing/report/material_requirements_planning_report/material_requirements_planning_report.py
+++ b/erpnext/manufacturing/report/material_requirements_planning_report/material_requirements_planning_report.py
@@ -267,22 +267,17 @@ class MaterialRequirementsPlanningReport:
 
 	def get_detailed_view_chart_data(self, data):
 		chart_data = frappe._dict({})
-		i = 0
 
 		sorted_data = sorted(data, key=lambda x: getdate(x.get("delivery_date")))
 		for row in sorted_data:
-			if getdate(row.deliver_date) < getdate(today()):
-				continue
-
 			if not row.delivery_date:
 				continue
 
-			if i == 10:
-				break
+			if getdate(row.delivery_date) < getdate(today()):
+				continue
 
 			delivery_date = formatdate(row.delivery_date, "dd MMM")
 			if delivery_date not in chart_data:
-				i += 1
 				chart_data[delivery_date] = frappe._dict(
 					{
 						"demand": 0.0,

--- a/erpnext/manufacturing/report/material_requirements_planning_report/material_requirements_planning_report.py
+++ b/erpnext/manufacturing/report/material_requirements_planning_report/material_requirements_planning_report.py
@@ -276,7 +276,7 @@ class MaterialRequirementsPlanningReport:
 			if getdate(row.delivery_date) < getdate(today()):
 				continue
 
-			delivery_date = formatdate(row.delivery_date, "dd MMM")
+			delivery_date = getdate(row.delivery_date)
 			if delivery_date not in chart_data:
 				chart_data[delivery_date] = frappe._dict(
 					{
@@ -293,6 +293,7 @@ class MaterialRequirementsPlanningReport:
 
 		demand_data = []
 		supply_data = []
+		delivery_dates = list(chart_data)
 		for row in chart_data:
 			value = chart_data[row]
 
@@ -301,7 +302,7 @@ class MaterialRequirementsPlanningReport:
 
 		return {
 			"data": {
-				"labels": list(chart_data.keys()),
+				"labels": self.get_detailed_chart_labels(delivery_dates),
 				"datasets": [
 					{
 						"name": _("Demand"),
@@ -318,6 +319,10 @@ class MaterialRequirementsPlanningReport:
 			"colors": ["#7cd6fd", "green"],
 			"title": _("Demand vs Supply"),
 		}
+
+	def get_detailed_chart_labels(self, delivery_dates):
+		date_format = "dd MMM yyyy" if len({date.year for date in delivery_dates}) > 1 else "dd MMM"
+		return [formatdate(date, date_format) for date in delivery_dates]
 
 	def get_bucket_view_chart_data(self, data):
 		chart_data = frappe._dict({})

--- a/erpnext/manufacturing/report/material_requirements_planning_report/test_material_requirements_planning_report.py
+++ b/erpnext/manufacturing/report/material_requirements_planning_report/test_material_requirements_planning_report.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 import frappe
+from frappe.tests.classes.context_managers import freeze_time
 from frappe.utils import add_days, flt, formatdate, today
 
 from erpnext.accounts.doctype.tax_rule.test_tax_rule import make_tax_rule
@@ -23,33 +24,51 @@ TAX_TEMPLATE = "_Test Purchase Taxes and Charges Template - _TC"
 
 class TestMaterialRequirementsPlanningReport(ERPNextTestSuite):
 	def test_detailed_chart_includes_full_date_range(self):
-		start_date = add_days(today(), 1)
-		delivery_dates = [add_days(start_date, offset) for offset in range(12)]
-		rows = [make_chart_row(delivery_date) for delivery_date in delivery_dates]
-		rows.append(make_chart_row(delivery_dates[-1], planned_qty=2))
+		with freeze_time("2026-08-12"):
+			start_date = add_days(today(), 1)
+			delivery_dates = [add_days(start_date, offset) for offset in range(12)]
+			rows = [make_chart_row(delivery_date) for delivery_date in delivery_dates]
+			rows.append(make_chart_row(delivery_dates[-1], planned_qty=2))
 
-		chart = MaterialRequirementsPlanningReport(frappe._dict()).get_detailed_view_chart_data(rows)
+			chart = MaterialRequirementsPlanningReport(frappe._dict()).get_detailed_view_chart_data(rows)
 
-		self.assertEqual(
-			chart["data"]["labels"],
-			[formatdate(delivery_date, "dd MMM") for delivery_date in delivery_dates],
-		)
-		self.assertEqual(chart["data"]["datasets"][0]["values"], [1] * 11 + [3])
+			self.assertEqual(
+				chart["data"]["labels"],
+				[formatdate(delivery_date, "dd MMM") for delivery_date in delivery_dates],
+			)
+			self.assertEqual(chart["data"]["datasets"][0]["values"], [1] * 11 + [3])
+
+	def test_detailed_chart_distinguishes_delivery_dates_across_years(self):
+		with freeze_time("2026-08-12"):
+			delivery_dates = ["2026-08-15", "2027-08-15"]
+			rows = [
+				make_chart_row(delivery_dates[0]),
+				make_chart_row(delivery_dates[1], planned_qty=2),
+			]
+
+			chart = MaterialRequirementsPlanningReport(frappe._dict()).get_detailed_view_chart_data(rows)
+
+			self.assertEqual(
+				chart["data"]["labels"],
+				[formatdate(delivery_date, "dd MMM yyyy") for delivery_date in delivery_dates],
+			)
+			self.assertEqual(chart["data"]["datasets"][0]["values"], [1, 2])
 
 	def test_detailed_chart_excludes_past_and_empty_delivery_dates(self):
-		delivery_dates = [today(), add_days(today(), 1)]
-		rows = [
-			make_chart_row(add_days(today(), -1)),
-			make_chart_row(None),
-			*[make_chart_row(delivery_date) for delivery_date in delivery_dates],
-		]
+		with freeze_time("2026-08-12"):
+			delivery_dates = [today(), add_days(today(), 1)]
+			rows = [
+				make_chart_row(add_days(today(), -1)),
+				make_chart_row(None),
+				*[make_chart_row(delivery_date) for delivery_date in delivery_dates],
+			]
 
-		chart = MaterialRequirementsPlanningReport(frappe._dict()).get_detailed_view_chart_data(rows)
+			chart = MaterialRequirementsPlanningReport(frappe._dict()).get_detailed_view_chart_data(rows)
 
-		self.assertEqual(
-			chart["data"]["labels"],
-			[formatdate(delivery_date, "dd MMM") for delivery_date in delivery_dates],
-		)
+			self.assertEqual(
+				chart["data"]["labels"],
+				[formatdate(delivery_date, "dd MMM") for delivery_date in delivery_dates],
+			)
 
 	def test_manufacture_lead_time_is_not_int_truncated(self):
 		"""lead_time = 1440 / manufacturing_time_in_mins + buffer_time. Both columns are Int;

--- a/erpnext/manufacturing/report/material_requirements_planning_report/test_material_requirements_planning_report.py
+++ b/erpnext/manufacturing/report/material_requirements_planning_report/test_material_requirements_planning_report.py
@@ -2,11 +2,12 @@
 # See license.txt
 
 import frappe
-from frappe.utils import add_days, flt, today
+from frappe.utils import add_days, flt, formatdate, today
 
 from erpnext.accounts.doctype.tax_rule.test_tax_rule import make_tax_rule
 from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom
 from erpnext.manufacturing.report.material_requirements_planning_report.material_requirements_planning_report import (
+	MaterialRequirementsPlanningReport,
 	execute,
 	get_item_lead_time,
 	make_order,
@@ -21,6 +22,35 @@ TAX_TEMPLATE = "_Test Purchase Taxes and Charges Template - _TC"
 
 
 class TestMaterialRequirementsPlanningReport(ERPNextTestSuite):
+	def test_detailed_chart_includes_full_date_range(self):
+		start_date = add_days(today(), 1)
+		delivery_dates = [add_days(start_date, offset) for offset in range(12)]
+		rows = [make_chart_row(delivery_date) for delivery_date in delivery_dates]
+		rows.append(make_chart_row(delivery_dates[-1], planned_qty=2))
+
+		chart = MaterialRequirementsPlanningReport(frappe._dict()).get_detailed_view_chart_data(rows)
+
+		self.assertEqual(
+			chart["data"]["labels"],
+			[formatdate(delivery_date, "dd MMM") for delivery_date in delivery_dates],
+		)
+		self.assertEqual(chart["data"]["datasets"][0]["values"], [1] * 11 + [3])
+
+	def test_detailed_chart_excludes_past_and_empty_delivery_dates(self):
+		delivery_dates = [today(), add_days(today(), 1)]
+		rows = [
+			make_chart_row(add_days(today(), -1)),
+			make_chart_row(None),
+			*[make_chart_row(delivery_date) for delivery_date in delivery_dates],
+		]
+
+		chart = MaterialRequirementsPlanningReport(frappe._dict()).get_detailed_view_chart_data(rows)
+
+		self.assertEqual(
+			chart["data"]["labels"],
+			[formatdate(delivery_date, "dd MMM") for delivery_date in delivery_dates],
+		)
+
 	def test_manufacture_lead_time_is_not_int_truncated(self):
 		"""lead_time = 1440 / manufacturing_time_in_mins + buffer_time. Both columns are Int;
 		integer/integer division truncates on Postgres (1440/7 -> 205) while MariaDB yields a
@@ -81,6 +111,18 @@ class TestMaterialRequirementsPlanningReport(ERPNextTestSuite):
 		self.assertEqual(
 			purchase_order.grand_total, net_total + net_total * flt(template.taxes[0].rate) / 100
 		)
+
+
+def make_chart_row(delivery_date, planned_qty=1):
+	return frappe._dict(
+		{
+			"delivery_date": delivery_date,
+			"planned_qty": planned_qty,
+			"in_hand_qty": 0,
+			"po_ordered_qty": 0,
+			"wo_ordered_qty": 0,
+		}
+	)
 
 
 def make_mrp_plan(test_case, planned_qty=10, rm_qty=2):


### PR DESCRIPTION
## Problem

The non-bucket Material Requirements Planning chart does not match the report data. It stops after the first 10 delivery dates and can include past dates.

## Root cause

The detailed chart loop stops when its date counter reaches 10. This truncates the selected range and can omit rows for the tenth date.

The past-date check reads `row.deliver_date` instead of `row.delivery_date`. A missing key on `frappe._dict` returns `None`. `getdate(None)` returns the current date, so the check does not exclude past dates.

The chart also uses the `dd MMM` label as its aggregation key. This combines matching days from different years into one chart bucket.

## Fix

- Remove the 10-date limit from the detailed chart.
- Check that `delivery_date` exists before comparing it.
- Use `delivery_date` in the past-date check.
- Aggregate by the complete delivery date.
- Include the year in labels when the data spans multiple years.

## Tests

The tests cover more than 10 dates, duplicate-date aggregation, past dates, empty dates, and matching days across years. Date-sensitive tests use frozen time.

```
pilot --bench postgres frappe --site testing.localhost run-tests --module erpnext.manufacturing.report.material_requirements_planning_report.test_material_requirements_planning_report
```

All 6 report tests pass. The targeted pre-commit checks also pass.

## Credit

@soulxone found and wrote the initial logic fix in commit `3c17a60`. This PR preserves that commit and its authorship, then adds regression tests and review fixes.

Closes #52632