### PR TITLE
Fix/item description in the item price list

### DIFF
--- a/erpnext/stock/doctype/item_price/item_price.json
+++ b/erpnext/stock/doctype/item_price/item_price.json
@@ -89,7 +89,7 @@
   },
   {
    "fieldname": "item_description",
-   "fieldtype": "Text",
+   "fieldtype": "Text Editor",
    "label": "Item Description",
    "read_only": 1
   },
@@ -226,7 +226,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-19 20:27:21.382369",
+ "modified": "2026-08-12 13:14:41.847412",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item Price",

--- a/erpnext/stock/doctype/item_price/item_price.py
+++ b/erpnext/stock/doctype/item_price/item_price.py
@@ -28,7 +28,7 @@ class ItemPrice(Document):
 		currency: DF.Link | None
 		customer: DF.Link | None
 		item_code: DF.Link
-		item_description: DF.Text | None
+		item_description: DF.TextEditor | None
 		item_name: DF.Data | None
 		lead_time_days: DF.Int
 		note: DF.Text | None


### PR DESCRIPTION
## Why
The Item Description field in the Item Price DocType was displaying raw HTML code instead of readable text.
<img width="2880" height="1368" alt="image" src="https://github.com/user-attachments/assets/684d2087-4d18-403a-81cf-1f27a3deaa33" />

## How
Changed the Item Description field type from Text to Text Editor.

## What
The Item Description now displays the formatted text correctly instead of showing the underlying HTML code.
<img width="2880" height="1368" alt="image" src="https://github.com/user-attachments/assets/513aba51-f6c6-467c-a113-1f82c2b9f76b" />

no-docs