### PR TITLE
fix: work order finish dialog with process loss qty from job card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -280,13 +280,6 @@ frappe.ui.form.on("Job Card", {
 			pending_qty = frm.doc.pending_qty;
 		}
 
-		const max_completable_qty = frm.doc.__onload?.max_completable_qty;
-		let default_completed_qty = pending_qty;
-		if (max_completable_qty != null) {
-			default_completed_qty = Math.min(pending_qty, Math.max(flt(max_completable_qty), 0));
-		}
-		const default_process_loss_qty = flt(pending_qty - default_completed_qty);
-
 		const fields = [
 			{
 				fieldtype: "Float",
@@ -307,29 +300,9 @@ frappe.ui.form.on("Job Card", {
 				label: __("Completed Quantity"),
 				fieldname: "completed_qty",
 				reqd: 1,
-				default: default_completed_qty,
-				description:
-					max_completable_qty != null
-						? __("Max: {0}, as per the completed quantity of the previous operation.", [
-								get_qty_with_uom(Math.max(flt(max_completable_qty), 0), frm.doc.stock_uom),
-						  ])
-						: "",
+				default: pending_qty,
 				change() {
 					const dialog = frm.job_completion_dialog;
-
-					if (
-						max_completable_qty != null &&
-						flt(dialog.get_value("completed_qty")) > flt(max_completable_qty)
-					) {
-						dialog.set_value("completed_qty", Math.max(flt(max_completable_qty), 0));
-						frappe.throw(
-							__(
-								"Completed Quantity cannot be greater than {0}, as the previous operation has only completed that quantity.",
-								[get_qty_with_uom(Math.max(flt(max_completable_qty), 0), frm.doc.stock_uom)]
-							)
-						);
-					}
-
 					const remaining =
 						dialog.get_value("for_quantity") -
 						dialog.get_value("completed_qty") -
@@ -386,7 +359,6 @@ frappe.ui.form.on("Job Card", {
 				fieldtype: "Float",
 				label: __("Process Loss Quantity"),
 				fieldname: "process_loss_qty",
-				default: default_process_loss_qty,
 				description: __("Qty scrapped in this cycle, nobody will produce it."),
 				onchange() {
 					const dialog = frm.job_completion_dialog;

--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -280,6 +280,13 @@ frappe.ui.form.on("Job Card", {
 			pending_qty = frm.doc.pending_qty;
 		}
 
+		const max_completable_qty = frm.doc.__onload?.max_completable_qty;
+		let default_completed_qty = pending_qty;
+		if (max_completable_qty != null) {
+			default_completed_qty = Math.min(pending_qty, Math.max(flt(max_completable_qty), 0));
+		}
+		const default_process_loss_qty = flt(pending_qty - default_completed_qty);
+
 		const fields = [
 			{
 				fieldtype: "Float",
@@ -300,9 +307,29 @@ frappe.ui.form.on("Job Card", {
 				label: __("Completed Quantity"),
 				fieldname: "completed_qty",
 				reqd: 1,
-				default: pending_qty,
+				default: default_completed_qty,
+				description:
+					max_completable_qty != null
+						? __("Max: {0}, as per the completed quantity of the previous operation.", [
+								get_qty_with_uom(Math.max(flt(max_completable_qty), 0), frm.doc.stock_uom),
+						  ])
+						: "",
 				change() {
 					const dialog = frm.job_completion_dialog;
+
+					if (
+						max_completable_qty != null &&
+						flt(dialog.get_value("completed_qty")) > flt(max_completable_qty)
+					) {
+						dialog.set_value("completed_qty", Math.max(flt(max_completable_qty), 0));
+						frappe.throw(
+							__(
+								"Completed Quantity cannot be greater than {0}, as the previous operation has only completed that quantity.",
+								[get_qty_with_uom(Math.max(flt(max_completable_qty), 0), frm.doc.stock_uom)]
+							)
+						);
+					}
+
 					const remaining =
 						dialog.get_value("for_quantity") -
 						dialog.get_value("completed_qty") -
@@ -359,6 +386,7 @@ frappe.ui.form.on("Job Card", {
 				fieldtype: "Float",
 				label: __("Process Loss Quantity"),
 				fieldname: "process_loss_qty",
+				default: default_process_loss_qty,
 				description: __("Qty scrapped in this cycle, nobody will produce it."),
 				onchange() {
 					const dialog = frm.job_completion_dialog;

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -159,6 +159,8 @@ class JobCard(Document):
 		)
 		self.set_onload("work_order_closed", self.is_work_order_closed())
 		self.set_onload("has_stock_entry", self.has_stock_entry())
+		if self.docstatus == 0:
+			self.set_onload("max_completable_qty", self.get_max_completable_qty())
 
 	def on_discard(self):
 		self.db_set("status", "Cancelled")
@@ -1509,6 +1511,20 @@ class JobCard(Document):
 			current_operation_qty = flt(data[0].completed_qty)
 
 		return current_operation_qty + flt(self.total_completed_qty)
+
+	def get_max_completable_qty(self):
+		if self.is_corrective_job_card or not (self.work_order and self.sequence_id):
+			return None
+
+		previous_operations = self.get_previous_operations()
+		if not previous_operations:
+			return None
+
+		qty_field = "manufactured_qty" if self.track_semi_finished_goods else "completed_qty"
+		min_completed_qty = min(flt(row.get(qty_field)) for row in previous_operations)
+
+		precision = self.precision("total_completed_qty")
+		return flt(min_completed_qty - self.get_current_operation_completed_qty(), precision)
 
 	def validate_previous_operation(self, row, current_operation_qty):
 		if not row.completed_qty or (row.status != "Completed" and row.completed_qty < current_operation_qty):

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -1186,6 +1186,110 @@ class TestJobCard(ERPNextTestSuite):
 		self.assertEqual(wo_doc.process_loss_qty, 2)
 		self.assertEqual(wo_doc.status, "Completed")
 
+	def make_two_operation_work_order(self, qty=10):
+		from erpnext.manufacturing.doctype.routing.test_routing import (
+			create_routing,
+			setup_bom,
+			setup_operations,
+		)
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		operations = [
+			{"operation": "Test Operation A1", "workstation": "Test Workstation A", "time_in_mins": 30},
+			{"operation": "Test Operation B1", "workstation": "Test Workstation A", "time_in_mins": 20},
+		]
+
+		warehouse = create_warehouse("Test Warehouse 123 for Job Card")
+		setup_operations(operations)
+
+		item_code = "Test Job Card Process Qty Item"
+		for item in [item_code, item_code + "RM 1", item_code + "RM 2"]:
+			if not frappe.db.exists("Item", item):
+				make_item(item, {"item_name": item, "stock_uom": "Nos", "is_stock_item": 1})
+
+		routing_doc = create_routing(routing_name="Testing Route", operations=operations)
+		bom_doc = setup_bom(
+			item_code=item_code,
+			routing=routing_doc.name,
+			raw_materials=[item_code + "RM 1", item_code + "RM 2"],
+			source_warehouse=warehouse,
+		)
+
+		for row in bom_doc.items:
+			make_stock_entry(item_code=row.item_code, target=row.source_warehouse, qty=qty, basic_rate=100)
+
+		return make_wo_order_test_record(
+			production_item=item_code,
+			bom_no=bom_doc.name,
+			qty=qty,
+			skip_transfer=1,
+			wip_warehouse=warehouse,
+			source_warehouse=warehouse,
+		)
+
+	def test_completion_qty_capped_by_previous_operation(self):
+		wo_doc = self.make_two_operation_work_order()
+		job_cards = frappe.get_all(
+			"Job Card",
+			filters={"work_order": wo_doc.name},
+			fields=["name", "sequence_id"],
+			order_by="sequence_id",
+		)
+
+		jc1 = frappe.get_doc("Job Card", job_cards[0].name)
+		self.assertIsNone(jc1.get_max_completable_qty())
+
+		jc1.append(
+			"time_logs",
+			{"from_time": now(), "to_time": add_to_date(now(), minutes=30), "completed_qty": 8},
+		)
+		jc1.save()
+		jc1.submit()
+		self.assertEqual(jc1.process_loss_qty, 2)
+
+		jc2 = frappe.get_doc("Job Card", job_cards[1].name)
+		self.assertEqual(jc2.get_max_completable_qty(), 8)
+
+		jc2.append("time_logs", {"from_time": add_to_date(now(), minutes=40)})
+		jc2.save()
+
+		self.assertRaises(
+			frappe.ValidationError,
+			jc2.complete_job_card,
+			qty=10,
+			for_quantity=10,
+			pending_qty=0,
+			process_loss_qty=0,
+			end_time=add_to_date(now(), minutes=70),
+		)
+
+		self.complete_second_operation_and_finish(wo_doc, jc2.name)
+
+	def complete_second_operation_and_finish(self, wo_doc, job_card):
+		from erpnext.manufacturing.doctype.work_order.mapper import (
+			make_stock_entry as make_stock_entry_for_wo,
+		)
+
+		jc2 = frappe.get_doc("Job Card", job_card)
+		jc2.time_logs[0].completed_qty = 7
+		jc2.time_logs[0].to_time = add_to_date(now(), minutes=70)
+		jc2.save()
+		self.assertEqual(jc2.process_loss_qty, 3)
+		jc2.submit()
+
+		se = frappe.get_doc(make_stock_entry_for_wo(wo_doc.name, "Manufacture", 10))
+		se.submit()
+
+		self.assertEqual(se.process_loss_qty, 3)
+		fg_qty = sum(d.qty for d in se.items if d.is_finished_item)
+		self.assertEqual(flt(fg_qty), 7)
+
+		wo_doc.reload()
+		self.assertEqual(wo_doc.produced_qty, 7)
+		self.assertEqual(wo_doc.process_loss_qty, 3)
+		self.assertEqual(wo_doc.status, "Completed")
+
 	def get_first_job_card(self, work_order):
 		return frappe.get_doc(
 			"Job Card",

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -1053,6 +1053,15 @@ erpnext.work_order = {
 		return flt(max, precision("qty"));
 	},
 
+	get_pending_operation_process_loss: (frm) => {
+		if (!(frm.doc.operations || []).length) {
+			return 0;
+		}
+
+		const total_loss = Math.max(...frm.doc.operations.map((row) => flt(row.process_loss_qty)));
+		return flt(Math.max(total_loss - flt(frm.doc.process_loss_qty), 0), precision("qty"));
+	},
+
 	get_max_requestable_qty: (frm) => {
 		const required = {};
 		const covered = {};
@@ -1129,6 +1138,11 @@ erpnext.work_order = {
 
 	show_prompt_for_qty_input: function (frm, purpose, { qty, additional_transfer_entry, target } = {}) {
 		let max = qty == null ? this.get_max_transferable_qty(frm, purpose) : qty;
+		if (purpose === "Manufacture") {
+			max = flt(Math.max(max - flt(frm.doc.process_loss_qty), 0), precision("qty"));
+		}
+		const pending_process_loss =
+			purpose === "Manufacture" ? this.get_pending_operation_process_loss(frm) : 0;
 
 		let fields = [
 			{
@@ -1137,23 +1151,36 @@ erpnext.work_order = {
 				fieldname: "qty",
 				description: __("Max: {0}", [max]),
 				default: max,
+				onchange: function () {
+					if (pending_process_loss && frm.qty_prompt) {
+						frm.qty_prompt.set_value(
+							"finished_good_qty",
+							flt(Math.max(flt(this.value) - pending_process_loss, 0), precision("qty"))
+						);
+					}
+				},
 			},
 		];
 
-		if (!additional_transfer_entry && !target) {
-			fields.push({
-				fieldtype: "Check",
-				label: __("Consider Process Loss"),
-				fieldname: "consider_process_loss",
-				default: 0,
-				onchange: function () {
-					if (this.value) {
-						frm.qty_prompt.set_value("qty", max - frm.doc.process_loss_qty);
-					} else {
-						frm.qty_prompt.set_value("qty", max);
-					}
+		if (pending_process_loss) {
+			fields.push(
+				{
+					fieldtype: "Float",
+					label: __("Process Loss Qty"),
+					fieldname: "process_loss_qty",
+					default: pending_process_loss,
+					read_only: 1,
+					description: __("Process loss booked against the operations of this work order."),
 				},
-			});
+				{
+					fieldtype: "Float",
+					label: __("Finished Good Qty"),
+					fieldname: "finished_good_qty",
+					default: flt(Math.max(max - pending_process_loss, 0), precision("qty")),
+					read_only: 1,
+					description: __("Actual quantity of the finished good that will be manufactured."),
+				}
+			);
 		}
 
 		return new Promise((resolve, reject) => {


### PR DESCRIPTION
### Issue

With a Work Order of 10 qty and two sequential operations (e.g. Cutting → Assembly):

- The first operation's job card is completed with 8 qty and 2 qty process loss.
- The Complete Job dialog of the second operation's job card still offers 10 qty. The server rejects it on save (validate_sequence_id), but only after the user has filled and submitted the dialog — there is no upfront indication that only 8 can be completed.
- After the second operation ends with 7 completed and 3 process loss, the Finish dialog on the Work Order shows Qty for Manufacture: 10 (Max: 10) with no hint that only 7 finished goods will actually be produced, since the operations' process loss is only rolled into Work Order.process_loss_qty after a Manufacture entry is submitted.

### Afer Fix

Work Order → Finish dialog

- Two new read-only fields, shown when the operations carry process loss that no Manufacture entry has booked yet:
    - Process Loss Qty — pending loss from the operations,
    - Finished Good Qty — entered qty minus that loss, recalculated live as the qty changes.
    - Removed the Consider Process Loss checkbox. Its adjustment is now applied automatically: for Manufacture, the Max (description, default qty, and the over-entry check) is reduced by the loss already booked in earlier Manufacture entries. Previously the checkbox only changed the default value while the validation still allowed the unadjusted max. Nothing server-side read the consider_process_loss flag


<img width="726" height="510" alt="image" src="https://github.com/user-attachments/assets/1762d21e-4c45-445c-90f4-75ebcabedbf9" />
