### PR TITLE
fix: 'Select All' in General Ledger filters picks only the first 10

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -38,10 +38,13 @@ frappe.query_reports["General Ledger"] = {
 			label: __("Account"),
 			fieldtype: "MultiSelectList",
 			options: "Account",
-			get_data: function (txt) {
-				return frappe.db.get_link_options("Account", txt, {
-					company: frappe.query_report.get_filter_value("company"),
-				});
+			get_data: function (txt, for_select_all) {
+				return frappe.db.get_link_options(
+					"Account",
+					txt,
+					{ company: frappe.query_report.get_filter_value("company") },
+					for_select_all ? 25000 : undefined
+				);
 			},
 		},
 		{
@@ -75,13 +78,13 @@ frappe.query_reports["General Ledger"] = {
 			fieldtype: "MultiSelectList",
 			options: "party_type",
 			depends_on: "party_type",
-			get_data: function (txt) {
+			get_data: function (txt, for_select_all) {
 				if (!frappe.query_report.filters) return;
 
 				let party_type = frappe.query_report.get_filter_value("party_type");
 				if (!party_type) return;
 
-				return frappe.db.get_link_options(party_type, txt);
+				return frappe.db.get_link_options(party_type, txt, {}, for_select_all ? 25000 : undefined);
 			},
 			on_change: function () {
 				var party_type = frappe.query_report.get_filter_value("party_type");
@@ -154,10 +157,13 @@ frappe.query_reports["General Ledger"] = {
 			label: __("Cost Center"),
 			fieldtype: "MultiSelectList",
 			options: "Cost Center",
-			get_data: function (txt) {
-				return frappe.db.get_link_options("Cost Center", txt, {
-					company: frappe.query_report.get_filter_value("company"),
-				});
+			get_data: function (txt, for_select_all) {
+				return frappe.db.get_link_options(
+					"Cost Center",
+					txt,
+					{ company: frappe.query_report.get_filter_value("company") },
+					for_select_all ? 25000 : undefined
+				);
 			},
 		},
 		{
@@ -165,10 +171,13 @@ frappe.query_reports["General Ledger"] = {
 			label: __("Project"),
 			fieldtype: "MultiSelectList",
 			options: "Project",
-			get_data: function (txt) {
-				return frappe.db.get_link_options("Project", txt, {
-					company: frappe.query_report.get_filter_value("company"),
-				});
+			get_data: function (txt, for_select_all) {
+				return frappe.db.get_link_options(
+					"Project",
+					txt,
+					{ company: frappe.query_report.get_filter_value("company") },
+					for_select_all ? 25000 : undefined
+				);
 			},
 		},
 		{


### PR DESCRIPTION
## What was wrong
In the General Ledger report, clicking **Select All** on the Account, Party, Cost Center, or Project filter only selected the first 10 matching records, even if there were many more.

## Fix
These filters now fetch the complete matching list when you click Select All, instead of just the small preview the dropdown loads for browsing. Requires the companion fix in frappe/frappe#41991.