### PR TITLE
fix: don't set work order status to In Process only due to skip material transfer

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/services/status.py
+++ b/erpnext/manufacturing/doctype/work_order/services/status.py
@@ -132,9 +132,7 @@ class StatusService:
 
 		status = (
 			"In Process"
-			if flt(self.doc.material_transferred_for_manufacturing) > 0
-			or self.doc.skip_transfer
-			or self._has_transferred_material()
+			if flt(self.doc.material_transferred_for_manufacturing) > 0 or self._has_transferred_material()
 			else "Not Started"
 		)
 		precision = frappe.get_precision("Work Order", "produced_qty")


### PR DESCRIPTION
Reverts the change introduced in #55641.

Enabling **Skip Material Transfer to WIP Warehouse** should not by itself move a submitted Work Order to **In Process**. The status should remain **Not Started** until material is actually transferred or production begins against the Work Order.