### PR TITLE
Fix/asset value adjustment multi finance book

### DIFF
--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -277,7 +277,7 @@ class AssetDepreciationSchedule(Document):
 		value_after_depreciation,
 	):
 		asset_doc.validate_asset_finance_books(row)
-		if not value_after_depreciation:
+		if value_after_depreciation is None:
 			value_after_depreciation = _get_value_after_depreciation_for_making_schedule(asset_doc, row)
 		row.value_after_depreciation = value_after_depreciation
 

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -9,6 +9,7 @@ from frappe.utils import (
 	add_months,
 	add_years,
 	cint,
+	cstr,
 	date_diff,
 	flt,
 	get_first_day,
@@ -276,10 +277,7 @@ class AssetDepreciationSchedule(Document):
 		value_after_depreciation,
 	):
 		asset_doc.validate_asset_finance_books(row)
-		if (
-			not value_after_depreciation
-			and not asset_doc.flags.decrease_in_asset_value_due_to_value_adjustment
-		):
+		if not value_after_depreciation:
 			value_after_depreciation = _get_value_after_depreciation_for_making_schedule(asset_doc, row)
 		row.value_after_depreciation = value_after_depreciation
 
@@ -540,7 +538,10 @@ class AssetDepreciationSchedule(Document):
 
 			if not accumulated_depreciation:
 				if i > 0 and (
-					asset_doc.flags.decrease_in_asset_value_due_to_value_adjustment
+					(
+						asset_doc.flags.decrease_in_asset_value_due_to_value_adjustment
+						and cstr(row.finance_book) == cstr(asset_doc.flags.value_adjustment_finance_book)
+					)
 					or asset_doc.flags.increase_in_asset_value_due_to_repair
 				):
 					accumulated_depreciation = self.get("depreciation_schedule")[
@@ -716,7 +717,9 @@ def get_straight_line_or_manual_depr_amount(
 			number_of_pending_depreciations
 		)
 	# if the Depreciation Schedule is being modified after Asset Value Adjustment due to decrease in asset value
-	elif asset.flags.decrease_in_asset_value_due_to_value_adjustment:
+	elif asset.flags.decrease_in_asset_value_due_to_value_adjustment and cstr(row.finance_book) == cstr(
+		asset.flags.value_adjustment_finance_book
+	):
 		if row.daily_prorata_based:
 			amount = flt(row.value_after_depreciation) - flt(row.expected_value_after_useful_life)
 
@@ -1082,6 +1085,7 @@ def make_new_active_asset_depr_schedules_and_cancel_current_ones(
 	value_after_depreciation=None,
 	ignore_booked_entry=False,
 	difference_amount=None,
+	target_finance_book=None,
 ):
 	for row in asset_doc.get("finance_books"):
 		current_asset_depr_schedule_doc = get_asset_depr_schedule_doc(
@@ -1107,8 +1111,17 @@ def make_new_active_asset_depr_schedules_and_cancel_current_ones(
 			row.rate_of_depreciation = new_rate_of_depreciation
 			new_asset_depr_schedule_doc.rate_of_depreciation = new_rate_of_depreciation
 
+		# value_after_depreciation is an override meant for a single finance book (eg. the book
+		# targeted by an Asset Value Adjustment). Only apply it to that book's row so other
+		# finance books on the same asset keep rebuilding from their own current value.
+		row_value_after_depreciation = (
+			value_after_depreciation
+			if target_finance_book is None or cstr(row.finance_book) == cstr(target_finance_book)
+			else None
+		)
+
 		new_asset_depr_schedule_doc.make_depr_schedule(
-			asset_doc, row, date_of_disposal, value_after_depreciation=value_after_depreciation
+			asset_doc, row, date_of_disposal, value_after_depreciation=row_value_after_depreciation
 		)
 		new_asset_depr_schedule_doc.set_accumulated_depreciation(
 			asset_doc, row, date_of_disposal, date_of_return, ignore_booked_entry

--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -174,6 +174,7 @@ class AssetValueAdjustment(Document):
 		asset = self.update_asset_value_after_depreciation(difference_amount)
 
 		asset.flags.decrease_in_asset_value_due_to_value_adjustment = True
+		asset.flags.value_adjustment_finance_book = self.finance_book
 
 		if self.docstatus == 1:
 			notes = _(
@@ -196,6 +197,7 @@ class AssetValueAdjustment(Document):
 			value_after_depreciation=asset_value,
 			ignore_booked_entry=True,
 			difference_amount=difference_amount,
+			target_finance_book=self.finance_book,
 		)
 		asset.flags.ignore_validate_update_after_submit = True
 		asset.save()

--- a/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
@@ -329,6 +329,61 @@ class TestAssetValueAdjustment(unittest.TestCase):
 		self.assertEqual(asset_doc.finance_books[0].value_after_depreciation, 40000.0)
 		self.assertEqual(asset_doc.finance_books[0].expected_value_after_useful_life, 2000.0)
 
+	def test_asset_value_adjustment_does_not_affect_other_finance_books(self):
+		pr = make_purchase_receipt(item_code="Macbook Pro", qty=1, rate=120000.0, location="Test Location")
+
+		asset_name = frappe.db.get_value("Asset", {"purchase_receipt": pr.name}, "name")
+		asset_doc = frappe.get_doc("Asset", asset_name)
+		asset_doc.calculate_depreciation = 1
+		asset_doc.available_for_use_date = "2023-01-15"
+		asset_doc.purchase_date = "2023-01-15"
+
+		finance_book_row = {
+			"expected_value_after_useful_life": 200,
+			"depreciation_method": "Straight Line",
+			"total_number_of_depreciations": 12,
+			"frequency_of_depreciation": 1,
+			"depreciation_start_date": "2023-01-31",
+		}
+		asset_doc.append("finance_books", {**finance_book_row, "finance_book": "Test Finance Book 1"})
+		asset_doc.append("finance_books", {**finance_book_row, "finance_book": "Test Finance Book 2"})
+		asset_doc.submit()
+
+		other_book_schedule_before = [
+			d.depreciation_amount
+			for d in get_asset_depr_schedule_doc(asset_doc.name, "Active", "Test Finance Book 2").get(
+				"depreciation_schedule"
+			)
+		]
+
+		current_value = get_asset_value_after_depreciation(asset_doc.name, "Test Finance Book 1")
+
+		# adjust only "Test Finance Book 1"
+		adj_doc = make_asset_value_adjustment(
+			asset=asset_doc.name,
+			finance_book="Test Finance Book 1",
+			current_asset_value=current_value,
+			new_asset_value=50000.0,
+			date="2023-08-21",
+		)
+		adj_doc.submit()
+
+		asset_doc.load_from_db()
+		book_1 = next(d for d in asset_doc.finance_books if d.finance_book == "Test Finance Book 1")
+		book_2 = next(d for d in asset_doc.finance_books if d.finance_book == "Test Finance Book 2")
+
+		self.assertEqual(book_1.value_after_depreciation, 50000.0)
+		# "Test Finance Book 2" was never referenced by the adjustment and must be untouched
+		self.assertEqual(book_2.value_after_depreciation, current_value)
+
+		other_book_schedule_after = [
+			d.depreciation_amount
+			for d in get_asset_depr_schedule_doc(asset_doc.name, "Active", "Test Finance Book 2").get(
+				"depreciation_schedule"
+			)
+		]
+		self.assertEqual(other_book_schedule_after, other_book_schedule_before)
+
 
 def make_asset_value_adjustment(**args):
 	args = frappe._dict(args)
@@ -338,6 +393,7 @@ def make_asset_value_adjustment(**args):
 			"doctype": "Asset Value Adjustment",
 			"company": args.company or "_Test Company",
 			"asset": args.asset,
+			"finance_book": args.finance_book,
 			"date": args.date or nowdate(),
 			"new_asset_value": args.new_asset_value,
 			"current_asset_value": args.current_asset_value,


### PR DESCRIPTION
**Description:**
When an Asset has multiple Finance Books (e.g. Companies Act (Ind AS) and Income Tax) and an Asset Value Adjustment is submitted against only one of them, the adjustment incorrectly overwrites the value_after_depreciation (and depreciation schedule) of every finance book on the Asset — including ones never referenced by the adjustment.
This breaks the expected accounting isolation between finance books. Per Ind AS 36 (impairment/revaluation) and Ind AS 12 (deferred tax), an Asset Value Adjustment posted against the Companies Act (Ind AS) book must not affect the Income Tax book, since tax depreciation continues independently under the WDV block method.

  **Steps to reproduce:**
  1. Create an Asset with calculate_depreciation = 1 and two Finance Book rows, e.g. "Companies Act (Ind AS)" and "Income Tax".
  2. Submit the Asset.
  3. Create an Asset Value Adjustment against the "Companies Act (Ind AS)" finance book only, with a new asset value.
  4. Submit it.
  5. Reload the Asset and inspect both finance book rows.

**Before:**

<img width="1298" height="610" alt="image" src="https://github.com/user-attachments/assets/258adc03-19ca-47eb-8aba-3eab41c11d50" />



**After:**

<img width="1254" height="596" alt="image" src="https://github.com/user-attachments/assets/be2c4b1d-62cd-440a-812e-34318682247f" />


