### PR TITLE
fix(crm_settings): create `crm_deal` fields on enabling frappe crm data synchronization

### DIFF
--- a/erpnext/crm/doctype/crm_settings/crm_settings.py
+++ b/erpnext/crm/doctype/crm_settings/crm_settings.py
@@ -69,6 +69,13 @@ class CRMSettings(Document):
 			self.allowed_users = []
 
 	def custom_fields_for_frappe_crm_data_sync(self):
+		custom_fields = self.get_frappe_crm_custom_fields()
+
+		if self.enable_frappe_crm_data_synchronization:
+			create_custom_fields(custom_fields, ignore_validate=True)
+
+	@staticmethod
+	def get_frappe_crm_custom_fields():
 		custom_fields = {
 			"Quotation": [
 				{
@@ -88,4 +95,4 @@ class CRMSettings(Document):
 			],
 		}
 
-		create_custom_fields(custom_fields, ignore_validate=True)
+		return custom_fields

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -513,3 +513,4 @@ erpnext.patches.v16_0.rename_italy_customer_name_fields
 erpnext.patches.v16_0.recalculate_purchase_receipt_billing_status
 erpnext.patches.v16_0.recalculate_mixed_purchase_receipt_billing_status
 erpnext.patches.v16_0.repair_work_order_material_transfer
+erpnext.patches.v16_0.remove_frappe_crm_custom_fields

--- a/erpnext/patches/v16_0/remove_frappe_crm_custom_fields.py
+++ b/erpnext/patches/v16_0/remove_frappe_crm_custom_fields.py
@@ -1,0 +1,27 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import delete_custom_fields
+
+from erpnext.crm.doctype.crm_settings.crm_settings import CRMSettings
+
+
+def execute():
+	"""Delete the `crm_deal` fields on Quotation and Customer if Frappe CRM Data Synchronization is disabled and there's no data on those fields."""
+
+	crm_deal_exists_in_quotation = frappe.db.has_column("Quotation", "crm_deal") and frappe.get_all(
+		"Quotation", filters={"crm_deal": ["is", "set"]}, limit=1
+	)
+
+	crm_deal_exists_in_customer = frappe.db.has_column("Customer", "crm_deal") and frappe.get_all(
+		"Customer", filters={"crm_deal": ["is", "set"]}, limit=1
+	)
+
+	enable_frappe_crm_data_sync = frappe.get_single_value(
+		"CRM Settings", "enable_frappe_crm_data_synchronization"
+	)
+
+	if enable_frappe_crm_data_sync or crm_deal_exists_in_quotation or crm_deal_exists_in_customer:
+		return
+
+	custom_fields = CRMSettings.get_frappe_crm_custom_fields()
+
+	delete_custom_fields(custom_fields)


### PR DESCRIPTION
Changes include:

- Create `crm_deal` fields on Customer and Quotation DocType when enabling Frappe CRM Data Synchronization.
- Patch to delete if Frappe CRM Data Synchronization is disabled or there's no data on `crm_deal` on either Customer or Quotation.