### PR TITLE
fix: drop removed Restaurant doctype from sales tax template dashboard 

### DIFF
--- a/erpnext/accounts/doctype/sales_taxes_and_charges_template/sales_taxes_and_charges_template_dashboard.py
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges_template/sales_taxes_and_charges_template_dashboard.py
@@ -7,10 +7,9 @@ def get_data():
 		"non_standard_fieldnames": {
 			"Tax Rule": "sales_tax_template",
 			"Subscription": "sales_tax_template",
-			"Restaurant": "default_tax_template",
 		},
 		"transactions": [
 			{"label": _("Transactions"), "items": ["Sales Invoice", "Sales Order", "Delivery Note"]},
-			{"label": _("References"), "items": ["POS Profile", "Subscription", "Restaurant", "Tax Rule"]},
+			{"label": _("References"), "items": ["POS Profile", "Subscription", "Tax Rule"]},
 		],
 	}


### PR DESCRIPTION
**Issue :** 

- The Sales Taxes and Charges Template form fails to load when the Hospitality app is not installed.

- The Connections tab still references the Restaurant DocType, which was removed from ERPNext and moved to the Hospitality app. When the dashboard tries to fetch the linked document count for Restaurant, it raises a DoesNotExistError.

**Fixes:** [#58180](https://github.com/frappe/erpnext/issues/58180)

**Backport Needed For V16 and V15**