### PR TITLE
fix(crm)!: remove unused `get_last_interaction` module function

### DIFF
--- a/erpnext/crm/doctype/test_utils.py
+++ b/erpnext/crm/doctype/test_utils.py
@@ -1,47 +1,8 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-import frappe
-
-from erpnext.crm.doctype.utils import get_last_interaction
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestCrmDoctypeUtils(ERPNextTestSuite):
-	def test_get_last_interaction_for_contact(self):
-		"""Covers the converted Communication query (contact path): returns the earliest Received
-		communication across the doctypes the contact is linked to. `creation` is unique, so the
-		LIMIT-1 pick is deterministic and identical on MariaDB and Postgres."""
-		customer = "_Test CRM Util Customer"
-		if not frappe.db.exists("Customer", customer):
-			frappe.get_doc(
-				{
-					"doctype": "Customer",
-					"customer_name": customer,
-					"customer_group": "_Test Customer Group",
-					"territory": "_Test Territory",
-				}
-			).insert(ignore_permissions=True)
-
-		contact = frappe.get_doc(
-			{
-				"doctype": "Contact",
-				"first_name": "CRM Util Test",
-				"links": [{"link_doctype": "Customer", "link_name": customer}],
-			}
-		).insert(ignore_permissions=True)
-
-		comm = frappe.get_doc(
-			{
-				"doctype": "Communication",
-				"subject": "hi",
-				"content": "first interaction",
-				"sent_or_received": "Received",
-				"reference_doctype": "Customer",
-				"reference_name": customer,
-			}
-		).insert(ignore_permissions=True)
-
-		result = get_last_interaction(contact=contact.name)
-		self.assertIsNotNone(result["last_communication"])
-		self.assertEqual(result["last_communication"]["name"], comm.name)
+	pass

--- a/erpnext/crm/doctype/utils.py
+++ b/erpnext/crm/doctype/utils.py
@@ -1,48 +1,4 @@
 import frappe
-from frappe.query_builder import Criterion
-
-
-@frappe.whitelist()
-def get_last_interaction(contact: str | None = None, lead: str | None = None):
-	if not contact and not lead:
-		return
-
-	last_communication = None
-	last_issue = None
-	if contact:
-		communication = frappe.qb.DocType("Communication")
-		link_conditions = []
-		contact = frappe.get_doc("Contact", contact)
-		for link in contact.links:
-			if link.link_doctype == "Customer":
-				last_issue = get_last_issue_from_customer(link.link_name)
-			link_conditions.append(
-				(communication.reference_doctype == link.link_doctype)
-				& (communication.reference_name == link.link_name)
-			)
-
-		if link_conditions:
-			last_communication = (
-				frappe.qb.from_(communication)
-				.select(communication.name, communication.content)
-				.where((communication.sent_or_received == "Received") & Criterion.any(link_conditions))
-				.orderby(communication.creation)
-				.limit(1)
-				.run(as_dict=1)
-			)
-
-	if lead:
-		last_communication = frappe.get_all(
-			"Communication",
-			filters={"reference_doctype": "Lead", "reference_name": lead, "sent_or_received": "Received"},
-			fields=["name", "content"],
-			order_by="creation desc",
-			limit=1,
-		)
-
-	last_communication = last_communication[0] if last_communication else None
-
-	return {"last_communication": last_communication, "last_issue": last_issue}
 
 
 def get_last_issue_from_customer(customer_name):


### PR DESCRIPTION
> [!CAUTION]
> BREAKING CHANGES: Removal of a whitelisted function.

Changes include:

- Removed `get_last_interaction`, a whitelisted module function, from `erpnext/crm/doctype/utils.py`, which was not being used anywhere internally.