### PR TITLE
fix(italy): handle none price_list_rate in e-invoice xml generation

### DIFF
--- a/erpnext/regional/italy/e-invoice.xml
+++ b/erpnext/regional/italy/e-invoice.xml
@@ -191,7 +191,7 @@
         <Descrizione>{{ html2text(item.description or '') or item.item_name }}</Descrizione>
         <Quantita>{{ format_float(item.qty) }}</Quantita>
         <UnitaMisura>{{ item.stock_uom }}</UnitaMisura>
-        {%- set item_unit_net_price = (item.price_list_rate / tax_divisor) or (item.net_rate) or (item.rate / tax_divisor) %}
+        {%- set item_unit_net_price = ((item.price_list_rate or 0) / tax_divisor) or (item.net_rate) or (item.rate / tax_divisor) %}
         <PrezzoUnitario>{{ format_float(item_unit_net_price, item_meta.get_field("rate").precision) }}</PrezzoUnitario>
         {{ render_discount_or_margin(item, tax_divisor) }}
         <PrezzoTotale>{{ format_float(item.net_amount, item_meta.get_field("amount").precision) }}</PrezzoTotale>


### PR DESCRIPTION
**Issue:**
When trying to Submit a Sales Invoice, ERPNext fails during the generation of the Italian E-Invoice XML and returns the following error:

**Traceback**
<pre>Traceback (most recent call last):
  File &quot;apps/frappe/frappe/utils/jinja.py&quot;, line 156, in render_template
    return compiled_template.render(context)
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File &quot;env/lib/python3.14/site-packages/jinja2/environment.py&quot;, line 1295, in render
    self.environment.handle_exception()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File &quot;env/lib/python3.14/site-packages/jinja2/environment.py&quot;, line 942, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File &quot;apps/erpnext/erpnext/regional/italy/e-invoice.xml&quot;, line 194, in top-level template code
    {%- set item_unit_net_price = (item.price_list_rate / tax_divisor) or (item.net_rate) or (item.rate / tax_divisor) %}
    ^^^^^^^^^^^^^^^^^
TypeError: unsupported operand type(s) for /: &#x27;NoneType&#x27; and &#x27;int&#x27;
</pre>
