### PR TITLE
fix(manufacturing): scope used secondary items to job card 

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -2384,6 +2384,113 @@ class TestJobCard(ERPNextTestSuite):
 			frappe.db.get_value("Job Card", {"work_order": work_order.name, "operation": operation}, "name"),
 		)
 
+	def submit_semi_fg_job_card_with_secondary_item(self, work_order, operation, item_code, stock_qty, day):
+		job_card = self.get_semi_fg_job_card(work_order, operation)
+		job_card.append(
+			"time_logs",
+			{
+				"from_time": f"2024-03-{day} 08:00:00",
+				"to_time": f"2024-03-{day} 09:00:00",
+				"completed_qty": job_card.for_quantity,
+			},
+		)
+		job_card.append(
+			"secondary_items",
+			{"item_code": item_code, "stock_qty": stock_qty, "secondary_item_type": "Scrap"},
+		)
+		job_card.submit()
+		return job_card
+
+	def test_secondary_items_scoped_per_job_card(self):
+		work_order = self.make_semi_fg_work_order("Secondary Scope")
+		scrap_item = create_item("Secondary Scope Scrap")
+
+		for operation, day in (("Secondary Scope Op A", "01"), ("Secondary Scope Op B", "02")):
+			job_card = self.submit_semi_fg_job_card_with_secondary_item(
+				work_order, operation, scrap_item.name, 2, day
+			)
+			manufacturing_entry = frappe.get_doc(job_card.make_stock_entry_for_semi_fg_item())
+			secondary_item = next((row for row in manufacturing_entry.items if row.secondary_item_type), None)
+			self.assertIsNotNone(secondary_item, f"secondary item missing for {operation}")
+			self.assertEqual(secondary_item.item_code, scrap_item.name)
+			self.assertEqual(secondary_item.qty, 2)
+			manufacturing_entry.submit()
+
+	def test_fully_used_secondary_item_is_not_added_to_partial_follow_up(self):
+		work_order = self.make_semi_fg_work_order("Secondary Used")
+		scrap_item = create_item("Secondary Used Scrap")
+		job_card = self.submit_semi_fg_job_card_with_secondary_item(
+			work_order, "Secondary Used Op A", scrap_item.name, 2, "04"
+		)
+
+		first = frappe.get_doc(job_card.make_stock_entry_for_semi_fg_item())
+		first.fg_completed_qty = 2
+		for row in first.items:
+			if row.is_finished_item:
+				row.qty = 2
+			elif row.s_warehouse:
+				row.qty = flt(row.qty) * 2 / 5
+		first.save()
+		first.submit()
+
+		job_card.reload()
+		follow_up = frappe.get_doc(job_card.make_stock_entry_for_semi_fg_item())
+		self.assertFalse(any(row.secondary_item_type for row in follow_up.items))
+
+	def test_over_booked_secondary_item_does_not_block_follow_up(self):
+		work_order = self.make_semi_fg_work_order("Secondary Over")
+		scrap_item = create_item("Secondary Over Scrap")
+		job_card = self.submit_semi_fg_job_card_with_secondary_item(
+			work_order, "Secondary Over Op A", scrap_item.name, 2, "05"
+		)
+
+		first = frappe.get_doc(job_card.make_stock_entry_for_semi_fg_item())
+		first.fg_completed_qty = 2
+		for row in first.items:
+			if row.is_finished_item:
+				row.qty = 2
+			elif row.secondary_item_type:
+				row.qty = 3
+			elif row.s_warehouse:
+				row.qty = flt(row.qty) * 2 / 5
+		first.save()
+		first.submit()
+
+		job_card.reload()
+		frappe.clear_messages()
+		follow_up = frappe.get_doc(job_card.make_stock_entry_for_semi_fg_item())
+		self.assertFalse(any(row.secondary_item_type for row in follow_up.items))
+
+		alerts = [msg for msg in frappe.get_message_log() if scrap_item.name in msg.get("message", "")]
+		self.assertTrue(alerts, "over booked secondary item was skipped without an alert")
+		self.assertIn(job_card.name, alerts[0].get("message"))
+
+	def test_over_booked_qty_is_measured_before_proration(self):
+		from erpnext.stock.doctype.stock_entry.services.manufacturing import ManufactureStockEntry
+
+		# A work order level entry prorates the balance, so the excess has to be taken before that
+		entry = ManufactureStockEntry(frappe.new_doc("Stock Entry", fg_completed_qty=2))
+		rows = [frappe._dict(item_code="_Test Item", stock_qty=10.0)]
+		entry._adjust_secondary_item_qtys(rows, {"_Test Item": 12.0}, pending_qty=10)
+
+		self.assertEqual(flt(rows[0].over_booked_qty), 2.0)
+		self.assertEqual(flt(rows[0].stock_qty), 0.0)
+
+	def test_used_qty_is_shared_across_rows_of_the_same_item(self):
+		from erpnext.stock.doctype.stock_entry.services.manufacturing import ManufactureStockEntry
+
+		# The same item under two secondary types makes two rows drawing on one used balance
+		entry = ManufactureStockEntry(frappe.new_doc("Stock Entry", fg_completed_qty=10))
+		rows = [
+			frappe._dict(item_code="_Test Item", secondary_item_type="Scrap", stock_qty=5.0),
+			frappe._dict(item_code="_Test Item", secondary_item_type="By-Product", stock_qty=5.0),
+		]
+		entry._adjust_secondary_item_qtys(rows, {"_Test Item": 8.0}, pending_qty=10)
+
+		self.assertEqual(flt(rows[0].stock_qty), 0.0)
+		self.assertEqual(flt(rows[1].stock_qty), 2.0)
+		self.assertEqual(flt(rows[1].over_booked_qty), 0.0)
+
 	def test_partial_manufacture_entry_then_finish(self):
 		work_order = self.make_semi_fg_work_order("PL Partial")
 

