### PR TITLE
fix: correct Item Group doctype name in item tax template dashboard 

### DIFF
--- a/erpnext/accounts/doctype/item_tax_template/item_tax_template_dashboard.py
+++ b/erpnext/accounts/doctype/item_tax_template/item_tax_template_dashboard.py
@@ -8,6 +8,6 @@ def get_data():
 			{"label": _("Pre Sales"), "items": ["Quotation", "Supplier Quotation"]},
 			{"label": _("Sales"), "items": ["Sales Invoice", "Sales Order", "Delivery Note"]},
 			{"label": _("Purchase"), "items": ["Purchase Invoice", "Purchase Order", "Purchase Receipt"]},
-			{"label": _("Stock"), "items": ["Item Groups", "Item"]},
+			{"label": _("Stock"), "items": ["Item Group", "Item"]},
 		],
 	}


### PR DESCRIPTION
**Issue:** 

- The Item Tax Template form fails to load because the Connections dashboard references a non-existent DocType.

**Description:**

- The Stock section in item_tax_template_dashboard.py uses Item Groups, but the correct DocType name is Item Group. When the dashboard tries to fetch the linked document count, Frappe raises a DoesNotExistError.


**Backport Needed For V15 and V16**