### PR TITLE
fix(pos): don't scope item search to one arbitrary permitted item group

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -123,12 +123,7 @@ def filter_result_items(result, pos_profile):
 
 @frappe.whitelist()
 def get_parent_item_group(pos_profile: str):
-	item_groups = get_item_groups(pos_profile)
-
-	if not item_groups:
-		item_groups = frappe.get_all("Item Group", {"lft": 1, "is_group": 1}, pluck="name")
-
-	return item_groups[0] if item_groups else None
+	return get_root_of("Item Group")
 
 
 @frappe.whitelist()

--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -240,7 +240,6 @@ erpnext.PointOfSale.ItemSelector = class {
 				only_select: true,
 				onchange: function () {
 					me.item_group = this.value;
-					!me.item_group && (me.item_group = me.parent_item_group);
 					me.filter_items();
 					me.set_item_selector_filter_label(this.value);
 				},


### PR DESCRIPTION

**Issue:**
In POS (Point of Sale), when no Item Group is explicitly selected, item search unexpectedly returns only a subset of items instead of all items the POS Profile allows.

**Before:**

<img width="1297" height="613" alt="image" src="https://github.com/user-attachments/assets/ec404536-c8ec-4a4b-981e-d51833f823ec" />

**After:**
<img width="1297" height="613" alt="image" src="https://github.com/user-attachments/assets/04d34678-c5cf-438a-9a75-0608ade9a2b7" />




