### PR TITLE
fix: allow corrective job card for job cards with a finished good

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -102,6 +102,7 @@ frappe.ui.form.on("Job Card", {
 			doc.track_semi_finished_goods &&
 			doc.docstatus === 1 &&
 			!doc.is_subcontracted &&
+			!doc.is_corrective_job_card &&
 			(doc.skip_material_transfer || doc.transferred_qty > 0) &&
 			flt(doc.manufactured_qty) + flt(doc.process_loss_qty) <
 				flt(doc.for_quantity) - flt(doc.pending_qty);
@@ -165,7 +166,7 @@ frappe.ui.form.on("Job Card", {
 
 		frm.events.setup_material_transfer_buttons(frm, has_items);
 
-		if (doc.docstatus == 1 && !doc.is_corrective_job_card && !doc.finished_good) {
+		if (doc.docstatus == 1 && !doc.is_corrective_job_card) {
 			frm.trigger("setup_corrective_job_card");
 		}
 

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -179,7 +179,7 @@ class JobCard(Document):
 			self.validate_semi_finished_goods()
 
 	def validate_semi_finished_goods(self):
-		if not self.track_semi_finished_goods or self.is_subcontracted:
+		if not self.track_semi_finished_goods or self.is_subcontracted or self.is_corrective_job_card:
 			return
 
 		if self.items and not self.transferred_qty and not self.skip_material_transfer:

--- a/erpnext/manufacturing/doctype/job_card/mapper.py
+++ b/erpnext/manufacturing/doctype/job_card/mapper.py
@@ -185,6 +185,17 @@ def make_corrective_job_card(
 				"field_map": {
 					"name": "for_job_card",
 				},
+				# A corrective job card only reworks an operation, it does not produce the
+				# finished good again, so the production details of the source card are not carried over.
+				"field_no_map": [
+					"finished_good",
+					"semi_fg_bom",
+					"manufactured_qty",
+					"transferred_qty",
+					"total_completed_qty",
+					"process_loss_qty",
+					"pending_qty",
+				],
 			}
 		},
 		target_doc,

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -1288,6 +1288,105 @@ class TestJobCard(ERPNextTestSuite):
 		self.assertEqual(manufacturing_entry.items[2].qty, 9)
 		self.assertEqual(flt(manufacturing_entry.items[2].basic_rate, 3), 5.278)
 
+	@ERPNextTestSuite.change_settings(
+		"Manufacturing Settings", {"add_corrective_operation_cost_in_finished_good_valuation": 1}
+	)
+	def test_corrective_job_card_against_semi_fg_job_card(self):
+		from erpnext.manufacturing.doctype.operation.test_operation import make_operation
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		warehouse = "Stores - _TC"
+		rm = make_item("Corrective JC RM 1", {"is_stock_item": 1}).name
+		fg = make_item("Corrective JC FG 1", {"is_stock_item": 1}).name
+
+		fg_bom = frappe.new_doc(
+			"BOM",
+			company="_Test Company",
+			item=fg,
+			quantity=1,
+			with_operations=1,
+			track_semi_finished_goods=1,
+		)
+		fg_bom.append("items", {"item_code": rm, "qty": 1, "operation_row_id": 1})
+
+		operation = {
+			"operation": "Corrective JC Op A",
+			"workstation": "_Test Workstation A",
+			"finished_good": fg,
+			"finished_good_qty": 1,
+			"is_final_finished_good": 1,
+			"sequence_id": 1,
+			"time_in_mins": 60,
+			"source_warehouse": warehouse,
+			"fg_warehouse": warehouse,
+		}
+		make_workstation(operation)
+		make_operation(operation)
+		fg_bom.append("operations", operation)
+		fg_bom.insert()
+		fg_bom.submit()
+
+		work_order = make_wo_order_test_record(
+			item=fg,
+			qty=5,
+			source_warehouse=warehouse,
+			fg_warehouse=warehouse,
+			bom_no=fg_bom.name,
+			do_not_save=True,
+		)
+		work_order.operations[0].time_in_mins = 60
+		work_order.save()
+		work_order.submit()
+
+		make_stock_entry(item_code=rm, target=warehouse, qty=100, basic_rate=100)
+
+		job_card = frappe.get_doc(
+			"Job Card", frappe.db.get_value("Job Card", {"work_order": work_order.name}, "name")
+		)
+		transfer_entry = make_stock_entry_from_jc(job_card.name)
+		transfer_entry.insert()
+		transfer_entry.submit()
+
+		job_card.reload()
+		job_card.append(
+			"time_logs",
+			{
+				"from_time": "2024-02-01 08:00:00",
+				"to_time": "2024-02-01 09:00:00",
+				"completed_qty": job_card.for_quantity,
+			},
+		)
+		job_card.save()
+		job_card.submit()
+		frappe.get_doc(job_card.make_stock_entry_for_semi_fg_item()).submit()
+
+		corrective_operation = frappe.get_doc(
+			doctype="Operation", is_corrective_operation=1, name=frappe.generate_hash()
+		).insert()
+
+		corrective_job_card = make_corrective_job_card(
+			job_card.name, operation=corrective_operation.name, for_operation=job_card.operation
+		)
+		corrective_job_card.hour_rate = 100
+		corrective_job_card.insert()
+
+		self.assertFalse(corrective_job_card.finished_good)
+		self.assertFalse(flt(corrective_job_card.manufactured_qty))
+
+		corrective_job_card.append(
+			"time_logs",
+			{
+				"from_time": "2024-02-02 08:00:00",
+				"to_time": "2024-02-02 09:00:00",
+				"completed_qty": corrective_job_card.for_quantity,
+			},
+		)
+		corrective_job_card.submit()
+
+		work_order.reload()
+		self.assertEqual(flt(work_order.corrective_operation_cost), 100)
+		self.assertEqual(flt(work_order.produced_qty), 5)
+
 	def test_semi_fg_produced_qty_across_split_job_cards(self):
 		from erpnext.manufacturing.doctype.operation.test_operation import make_operation
 		from erpnext.manufacturing.doctype.work_order.mapper import make_job_card


### PR DESCRIPTION
**Issue:**

The Corrective Job Card option is missing when a Job Card produces a finished good.

**Fixes:** [#58063](https://github.com/frappe/erpnext/issues/58063)

**Steps to replicate:**

1. Create a BOM with operations and enable Track Semi-Finished Goods.
2. Set a finished good on the operation.
3. Create and submit a Work Order for that BOM.
4. Transfer the material, log the time, and submit the Job Card.
5. Create an Operation and tick Is Corrective Operation.
6. Open the submitted Job Card and check the Create menu.


**After:**

<img width="1855" height="931" alt="image" src="https://github.com/user-attachments/assets/d17e6420-791e-4ea7-a61f-581578595e4a" />


**Actual Behaviour:**

- The Corrective Job Card option is not shown.
- Rework done on the job cannot be recorded.
- Its cost never reaches the Work Order.

**Expected behaviour:**

- The Corrective Job Card option is shown.
- The corrective card records only the rework.
- It does not produce the finished good again.
- Its cost is added to the Work Order.


**Backport Needed For V16**