### PR TITLE
fix: escape on status image for workstations in production status

### DIFF
--- a/erpnext/manufacturing/doctype/workstation/workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/workstation.py
@@ -451,7 +451,7 @@ def get_workstations(**kwargs):
 
 	for d in data:
 		d.workstation_name = get_link_to_form("Workstation", d.name)
-		d.status_image = d.on_status_image
+		d.status_image = frappe.utils.escape_html(d.on_status_image)
 		d.workstation_off = ""
 		d.color = color_map.get(d.status, "red")
 		d.workstation_link = get_url_to_form("Workstation", d.name)


### PR DESCRIPTION
Escapes `on_status_image` in `get_workstations` so both status branches are handled consistently; the sibling `off_status_image` was already escaped.