### PR TITLE
fix: rename misspelled delink_refernce_from_voucher

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -1467,7 +1467,7 @@ class SerialandBatchBundle(Document):
 			else f"{self.voucher_type} Item"
 		)
 
-	def delink_refernce_from_voucher(self):
+	def delink_reference_from_voucher(self):
 		or_filters = {"serial_and_batch_bundle": self.name}
 
 		fields = ["name", "serial_and_batch_bundle"]
@@ -1850,7 +1850,7 @@ class SerialandBatchBundle(Document):
 
 	def on_trash(self):
 		self.validate_voucher_no_docstatus()
-		self.delink_refernce_from_voucher()
+		self.delink_reference_from_voucher()
 		self.delink_reference_from_batch()
 
 	@frappe.whitelist()


### PR DESCRIPTION
**Description:**

- Fixes a spelling mistake in a method name — "refernce" should be "reference". It's only used in this one file, in two places, and nothing outside it calls the method, so the rename is safe. The method right below it is already called `delink_reference_from_batch`, so the two now match. Nothing about the behaviour changes.


**No Backport Needed**