### PR TITLE
refactor(selling): reorder sales invoice mapper arguments

### DIFF
--- a/erpnext/selling/doctype/sales_order/mapper.py
+++ b/erpnext/selling/doctype/sales_order/mapper.py
@@ -432,8 +432,8 @@ def get_qty_net_of_returns(so_item) -> float:
 def make_sales_invoice(
 	source_name: str,
 	target_doc: str | dict | Document | None = None,
-	ignore_permissions: bool = False,
 	args: str | dict | None = None,
+	ignore_permissions: bool = False,
 ):
 	if args is None:
 		args = {}


### PR DESCRIPTION
## What changed

Reordered the optional `make_sales_invoice` parameters so `args` comes before `ignore_permissions`.

## Why

The mapper consumes `args` as its request payload. The new order makes the third positional argument map to that payload and keeps the permission override explicit.

## Impact

Positional callers can pass mapper arguments as the third argument. Existing keyword calls do not change.

## Validation

- All commit hooks passed, including Ruff, Python AST, and the PostgreSQL static check.
- The focused Sales Order invoice test could not start because the local test site references the deleted `Item Quality Trigger` DocType.
