### PR TITLE
fix: correct is_frozen description on customer and supplier

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -358,7 +358,7 @@
   },
   {
    "default": "0",
-   "description": "Frozen suppliers block ledger entries until unfrozen. Use this to temporarily lock accounting activity without disabling the supplier.",
+   "description": "Frozen suppliers block new transactions and ledger entries until unfrozen. Only users with the role set in Company's \"Roles Allowed to Set and Edit Frozen Account Entries\" can transact.",
    "fieldname": "is_frozen",
    "fieldtype": "Check",
    "label": "Is Frozen"
@@ -592,7 +592,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-08-06 14:58:00.561519",
+ "modified": "2026-08-14 16:10:58.600553",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -410,7 +410,7 @@
   },
   {
    "default": "0",
-   "description": "Blocks all further accounting entries on this customer's account. Only users with the frozen-entries role can override.\n",
+   "description": "Blocks new transactions and further accounting entries on this customer's account. Only users with the role set in Company's \"Roles Allowed to Set and Edit Frozen Account Entries\" can transact.",
    "fieldname": "is_frozen",
    "fieldtype": "Check",
    "label": "Is Frozen",
@@ -730,7 +730,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-08-06 15:14:35.049972",
+ "modified": "2026-08-14 16:10:58.600553",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",


### PR DESCRIPTION
**Fixes** #58164

**Description:**

The `is_frozen` descriptions say the flag blocks only ledger entries. It actually blocks the party from making any new transactions.

The existing wording was misleading, so this PR corrects the descriptions for both Customer and Supplier.

No behaviour change — description text only.

**Backport Needed For V16**
