### PR TITLE
feat: validate purchase receipt exchange rate parity on purchase invoice

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -295,6 +295,7 @@ class PurchaseInvoice(BuyingController):
 		BillingValidationService(self).validate_multiple_billing("Purchase Receipt", "pr_detail", "amount")
 		self.set_status()
 		self.validate_purchase_receipt_if_update_stock()
+		self.validate_exchange_rate_with_purchase_receipt()
 		validate_inter_company_party(
 			self.doctype, self.supplier, self.company, self.inter_company_invoice_reference
 		)
@@ -317,6 +318,47 @@ class PurchaseInvoice(BuyingController):
 
 		if total_billed_qty and total_received_qty:
 			self.per_received = total_received_qty / total_billed_qty * 100
+
+	def validate_exchange_rate_with_purchase_receipt(self):
+		if self.is_internal_transfer() or not erpnext.is_perpetual_inventory_enabled(self.company):
+			return
+
+		stock_items = self.get_stock_items()
+		receipts = {
+			item.purchase_receipt
+			for item in self.items
+			if item.purchase_receipt and item.item_code in stock_items
+		}
+		if not receipts:
+			return
+
+		if frappe.db.get_single_value("Buying Settings", "set_landed_cost_based_on_purchase_invoice_rate"):
+			return
+
+		mismatched = [
+			f"{frappe.bold(row.name)} ({row.conversion_rate})"
+			for row in frappe.get_all(
+				"Purchase Receipt",
+				filters={"name": ("in", list(receipts))},
+				fields=["name", "currency", "conversion_rate"],
+			)
+			if row.currency == self.currency
+			and flt(row.conversion_rate)
+			and flt(row.conversion_rate) != flt(self.conversion_rate)
+		]
+		if not mismatched:
+			return
+
+		frappe.throw(
+			_(
+				"Exchange rate {0} does not match the exchange rate of Purchase Receipt {1}. Use the same exchange rate as the Purchase Receipt or enable {2} in {3} to adjust the landed cost based on this invoice."
+			).format(
+				frappe.bold(self.conversion_rate),
+				", ".join(mismatched),
+				frappe.bold(_("Set Landed Cost Based on Purchase Invoice Rate")),
+				get_link_to_form("Buying Settings", "Buying Settings", _("Buying Settings")),
+			)
+		)
 
 	def validate_invoice_hold(self):
 		if self.is_return:

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -583,6 +583,12 @@ class TestPurchaseInvoice(ERPNextTestSuite, StockTestMixin):
 		)
 
 		frappe.db.set_single_value("Buying Settings", "set_landed_cost_based_on_purchase_invoice_rate", 0)
+		self.addCleanup(
+			frappe.db.set_single_value,
+			"Buying Settings",
+			"set_landed_cost_based_on_purchase_invoice_rate",
+			original_value,
+		)
 
 		pr = make_purchase_receipt(
 			company="_Test Company with perpetual inventory",
@@ -594,25 +600,15 @@ class TestPurchaseInvoice(ERPNextTestSuite, StockTestMixin):
 		pi = create_purchase_invoice(pr.name)
 		pi.conversion_rate = 80
 
+		self.assertRaises(frappe.ValidationError, pi.insert)
+
+		pi.conversion_rate = 70
 		pi.insert()
 		pi.submit()
 
-		# Get exchnage gain and loss account
 		exchange_gain_loss_account = frappe.db.get_value("Company", pi.company, "exchange_gain_loss_account")
-
-		# fetching the latest GL Entry with exchange gain and loss account account
-		amount = frappe.db.get_value(
-			"GL Entry", {"account": exchange_gain_loss_account, "voucher_no": pi.name}, "debit"
-		)
-
-		discrepancy_caused_by_exchange_rate_diff = abs(
-			pi.items[0].base_net_amount - pr.items[0].base_net_amount
-		)
-
-		self.assertEqual(discrepancy_caused_by_exchange_rate_diff, amount)
-
-		frappe.db.set_single_value(
-			"Buying Settings", "set_landed_cost_based_on_purchase_invoice_rate", original_value
+		self.assertFalse(
+			frappe.db.exists("GL Entry", {"account": exchange_gain_loss_account, "voucher_no": pi.name})
 		)
 
 	def test_purchase_invoice_with_exchange_rate_difference_for_non_stock_item(self):
@@ -620,7 +616,17 @@ class TestPurchaseInvoice(ERPNextTestSuite, StockTestMixin):
 			make_purchase_invoice as create_purchase_invoice,
 		)
 
-		# Creating Purchase Invoice with USD currency
+		original_value = frappe.db.get_single_value(
+			"Buying Settings", "set_landed_cost_based_on_purchase_invoice_rate"
+		)
+		frappe.db.set_single_value("Buying Settings", "set_landed_cost_based_on_purchase_invoice_rate", 0)
+		self.addCleanup(
+			frappe.db.set_single_value,
+			"Buying Settings",
+			"set_landed_cost_based_on_purchase_invoice_rate",
+			original_value,
+		)
+
 		pr = frappe.new_doc("Purchase Receipt")
 		pr.currency = "USD"
 		pr.company = "_Test Company with perpetual inventory"
@@ -634,33 +640,19 @@ class TestPurchaseInvoice(ERPNextTestSuite, StockTestMixin):
 				"rate": 100,
 			},
 		)