--- a/erpnext/stock/doctype/stock_entry/services/manufacturing.py
+++ b/erpnext/stock/doctype/stock_entry/services/manufacturing.py
@@ -903,7 +903,7 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 	def _query_used_secondary_items(self):
 		se = frappe.qb.DocType("Stock Entry")
 		sed = frappe.qb.DocType("Stock Entry Detail")
-		return (
+		query = (
 			frappe.qb.from_(se)
 			.inner_join(sed)
 			.on(sed.parent == se.name)
@@ -914,7 +914,12 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 				& (se.docstatus == 1)
 				& (se.purpose.isin(["Repack", "Manufacture"]))
 			)
-		).run(as_dict=1)
+		)
+
+		if self.doc.job_card:
+			query = query.where(se.job_card == self.doc.job_card)
+
+		return query.run(as_dict=1)
 
 	def get_completed_job_card_qty(self):
 		return flt(min([d.completed_qty for d in self.wo_doc.operations]))

--- a/erpnext/stock/doctype/stock_entry/services/manufacturing.py
+++ b/erpnext/stock/doctype/stock_entry/services/manufacturing.py
@@ -861,7 +861,13 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 			return
 
 		secondary_items = self.get_secondary_items_from_job_card()
+		precision = self.doc.precision("fg_completed_qty")
 		for row in secondary_items:
+			if flt(row.stock_qty, precision) <= 0:
+				if row.get("over_booked_qty"):
+					self.warn_over_booked_secondary_item(row)
+				continue
+
 			row.uom = row.uom or row.stock_uom
 			row.qty = ceil_qty_if_uom_has_whole_number(row.stock_qty, row.stock_uom)
 			row.transfer_qty = row.qty
@@ -871,6 +877,18 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 			row.secondary_item_type = row.get("secondary_item_type")
 
 			self.doc.append("items", row)
+
+	def warn_over_booked_secondary_item(self, row):
+		"""Earlier entries booked more than the job cards hold, so the skipped row is not silent."""
+		frappe.msgprint(
+			_("Item {0} is over booked by {1} {2} against {3} and has been skipped").format(
+				bold(row.item_code),
+				bold(row.over_booked_qty),
+				row.stock_uom,
+				bold(self.doc.job_card or self.doc.work_order),
+			),
+			alert=True,
+		)
 
 	def get_secondary_items_from_job_card(self):
 		if not self.wo_doc.operations:
@@ -887,11 +905,25 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 		return flt(self.get_completed_job_card_qty()) - flt(self.wo_doc.produced_qty)
 
 	def _adjust_secondary_item_qtys(self, secondary_items, used_secondary_items, pending_qty):
+		precision = self.doc.precision("fg_completed_qty")
+		# Rows are grouped per (item_code, secondary_item_type), so one item can hold several rows
+		# that draw on a single used balance.
+		last_row_per_item = {row.item_code: row for row in secondary_items}
+
 		for row in secondary_items:
-			row.stock_qty -= flt(used_secondary_items.get(row.item_code))
+			used = flt(used_secondary_items.get(row.item_code))
+			# A row can only absorb what it holds, so the rest is left for the rows after it.
+			consumed = min(max(flt(row.stock_qty), 0.0), used)
+			used_secondary_items[row.item_code] = used - consumed
+			row.stock_qty = flt(row.stock_qty) - consumed
+			# The excess no row could absorb, taken before proration so it is the real one and
+			# not this entry's share.
+			row.over_booked_qty = (
+				flt(used_secondary_items[row.item_code], precision)
+				if row is last_row_per_item.get(row.item_code)
+				else 0.0
+			)
 			row.stock_qty = row.stock_qty * flt(self.doc.fg_completed_qty) / flt(pending_qty)
-			if used_secondary_items.get(row.item_code):
-				used_secondary_items[row.item_code] -= row.stock_qty
 
 	def get_used_secondary_items(self):
 		data = self._query_used_secondary_items()


### PR DESCRIPTION
**Issue:**
Manufacture entries source secondary items from a single Job Card, but the already-used quantity was calculated across every Job Card of the Work Order. A scrap item shared by two operations was therefore counted as consumed by the first Job Card's entry and disappeared from the second one.

Scope the used-quantity query to the entry's Job Card, and restore the guard that skips secondary rows with nothing left, which the Stock Entry service rewrite dropped and which made the follow-up entry fail with "quantity cannot be zero". A quantity over booked by earlier entries is now skipped with an alert naming the Job Card (or Work Order) instead of blocking the entry, and the excess is measured before the row is prorated so the figure is the real one.

**Fixes:** #58100

**Backport Needed for v16**