### PR TITLE
fix: don't set work order status to In Process only due to skip material transfer

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -412,11 +412,7 @@ class WorkOrder(Document):
 		elif self.docstatus == 1:
 			if status not in ["Closed", "Stopped"]:
 				status = "Not Started"
-				if (
-					flt(self.material_transferred_for_manufacturing) > 0
-					or self.skip_transfer
-					or self.has_transferred_material()
-				):
+				if flt(self.material_transferred_for_manufacturing) > 0 or self.has_transferred_material():
 					status = "In Process"
 
 				precision = frappe.get_precision("Work Order", "produced_qty")


### PR DESCRIPTION
Reverts the change introduced in #55641.

Enabling **Skip Material Transfer to WIP Warehouse** should not by itself move a submitted Work Order to **In Process**. The status should remain **Not Started** until material is actually transferred or production begins against the Work Order.