### PR TITLE
fix(accounts): supplier group filter not applied on accounts payable …

### DIFF
--- a/erpnext/accounts/report/accounts_payable/accounts_payable.js
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.js
@@ -94,10 +94,15 @@ frappe.query_reports["Accounts Payable"] = {
 			options: get_party_type_options(),
 			on_change: function () {
 				frappe.query_report.set_filter_value("party", "");
-				frappe.query_report.toggle_filter_display(
-					"supplier_group",
-					frappe.query_report.get_filter_value("party_type") !== "Supplier"
-				);
+				let is_supplier = frappe.query_report.get_filter_value("party_type") === "Supplier";
+				let supplier_group_filter = frappe.query_report.get_filter("supplier_group");
+				if (supplier_group_filter) {
+					supplier_group_filter.df.hidden = !is_supplier;
+				}
+				frappe.query_report.toggle_filter_display("supplier_group", !is_supplier);
+				if (!is_supplier) {
+					frappe.query_report.set_filter_value("supplier_group", []);
+				}
 			},
 		},
 		{


### PR DESCRIPTION
**Issue:**
In the Accounts Payable Report, when Party Type = Supplier and Supplier Group are selected, the report also displays suppliers belonging to other Supplier Groups.


**Before:**

[Screencast from 2026-08-14 18-13-58.webm](https://github.com/user-attachments/assets/8adf9827-350b-4719-b091-402fc3a7b4a2)




**After:**

[Screencast from 2026-08-14 18-11-28.webm](https://github.com/user-attachments/assets/596cf972-ec59-4a14-97bc-96bf6d93f4ce)
