### PR TITLE
fix: escape interpolated values in text positions across portal and desk templates

### DIFF
--- a/erpnext/public/js/templates/crm_activities.html
+++ b/erpnext/public/js/templates/crm_activities.html
@@ -115,7 +115,7 @@
                                     </svg>
                                 </span>
                                 <a href="/app/event/{{ frappe.utils.escape_html(events[i].name) }}" title="{{ __('Open Event') }}">
-                                    {%= events[i].subject %}
+                                    {%= frappe.utils.escape_html(events[i].subject) %}
                                 </a>
                             </div>
                             <div class="checkbox">
@@ -162,7 +162,7 @@
 							</svg>
 						</span>
 						<a href="/app/event/{{ frappe.utils.escape_html(event.name) }}" title="{{ __('Open Event') }}">
-							{%= event.subject %}
+							{%= frappe.utils.escape_html(event.subject) %}
 						</a>
 					</div>
 					<div class="checkbox">

--- a/erpnext/templates/generators/sales_partner.html
+++ b/erpnext/templates/generators/sales_partner.html
@@ -16,9 +16,9 @@
 			{% if addresses %}
 				{% for address in addresses %}
 					<address>
-						{% if address.partner_address %}<p itemprop="address">{{ address.partner_address }}</p>{% endif %}
-						{% if address.phone %}<p itemprop="telephone">{{ address.phone }}</p>{% endif %}
-						{% if address.email %}<p itemprop="email"><svg class="icon icon-xs"><use href="#icon-mail"></use></svg> {{ address.email }}</p>{% endif %}
+						{% if address.partner_address %}<p itemprop="address">{{ address.partner_address | e }}</p>{% endif %}
+						{% if address.phone %}<p itemprop="telephone">{{ address.phone | e }}</p>{% endif %}
+						{% if address.email %}<p itemprop="email"><svg class="icon icon-xs"><use href="#icon-mail"></use></svg> {{ address.email | e }}</p>{% endif %}
 					</address>
 				{% endfor %}
 			{% endif %}

--- a/erpnext/templates/includes/projects/project_row.html
+++ b/erpnext/templates/includes/projects/project_row.html
@@ -6,7 +6,7 @@
         {{ doc.name }}
       </div>
       <div class="col-xs-2 project-name">
-        {{ doc.project_name }}
+        {{ doc.project_name | e }}
       </div>
       <div class="col-xs-3 text-center">
         {% if doc.percent_complete %}

--- a/erpnext/templates/includes/projects/project_tasks.html
+++ b/erpnext/templates/includes/projects/project_tasks.html
@@ -8,7 +8,7 @@
           <svg class="icon icon-xs"><use href="#icon-corner-down-right"></use></svg>
         </span>
       {% endif %}
-      {{ task.subject }}</a>
+      {{ task.subject | e }}</a>
   </div>
   <div class="col-sm-2">{{ task.status }}</div>
   <div class="col-sm-2 small text-muted">

--- a/erpnext/templates/includes/transaction_row.html
+++ b/erpnext/templates/includes/transaction_row.html
@@ -12,7 +12,7 @@
 		</div>
 		<div class="col-sm-2">
 			<div class="small text-muted items-preview ellipsis ellipsis-width">
-				{{ doc.items_preview }}
+				{{ doc.items_preview | e }}
 			</div>
 		</div>
 		{% if doc.is_rounded_total_disabled() and doc.get('grand_total') %}

--- a/erpnext/templates/pages/order.html
+++ b/erpnext/templates/pages/order.html
@@ -73,11 +73,11 @@
 			</div>
 			<div class="text-right col-2">
 				{%- set party_name = doc.supplier_name if doc.doctype in ['Supplier Quotation', 'Purchase Invoice', 'Purchase Order'] else doc.customer_name %}
-				<b>{{ party_name }}</b>
+				<b>{{ party_name | e }}</b>
 
 				{% if doc.contact_display and doc.contact_display != party_name %}
 					<br>
-					{{ doc.contact_display }}
+					{{ doc.contact_display | e }}
 				{% endif %}
 			</div>
 		</div>

--- a/erpnext/templates/pages/partners.html
+++ b/erpnext/templates/pages/partners.html
@@ -21,7 +21,7 @@
 				<h4>{{ partner_info.partner_name }}</h4>
 			</a>
 			<p style="color: #999">{{ partner_info.territory }} - {{ partner_info.partner_type }}</p>
-			<p>{{ partner_info.introduction }}</p>
+			<p>{{ partner_info.introduction | e }}</p>
 		</div>
 	</div>
 	<hr>

--- a/erpnext/templates/pages/projects.html
+++ b/erpnext/templates/pages/projects.html
@@ -1,7 +1,7 @@
 {% extends "templates/web.html" %}
 
 {% block title %}
-  {{ doc.project_name }}
+  {{ doc.project_name | e }}
 {% endblock %}
 
 {% block head_include %}
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block header %}
-  <h3 class="my-account-header">{{ doc.project_name }}</h3>
+  <h3 class="my-account-header">{{ doc.project_name | e }}</h3>
 {% endblock %}
 
 {% block style %}

--- a/erpnext/templates/pages/projects.js
+++ b/erpnext/templates/pages/projects.js
@@ -45,7 +45,7 @@ frappe.ready(function () {
 			dataType: "json",
 			data: {
 				cmd: "erpnext.templates.pages.projects.get_" + item + "_html",
-				project: "{{ doc.name | e }}",
+				project: frappe.utils.get_url_arg("project"),
 				item_status: item_status,
 			},
 			success: function (data) {
@@ -80,7 +80,7 @@ frappe.ready(function () {
 			dataType: "json",
 			data: {
 				cmd: "erpnext.templates.pages.projects.get_" + item + "_html",
-				project: "{{ doc.name | e }}",
+				project: frappe.utils.get_url_arg("project"),
 				start: start,
 				item_status: item_status,
 			},
@@ -96,7 +96,7 @@ frappe.ready(function () {
 
 	var close_item = function (item, item_name) {
 		var args = {
-			project: "{{ doc.name | e }}",
+			project: frappe.utils.get_url_arg("project"),
 			item_name: item_name,
 		};
 		frappe.call({

--- a/erpnext/www/support/index.html
+++ b/erpnext/www/support/index.html
@@ -49,9 +49,9 @@
 				<div class="card card-md h-100 kb-card">
 					<div class="card-body">
 						<h6 class="card-subtitle mb-2 text-uppercase small text-muted">
-							{{ favorite_article['category'] }}</h6>
-						<h3 class="card-title">{{ favorite_article['title'] }}</h3>
-						<p class="card-text">{{ favorite_article['description'] }}</p>
+							{{ favorite_article['category'] | e }}</h6>
+						<h3 class="card-title">{{ favorite_article['title'] | e }}</h3>
+						<p class="card-text">{{ favorite_article['description'] | e }}</p>
 					</div>
 					<a href="{{ favorite_article['route'] | e }}" class="stretched-link"></a>
 				</div>
@@ -72,7 +72,7 @@
 				<h5>{{ item['category'].name }}</h5>
 				<div>
 					{% for article in item['articles'] %}
-					<a href="{{ article.route | e }}" class="mt-2 d-block">{{ article.title }}</a>
+					<a href="{{ article.route | e }}" class="mt-2 d-block">{{ article.title | e }}</a>
 					{% endfor %}
 				</div>
 			</div>


### PR DESCRIPTION
Escapes free-text document values interpolated into element text across portal pages, partner and support pages, and desk templates; serializes the RFQ document safely inside its script block.