### PR TITLE
fix(stock): fetch item stock UOM in stock reconciliation

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -1317,12 +1317,15 @@ def get_item_and_warehouses(item_code, warehouse):
 	from frappe.utils.nestedset import get_descendants_of
 
 	items = []
+	stock_uom = frappe.get_cached_value("Item", item_code, "stock_uom")
 	if frappe.get_cached_value("Warehouse", warehouse, "is_group"):
 		childrens = get_descendants_of("Warehouse", warehouse, ignore_permissions=True, order_by="lft")
 		for ch_warehouse in childrens:
-			items.append(frappe._dict({"item_code": item_code, "warehouse": ch_warehouse}))
+			items.append(
+				frappe._dict({"item_code": item_code, "warehouse": ch_warehouse, "stock_uom": stock_uom})
+			)
 	else:
-		items = [frappe._dict({"item_code": item_code, "warehouse": warehouse})]
+		items = [frappe._dict({"item_code": item_code, "warehouse": warehouse, "stock_uom": stock_uom})]
 
 	return items
 
@@ -1349,6 +1352,7 @@ def get_items_for_stock_reco(warehouse, company):
 			bin_dt.warehouse.as_("warehouse"),
 			item.has_serial_no,
 			item.has_batch_no,
+			item.stock_uom,
 		)
 		.where(
 			((item.disabled == 0) | item.disabled.isnull())
@@ -1373,6 +1377,7 @@ def get_items_for_stock_reco(warehouse, company):
 			item_default.default_warehouse.as_("warehouse"),
 			item.has_serial_no,
 			item.has_batch_no,
+			item.stock_uom,
 		)
 		.where(
 			item_default.default_warehouse.isin(warehouses_in_tree)
@@ -1412,6 +1417,7 @@ def get_item_data(row, qty, valuation_rate, serial_no=None):
 		"current_serial_no": serial_no,
 		"serial_no": serial_no,
 		"batch_no": row.get("batch_no"),
+		"stock_uom": row.get("stock_uom"),
 	}
 
 
@@ -1439,6 +1445,7 @@ def get_itemwise_batch(warehouse, posting_date, company, item_code=None):
 					"valuation_rate": row[9],
 					"item_name": row[1],
 					"batch_no": row[4],
+					"stock_uom": row[11],
 				}
 			)
 		)

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -140,6 +140,7 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 			"_Test Stock Reco Item",
 			is_stock_item=1,
 			valuation_rate=100,
+			stock_uom="_Test UOM",
 			warehouse="_Test Warehouse Ledger 1 - _TC",
 			opening_stock=100,
 		)
@@ -147,8 +148,8 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 		items = get_items("_Test Warehouse Group 1 - _TC", nowdate(), nowtime(), "_Test Company")
 
 		self.assertEqual(
-			["_Test Stock Reco Item", "_Test Warehouse Ledger 1 - _TC", 100],
-			[items[0]["item_code"], items[0]["warehouse"], items[0]["qty"]],
+			["_Test Stock Reco Item", "_Test Warehouse Ledger 1 - _TC", 100, "_Test UOM"],
+			[items[0]["item_code"], items[0]["warehouse"], items[0]["qty"], items[0]["stock_uom"]],
 		)
 
 	def test_stock_reco_for_serialized_item(self):


### PR DESCRIPTION
Fixes #58252

In Stock Reconciliation, "Fetch Items from Warehouse" showed the same default Stock UOM on every row instead of each item's own UOM. The fetched rows didn't carry the item's UOM back from the server, so they fell back to the default set in Stock Settings, and the correct UOM only appeared once the document was saved.

Each fetched row now carries its item's Stock UOM, so the grid shows the right one straight away. It's taken from data the existing queries already return, so fetching items is no slower than before.

Backport Needed for v15 & v16