### PR TITLE
fix(accounts): attributeerror on budget against a non profit and loss account

### DIFF
--- a/erpnext/accounts/doctype/budget/budget.py
+++ b/erpnext/accounts/doctype/budget/budget.py
@@ -98,13 +98,13 @@ class Budget(Document):
 					frappe.throw(_("Budget cannot be assigned against Group Account {0}").format(d.account))
 				elif account_details.company != self.company:
 					frappe.throw(
-						_("Account {0} does not belongs to company {1}").format(d.account, self.company)
+						_("Account {0} does not belong to company {1}").format(d.account, self.company)
 					)
 				elif account_details.report_type != "Profit and Loss":
 					frappe.throw(
 						_(
 							"Budget cannot be assigned against {0}, as its Root Type is not of Income or Expense"
-						).format(self.account)
+						).format(d.account)
 					)
 
 				if d.account in account_list:

--- a/erpnext/accounts/doctype/budget/test_budget.py
+++ b/erpnext/accounts/doctype/budget/test_budget.py
@@ -357,6 +357,16 @@ class TestBudget(unittest.TestCase):
 
 		self.assertRaises(BudgetError, jv.submit)
 
+	def test_budget_against_balance_sheet_account(self):
+		budget = frappe.new_doc("Budget")
+		budget.budget_against = "Cost Center"
+		budget.cost_center = "_Test Cost Center - _TC"
+		budget.company = "_Test Company"
+		budget.fiscal_year = get_fiscal_year(nowdate())[0]
+		budget.append("accounts", {"account": "_Test Bank - _TC", "budget_amount": 200000})
+
+		self.assertRaisesRegex(frappe.ValidationError, "_Test Bank - _TC", budget.insert)
+
 
 def set_total_expense_zero(posting_date, budget_against_field=None, budget_against_CC=None):
 	if budget_against_field == "project":


### PR DESCRIPTION
**Issue:**

- On v15, a Budget saved with a non-Income/Expense account in the Budget Accounts table crashes with AttributeError: 'Budget' object has no attribute 'account' instead of showing the validation message. The Budget can't be saved, and the user is never told what's wrong with the account.

- Cause: inside the loop over the accounts child table, the "not Profit and Loss" branch formats its message with **self. account**, but Budget has no parent account field on v15 — only the accounts table.

Fixes: [#58085](https://github.com/frappe/erpnext/issues/58085)