-		pr.append(
-			"items",
-			{"item_code": "_Test Item", "qty": 1, "rate": 5, "warehouse": "Stores - TCP1"},
-		)
 		pr.insert()
 		pr.submit()
 
-		# Createing purchase invoice against Purchase Receipt
 		pi = create_purchase_invoice(pr.name)
 		pi.conversion_rate = 70
 		pi.credit_to = "_Test Payable USD - TCP1"
 		pi.insert()
 		pi.submit()
 
-		# Get exchnage gain and loss account
 		exchange_gain_loss_account = frappe.db.get_value("Company", pi.company, "exchange_gain_loss_account")
-
-		# fetching the latest GL Entry with exchange gain and loss account account
-		amount = frappe.db.get_value(
-			"GL Entry", {"account": exchange_gain_loss_account, "voucher_no": pi.name}, "credit"
+		self.assertFalse(
+			frappe.db.exists("GL Entry", {"account": exchange_gain_loss_account, "voucher_no": pi.name})
 		)
-
-		discrepancy_caused_by_exchange_rate_diff = abs(
-			pi.items[1].base_net_amount - pr.items[1].base_net_amount
-		)
-
-		self.assertEqual(flt(discrepancy_caused_by_exchange_rate_diff, 2), amount)
 
 	def test_purchase_invoice_change_naming_series(self):
 		pi = frappe.copy_doc(self.globalTestRecords["Purchase Invoice"][1])


### PR DESCRIPTION
## Problem

When a Purchase Invoice is created against a Purchase Receipt in a foreign currency and `Set Landed Cost Based on Purchase Invoice Rate` (Buying Settings) is **disabled**, the landed cost stays frozen at the receipt's exchange rate. If the invoice is then submitted at a different exchange rate, the system silently books the difference to the Exchange Gain/Loss account.

Example — PR @ 90, PI @ 100, item rate 100 (FC):

| Entry | Account | Amount (base) |
|---|---|---|
| PR | Stock Received But Not Billed (Cr) | 9,000 |
| PI | SRBNB (Dr) | 9,000 |
| PI | Creditors (Cr) | 10,000 |
| PI | **Exchange Gain/Loss (Dr)** | **1,000** |

This invoice-time FX booking is technically correct (it captures the receipt-date → invoice-date rate movement), but it repeatedly confuses users: when a Payment Entry later books its own gain/loss (invoice-date → payment-date movement), the two entries in the same account read as a *duplicate booking* of the same difference — especially when the payment rate lands back near the receipt rate, producing equal and opposite amounts.

Since the user has an explicit, supported alternative (enable the setting so the landed cost adjusts to the invoice rate and no FX entry arises), the mismatch should be a conscious choice rather than a silent side effect.

## Fix

Purchase Invoice now validates exchange-rate parity with its linked Purchase Receipts. Submission (and save) is blocked with a clear message when **all** of the following hold:

- the invoice has items linked to a Purchase Receipt and those items are **stock items** (non-stock items never produce the SRBNB exchange difference, so they remain unrestricted),
- perpetual inventory is enabled and the invoice is not an internal transfer,
- `Set Landed Cost Based on Purchase Invoice Rate` is **disabled**,
- a linked Purchase Receipt in the **same currency** as the invoice has a different `conversion_rate`.

The error names each mismatched receipt with its rate and offers both remedies:

> Exchange rate **80** does not match the exchange rate of Purchase Receipt **MAT-PRE-00001** (70). Use the same exchange rate as the Purchase Receipt or enable **Set Landed Cost Based on Purchase Invoice Rate** in Buying Settings to adjust the landed cost based on this invoice.

The same-currency condition matters: when the invoice currency equals the company currency, both documents are pinned to rate 1 and can never mismatch; and when the invoice is billed in a *different* currency than the receipt, the rates differ because they convert different currencies — not an FX movement — so those receipts are excluded from the comparison (the GL discrepancy logic never books in that case either).

## Behaviour after this change

| Scenario | Result |
|---|---|
| PR and PI in same FC, rates differ, setting disabled | Blocked with actionable message |
| PR and PI in same FC, rates equal | Allowed — no FX entry |
| Setting enabled, rates differ | Allowed — landed cost adjusts to PI rate, no FX entry |
| Only non-stock items billed, rates differ | Allowed — no SRBNB difference arises |
| PI currency differs from PR currency | Allowed — rates not comparable |

The existing exchange-difference GL block in `gl_composer` is intentionally retained: invoices submitted before this validation still need it when they are cancelled, amended, or reposted via Repost Accounting Ledger. It becomes unreachable for newly submitted invoices and can be removed in a future major release.

## Tests

- `test_purchase_invoice_with_exchange_rate_difference` — reworked: a mismatched rate now raises `ValidationError`; the same invoice at the receipt's rate submits with no Exchange Gain/Loss GL entry. Setting restore moved to `addCleanup` so it survives assertion failures.
- `test_purchase_invoice_with_exchange_rate_difference_for_non_stock_item` — now covers the non-stock boundary it was named for: mismatched rates remain allowed and produce no gain/loss entry.


no-docs