### PR TITLE
Fix/return qty validation different uom

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -215,7 +215,7 @@ def validate_quantity(doc, key, args, ref, valid_items, already_returned_items):
 			else 0
 		)
 
-		if column == "stock_qty" and not args.get("return_qty_from_rejected_warehouse"):
+		if column in ("stock_qty", "qty") and not args.get("return_qty_from_rejected_warehouse"):
 			reference_qty = ref.get(column)
 			current_stock_qty = args.get(column)
 		elif args.get("return_qty_from_rejected_warehouse"):

--- a/erpnext/controllers/tests/test_sales_and_purchase_return.py
+++ b/erpnext/controllers/tests/test_sales_and_purchase_return.py
@@ -110,3 +110,35 @@ class TestSalesAndPurchaseReturn(ERPNextTestSuite):
 		return_si.items[0].qty = 0
 
 		self.assertRaises(frappe.ValidationError, return_si.save)
+
+	def test_sales_invoice_partial_return_with_different_stock_uom(self):
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+		from erpnext.controllers.sales_and_purchase_return import make_return_doc
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		item_properties = {"is_stock_item": 1, "stock_uom": "Kg"}
+		if frappe.get_meta("Item").has_field("gst_hsn_code") and frappe.db.exists("GST HSN Code", "010121"):
+			item_properties["gst_hsn_code"] = "010121"
+
+		item = make_item(
+			"_Test SI Return Different Stock UOM",
+			item_properties,
+			uoms=[{"uom": "Nos", "conversion_factor": 0.013888889}],
+		)
+
+		si = create_sales_invoice(item_code=item.name, qty=48, do_not_save=True)
+		si.items[0].uom = "Nos"
+		si.items[0].stock_uom = "Kg"
+		si.items[0].conversion_factor = 0.013888889
+		si.save().submit()
+		self.addCleanup(self._cancel_and_delete, "Sales Invoice", si.name)
+
+		first_return = make_return_doc(si.doctype, si.name)
+		first_return.items[0].qty = -24
+		first_return.save().submit()
+		self.addCleanup(self._cancel_and_delete, "Sales Invoice", first_return.name)
+
+		second_return = make_return_doc(si.doctype, si.name)
+		self.assertEqual(second_return.items[0].qty, -24)
+		second_return.save().submit()
+		self.addCleanup(self._cancel_and_delete, "Sales Invoice", second_return.name)


### PR DESCRIPTION
**Issue:**                                                                                                                             
    When creating multiple partial returns against a Sales Invoice or Purchase Invoice (with update_stock = 0) where the item's transaction  
  UOM differs from its stock UOM (e.g., uom = Nos, stock_uom = Kg, conversion_factor = 0.013888889):                                             
                                                                                                                                                       
    1. The first partial return submits successfully.                                                                                                  
    2. Attempting a second partial return for the remaining quantity fails with StockOverReturnError (Cannot return more than -23.33...).          
                                                                                                                                                       
**Root Cause :**                                                                                                                            
    In sales_and_purchase_return.py:                                                                                                                   
    - For non-stock invoices, validate_quantity validates column = "qty".                                                                          
    - already_returned_items retrieves returned_qty in transaction UOM (qty).                                                                    
    - Previously, line 216 only checked if column == "stock_qty", causing column == "qty" to hit the else: block, which multiplied               
  reference_qty and current_stock_qty by conversion_factor into stock UOM while returned_qty remained in transaction UOM.                      
    - Comparing stock UOM quantities against transaction UOM quantities caused max_returnable_qty = reference_qty - returned_qty to become negative.

**Steps To Reproduce:**                                                                                                                    
                                                                                                                                                       
  1. Create an Item with stock UOM Kg and secondary UOM Nos (e.g. conversion_factor = 0.013888889).                                                    
  2. Create and submit a Sales Invoice with qty = 48 Nos (without stock update).                                                                       
  3. Create a Return Sales Invoice for -24 Nos and submit.                                                                                             
  4. Create a second Return Sales Invoice for -24 Nos and submit.                                                                                      
  5. Verify that the second return submits without throwing StockOverReturnError.      


Ref:[# 76265](https://support.frappe.io/helpdesk/tickets/76265)

Raising PR behalf of @Afsalsyed 