### PR TITLE
fix(accounts): disallow reversing a reverse journal entry

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -249,7 +249,7 @@ Object.assign(erpnext.journal_entry, {
 			);
 		}
 
-		if (frm.doc.docstatus == 1) {
+		if (frm.doc.docstatus == 1 && !frm.doc.reversal_of) {
 			frm.add_custom_button(
 				__("Reverse Journal Entry"),
 				() => erpnext.journal_entry.reverse_journal_entry(frm),

--- a/erpnext/accounts/doctype/journal_entry/mapper.py
+++ b/erpnext/accounts/doctype/journal_entry/mapper.py
@@ -222,6 +222,20 @@ def make_inter_company_journal_entry(name: str, voucher_type: str, company: str)
 @frappe.whitelist()
 def make_reverse_journal_entry(source_name: str, target_doc: str | dict | Document | None = None) -> Document:
 	"""Map a submitted Journal Entry to a reversing one (debits and credits swapped)."""
+	# `get_mapped_doc` checks this as well, but the guards below disclose which entry
+	# reverses which, so read access has to be settled before they run
+	if not frappe.has_permission("Journal Entry", doc=source_name):
+		frappe.throw(_("Not permitted"), frappe.PermissionError)
+
+	reversal_of = frappe.db.get_value("Journal Entry", source_name, "reversal_of")
+	if reversal_of:
+		frappe.throw(
+			_("{0} is already a Reverse Journal Entry of {1}. Cancel it instead of reversing it.").format(
+				get_link_to_form("Journal Entry", source_name),
+				get_link_to_form("Journal Entry", reversal_of),
+			)
+		)
+
 	existing_reverse = frappe.db.exists("Journal Entry", {"reversal_of": source_name, "docstatus": 1})
 	if existing_reverse:
 		frappe.throw(

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -301,6 +301,27 @@ class TestJournalEntry(ERPNextTestSuite):
 
 		self.check_gl_entries()
 
+	def test_disallow_reversal_of_a_reversal_journal_entry(self):
+		from erpnext.accounts.doctype.journal_entry.mapper import make_reverse_journal_entry
+
+		jv = make_journal_entry("_Test Bank - _TC", "Sales - _TC", 100, submit=True)
+
+		rjv = make_reverse_journal_entry(jv.name)
+		rjv.posting_date = nowdate()
+		rjv.submit()
+
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"is already a Reverse Journal Entry",
+			make_reverse_journal_entry,
+			rjv.name,
+		)
+
+		# the guard must not disclose the reversal to a user who cannot read the entry
+		frappe.set_user("Guest")
+		self.addCleanup(frappe.set_user, "Administrator")
+		self.assertRaises(frappe.PermissionError, make_reverse_journal_entry, rjv.name)
+
 	def test_disallow_change_in_account_currency_for_a_party(self):
 		# create jv in USD
 		jv = make_journal_entry("_Test Bank USD - _TC", "_Test Receivable USD - _TC", 100, save=False)


### PR DESCRIPTION
**Issue:**

- Exchange Rate Revaluation posts a gain/loss Journal Entry, and it can also post a reversal of that Journal Entry. The problem is that the reversal itself still shows the "Reverse Journal Entry" option — reversing it a second time re-creates the original gain/loss entry, so the same amount is posted twice in your books.

**Fixes:** [#58086](https://github.com/frappe/erpnext/issues/58086)

**Steps to Reproduce:**

1. Create an Exchange Rate Revaluation and submit it.
2. Click **Create → Journal Entries** to post the gain/loss entry.
3. Click **Create → Reversal Journal Entries** and submit the reversal.
4. Open that reversal entry and check the **Actions** menu.

**Actual Behaviour:**

The **Reverse Journal Entry** option is still there, and using it creates a copy of the original entry — so the same gain or loss gets recorded twice, and the Exchange Rate Revaluation screen shows nothing wrong.

**Expected Behaviour:**

An entry that is already a reversal should not be offered for reversal; you cancel it instead.

**Backport Needed For V15 and v16**