### PR TITLE
fix: Qty and UOM not fetched when adding Item in Material Request

### DIFF
--- a/erpnext/__init__.py
+++ b/erpnext/__init__.py
@@ -177,7 +177,12 @@ def normalize_ctx_input(T: type) -> callable:
 
 	def decorator(func: callable):
 		# conserve annotations for frappe.utils.typing_validations
-		@functools.wraps(func, assigned=(a for a in functools.WRAPPER_ASSIGNMENTS if a != "__annotations__"))
+		@functools.wraps(
+			func,
+			assigned=(
+				a for a in functools.WRAPPER_ASSIGNMENTS if a not in ("__annotations__", "__annotate__")
+			),
+		)
 		def wrapper(ctx: T | Document | dict | str, *args, **kwargs):
 			if isinstance(ctx, Document):
 				ctx = T(**ctx.as_dict())


### PR DESCRIPTION
On Python 3.14, \`functools.wraps\` also copies \`__annotate__\` (PEP 649 lazy annotations). \`normalize_ctx_input\` only excluded \`__annotations__\`, so the wrapped function's lazily-evaluated \`__annotate__\` overrode the manually patched \`__annotations__\`, leaving \`ctx\` typed as plain \`ItemDetailsCtx\` instead of the \`| str\` union.

This made frappe's type validation reject \`ctx\` whenever it arrived as a JSON string, crashing \`get_item_details\` — so adding an Item row in Material Request (Purchase) never fetched Qty/UOM.

Fix: exclude \`__annotate__\` too, matching \`develop\`.