### PR TITLE
feat: add status filter to Supplier Quotation Comparison report

### DIFF
--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js
@@ -86,6 +86,17 @@ frappe.query_reports["Supplier Quotation Comparison"] = {
 			default: __("Categorize by Supplier"),
 		},
 		{
+			fieldname: "status",
+			label: __("Status"),
+			fieldtype: "Select",
+			options: [
+				{ label: "", value: "" },
+				{ label: __("Draft"), value: "Draft" },
+				{ label: __("Submitted"), value: "Submitted" },
+			],
+			default: "Submitted",
+		},
+		{
 			fieldtype: "Check",
 			label: __("Include Expired"),
 			fieldname: "include_expired",

--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
@@ -56,12 +56,19 @@ def get_data(filters):
 		)
 		.where(
 			(sq_item.parent == sq.name)
-			& (sq_item.docstatus < 2)
 			& (sq.company == filters.get("company"))
 			& (sq.transaction_date.between(filters.get("from_date"), filters.get("to_date")))
 		)
 		.orderby(sq.transaction_date, sq_item.item_code)
 	)
+
+	# blank -> Draft + Submitted, else filter to the chosen docstatus
+	if filters.get("status") == "Draft":
+		query = query.where(sq_item.docstatus == 0)
+	elif filters.get("status") == "Submitted":
+		query = query.where(sq_item.docstatus == 1)
+	else:
+		query = query.where(sq_item.docstatus < 2)
 
 	if filters.get("item_code"):
 		query = query.where(sq_item.item_code == filters.get("item_code"))

--- a/erpnext/buying/report/supplier_quotation_comparison/test_supplier_quotation_comparison.py
+++ b/erpnext/buying/report/supplier_quotation_comparison/test_supplier_quotation_comparison.py
@@ -14,7 +14,7 @@ class TestSupplierQuotationComparison(ERPNextTestSuite):
 	"""The report lists Supplier Quotation item lines so quotes for the same item can
 	be compared across suppliers."""
 
-	def make_quotation(self, supplier, qty, rate, uom=None):
+	def make_quotation(self, supplier, qty, rate, uom=None, submit=True):
 		item = {"item_code": ITEM, "qty": qty, "rate": rate, "warehouse": "_Test Warehouse - _TC"}
 		if uom:
 			item["uom"] = uom
@@ -29,7 +29,8 @@ class TestSupplierQuotationComparison(ERPNextTestSuite):
 			}
 		)
 		sq.insert()
-		sq.submit()
+		if submit:
+			sq.submit()
 		return sq
 
 	def run_report(self, **extra):
@@ -64,3 +65,21 @@ class TestSupplierQuotationComparison(ERPNextTestSuite):
 		self.assertIn(sq2.name, quotes)
 		self.assertEqual(quotes[sq1.name]["base_rate"], 100)
 		self.assertEqual(quotes[sq2.name]["base_rate"], 120)
+
+	def test_status_filter(self):
+		draft = self.make_quotation("_Test Supplier", qty=10, rate=100, submit=False)
+		submitted = self.make_quotation("_Test Supplier 1", qty=10, rate=120)
+
+		def names(**extra):
+			return {r["quotation"] for r in self.run_report(item_code=ITEM, **extra)}
+
+		# default (Submitted) hides drafts
+		self.assertNotIn(draft.name, names(status="Submitted"))
+		self.assertIn(submitted.name, names(status="Submitted"))
+		# Draft shows only drafts
+		self.assertIn(draft.name, names(status="Draft"))
+		self.assertNotIn(submitted.name, names(status="Draft"))
+		# blank shows both
+		both = names(status="")
+		self.assertIn(draft.name, both)
+		self.assertIn(submitted.name, both)


### PR DESCRIPTION
Adds a `Status` filter (blank → both, Draft, Submitted) to the Supplier Quotation Comparison report, defaulting to **Submitted** so draft quotations no longer appear by default.

https://support.frappe.io/helpdesk/tickets/76282?view=VIEW-HD+Ticket-70177

<img width="1153" height="265" alt="Screenshot 2026-08-15 at 8 44 44 PM" src="https://github.com/user-attachments/assets/3bc4c6b5-0881-4e41-891c-b21155218588" />


no-docs