### PR TITLE
fix(stock): confirm before changing item qty from the batch selector

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -671,6 +671,27 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 			frappe.throw(__("Rejected Warehouse and Accepted Warehouse cannot be the same."));
 		}
 
+		let qty_to_fetch = flt(this.dialog.get_value("qty"));
+		let total_qty = entries.reduce((total, row) => total + (flt(row.qty) || 1.0), 0);
+
+		if (flt(total_qty, 6) !== flt(qty_to_fetch, 6)) {
+			const confirm_dialog = frappe.confirm(
+				__(
+					"<strong>Total qty</strong> of the rows (<strong>{0}</strong>) does not match the <strong>Qty to Fetch</strong> (<strong>{1}</strong>). Qty of the item will be changed to <strong>{0}</strong>. Are you sure want to proceed?",
+					[format_number(total_qty), format_number(qty_to_fetch)]
+				),
+				() => this.create_bundle_entries(entries, warehouse)
+			);
+			confirm_dialog.indicator = "blue";
+			confirm_dialog.set_indicator();
+
+			return;
+		}
+
+		this.create_bundle_entries(entries, warehouse);
+	}
+
+	create_bundle_entries(entries, warehouse) {
 		frappe
 			.call({
 				method: "erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.add_serial_batch_ledgers",


### PR DESCRIPTION
**Issue:**
The batch selector callback overwrites the item qty with the bundle total (sales_common.js sets qty = r.total_qty), so any row edited inside the Select Batch No dialog silently changed the delivered qty. Fetching 20 and hand-editing one batch row from 4.590 to 7.590 turned the Delivery Note into 22.390 with no warning at all. update_bundle_entries() now compares the total of the dialog rows against Qty to Fetch and asks for confirmation before creating the bundle, following the existing posting-date confirm pattern. Yes proceeds and updates the item qty, No leaves the item and the dialog untouched.

**Ref:** [#75774](https://support.frappe.io/helpdesk/tickets/75774)

<img width="973" height="797" alt="image" src="https://github.com/user-attachments/assets/a92bc0db-ea72-4e7a-a79e-d3220fda59d9" />


**Backport Needed for v15 & v16**