### PR TITLE
fix: validate discount account is set when discount accounting is enabled

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -396,6 +396,21 @@ class SalesInvoice(SellingController):
 		self.validate_write_off_account()
 		self.validate_account_for_change_amount()
 		self.validate_income_account()
+		self.validate_discount_accounting()
+
+	def validate_discount_accounting(self):
+		if not self.enable_discount_accounting:
+			return
+
+		for item in self.get("items"):
+			if flt(item.discount_amount) and not item.discount_account:
+				msgprint(
+					_("Row {0}: Please enter Discount Account").format(item.idx),
+					raise_exception=1,
+				)
+
+		if flt(self.discount_amount) and not self.additional_discount_account:
+			msgprint(_("Please enter Additional Discount Account"), raise_exception=1)
 
 	def validate_for_repost(self):
 		self.validate_write_off_account()


### PR DESCRIPTION
## Summary
- When **Enable discount accounting for selling** is turned on in Selling Settings, submitting a Sales Invoice with a line/additional discount but no Discount Account (or Additional Discount Account) set previously succeeded silently — the discount GL entries were just skipped instead of the transaction being blocked.
- This was easy to miss for single-invoice submission from the form (the field is usually pre-filled from Item/Item Group/Brand/Company defaults), but was fully exposed when submitting invoices in bulk via multi-select from the list view (e.g. Sales Order → Delivery Note → Sales Invoice created and submitted via multi-select), since that path goes straight through the server-side `validate()` with no client-side nudge to fill the field.
- Adds `validate_discount_accounting()` to `SalesInvoice`, called from the existing `validate_accounts()` hook, so both single-record and multi-select submission consistently require the discount account(s) to be set whenever a discount is applied and discount accounting is enabled.

## Test plan
- [ ] Enable "Enable discount accounting for selling" in Selling Settings without configuring a default Discount Account.
- [ ] Create a Sales Order → Delivery Note → Sales Invoice (via multi-select) with a line discount and no Discount Account set on the item — confirm bulk submission is now blocked with "Please enter Discount Account".
- [ ] Same as above but with an additional (grand total) discount and no Additional Discount Account — confirm bulk submission is blocked with "Please enter Additional Discount Account".
- [ ] Set the Discount Account(s) and confirm submission (single and multi-select) succeeds as before.
- [ ] Existing tests `test_sales_invoice_with_discount_accounting_enabled` and `test_additional_discount_for_sales_invoice_with_discount_accounting_enabled` in `test_sales_invoice.py` continue to pass (both already set proper discount accounts).