### PR TITLE
fix: use user data fields hook

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -656,16 +656,16 @@ regional_overrides = {
 		"erpnext.controllers.accounts_controller.validate_regional": "erpnext.regional.italy.utils.sales_invoice_validate",
 	},
 }
-user_privacy_documents = [
+user_data_fields = [
 	{
 		"doctype": "Lead",
-		"match_field": "email_id",
-		"personal_fields": ["phone", "mobile_no", "fax", "website", "lead_name"],
+		"filter_by": "email_id",
+		"redact_fields": ["phone", "mobile_no", "fax", "website", "lead_name"],
 	},
 	{
 		"doctype": "Opportunity",
-		"match_field": "contact_email",
-		"personal_fields": ["contact_mobile", "contact_display", "customer_name"],
+		"filter_by": "contact_email",
+		"redact_fields": ["contact_mobile", "contact_display", "customer_name"],
 	},
 ]
 


### PR DESCRIPTION
## Summary

- Replace the deprecated `user_privacy_documents` hook with `user_data_fields`.
- Replace `match_field` with `filter_by`.
- Replace `personal_fields` with `redact_fields`.

## Why

Frappe reads privacy rules from the `user_data_fields` hook. The deprecated hook prevents the Lead and Opportunity rules from loading.

Closes #58272

## Tests

- `pre-commit run --files erpnext/hooks.py`
- Imported `erpnext.hooks` and verified the complete `user_data_fields` value.
