### PR TITLE
fix: recalculate incoming rate on amended warehouse change

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -514,14 +514,12 @@ class SellingController(StockController):
 
 	def set_incoming_rate(self):
 		def reset_incoming_rate():
+			old_items = old_doc.get("items") + (old_doc.get("packed_items") or [])
 			old_item = next(
-				(
-					item
-					for item in (old_doc.get("items") + (old_doc.get("packed_items") or []))
-					if item.name == d.name
-				),
-				None,
+				(item for item in old_items if item.name == (d.get("_amended_from") or d.name)), None
 			)
+			if not old_item and self.is_new() and self.amended_from:
+				old_item = next((item for item in old_items if item.idx == d.idx), None)
 			if old_item:
 				old_qty = flt(old_item.get("stock_qty") or old_item.get("actual_qty") or old_item.get("qty"))
 				if (
@@ -555,6 +553,9 @@ class SellingController(StockController):
 		is_standalone = self.is_return and not self.return_against
 
 		old_doc = self.get_doc_before_save()
+		if not old_doc and self.amended_from:
+			old_doc = frappe.get_doc(self.doctype, self.amended_from)
+
 		items = self.get("items") + (self.get("packed_items") or [])
 		for d in items:
 			if not frappe.get_cached_value("Item", d.item_code, "is_stock_item"):


### PR DESCRIPTION
Changes:
- Recalculate incoming_rate in amended doctype.
- When we cancel, then amend a doctype, and then change the warehouse incoming rate would not get recalculated, but now it does.

Ticket:https://support.frappe.io/helpdesk/tickets/76059?view=VIEW-HD+Ticket-1547


Before changes:
Cancelled doc:
<img width="2912" height="1600" alt="image" src="https://github.com/user-attachments/assets/4073d13e-c79d-4bc3-a284-eac9c0cd2b25" />
Amended doc:
<img width="2912" height="1530" alt="image" src="https://github.com/user-attachments/assets/490703bb-4f99-40d9-899a-86a865d19cd1" />


After changes:
Cancelled doc:
<img width="2912" height="1463" alt="image" src="https://github.com/user-attachments/assets/5ca7a28e-2b2e-4b6d-b0ef-08d4b8ee4e0c" />
Amended doc:
<img width="2912" height="1374" alt="image" src="https://github.com/user-attachments/assets/2765d4c0-51fa-4940-b21c-d1ef2d6f03ae" />

