### PR TITLE
feat(accounts): opt-in 'Consider Accounting Dimension' filter on General Ledger Report

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -95,13 +95,14 @@
   "column_break_25",
   "reports_tab",
   "remarks_section",
-  "general_ledger_remarks_length",
-  "receivable_payable_remarks_length",
+  "disable_include_dimensions",
   "column_break_lvjk",
+  "general_ledger_remarks_length",
   "accounts_receivable_payable_tuning_section",
   "receivable_payable_fetch_method",
   "default_ageing_range",
   "column_break_ntmi",
+  "receivable_payable_remarks_length",
   "legacy_section",
   "ignore_is_opening_check_for_reporting",
   "tab_break_dpet",
@@ -477,7 +478,7 @@
   {
    "fieldname": "remarks_section",
    "fieldtype": "Section Break",
-   "label": "Remarks Column Length"
+   "label": "General Ledger Report"
   },
   {
    "default": "0",
@@ -551,7 +552,7 @@
   {
    "fieldname": "accounts_receivable_payable_tuning_section",
    "fieldtype": "Section Break",
-   "label": "Accounts Receivable / Payable Tuning"
+   "label": "Accounts Receivable / Payable Report"
   },
   {
    "fieldname": "legacy_section",
@@ -790,6 +791,12 @@
    "fieldname": "book_stock_expense_gl_entries",
    "fieldtype": "Check",
    "label": "Book Stock Expense GL Entries"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_include_dimensions",
+   "fieldtype": "Check",
+   "label": "Disable \"Consider Accounting Dimension\" Filter"
   }
  ],
  "grid_page_length": 50,
@@ -798,7 +805,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-08-13 14:48:13.211701",
+ "modified": "2026-08-14 13:12:47.895908",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -72,6 +72,7 @@ class AccountsSettings(Document):
 		default_ageing_range: DF.Data | None
 		delete_linked_ledger_entries: DF.Check
 		determine_address_tax_category_from: DF.Literal["Billing Address", "Shipping Address"]
+		disable_include_dimensions: DF.Check
 		enable_accounting_dimensions: DF.Check
 		enable_common_party_accounting: DF.Check
 		enable_discounts_and_margin: DF.Check

--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -175,7 +175,7 @@ frappe.query_reports["General Ledger"] = {
 			fieldname: "include_dimensions",
 			label: __("Consider Accounting Dimensions"),
 			fieldtype: "Check",
-			default: 1,
+			default: frappe.boot.sysdefaults.disable_include_dimensions ? 0 : 1,
 		},
 		{
 			fieldname: "disable_opening_balance_calculation",

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -24,6 +24,9 @@ def boot_session(bootinfo):
 		bootinfo.sysdefaults.over_billing_allowance = frappe.get_single_value(
 			"Accounts Settings", "over_billing_allowance"
 		)
+		bootinfo.sysdefaults.disable_include_dimensions = cint(
+			frappe.get_single_value("Accounts Settings", "disable_include_dimensions")
+		)
 
 		bootinfo.sysdefaults.quotation_valid_till = cint(
 			frappe.db.get_single_value("CRM Settings", "default_valid_till")


### PR DESCRIPTION
Changes include:

- Restructured the 'Reports' tab in Accounts Settings by breaking it down into two separate sections for the General Ledger Report and AP/AR Report 
- Introduced a new check called 'Disable "Consider Accounting Dimension" Filter', which, if enabled, will disable the "Consider Accounting Dimension" filter on the General Ledger Report.

Screenshot:

<img width="1044" height="522" alt="image" src="https://github.com/user-attachments/assets/f355dfb6-dbac-4e53-a9e7-2099fb4caa7d" />


<!-- no-docs -->
