### PR TITLE
fix(stock): honour pick serial / batch based on in the batch selector

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -8,6 +8,16 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 			? this.item.rejected_serial_and_batch_bundle
 			: this.item.serial_and_batch_bundle;
 
+		this.init();
+	}
+
+	async init() {
+		try {
+			this.based_on = await erpnext.stock.get_pick_serial_batch_based_on();
+		} catch (e) {
+			this.based_on = "FIFO";
+		}
+
 		this.make();
 		this.render_data();
 	}
@@ -391,7 +401,7 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 			{
 				fieldtype: "Select",
 				options: ["FIFO", "LIFO", "Expiry"],
-				default: "FIFO",
+				default: this.based_on,
 				fieldname: "based_on",
 				label: __("Fetch Based On"),
 				onchange: () => this.get_auto_data(),
@@ -537,7 +547,7 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 		}
 
 		if (!based_on) {
-			based_on = "FIFO";
+			based_on = this.based_on;
 		}
 
 		let warehouse = this.item.warehouse || this.item.s_warehouse;


### PR DESCRIPTION
**Issue:**
The Add Batch Nos dialog hardcoded FIFO both as the "Fetch Based On" default and as the fallback in `get_auto_data`, so Stock Settings > Pick Serial / Batch Based On was ignored: a site set to Expiry still fetched in creation order and consumed a batch that was not the nearest to expiry.

Now reads the setting via `erpnext.stock.get_pick_serial_batch_based_on()`, the cached helper the inline editor already uses for the same field. The backend already orders by expiry, so only the client needed changing.

Fixes #58135
