### PR TITLE
fix(stock): show backdated batches in stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -87,29 +87,15 @@ frappe.ui.form.on("Stock Entry", {
 
 		frm.set_query("batch_no", "items", function (doc, cdt, cdn) {
 			let item = locals[cdt][cdn];
-			let filters = {};
 
 			if (!item.item_code) {
 				frappe.throw(__("Please enter Item Code to get Batch Number"));
 			} else {
-				if (
-					[
-						"Material Transfer for Manufacture",
-						"Manufacture",
-						"Repack",
-						"Send to Subcontractor",
-						"Receive from Customer",
-					].includes(doc.purpose)
-				) {
-					filters = {
-						item_code: item.item_code,
-						posting_date: frm.doc.posting_date || frappe.datetime.nowdate(),
-					};
-				} else {
-					filters = {
-						item_code: item.item_code,
-					};
-				}
+				const filters = {
+					item_code: item.item_code,
+					posting_date: frm.doc.posting_date || frappe.datetime.nowdate(),
+					posting_time: frm.doc.posting_time || frappe.datetime.now_time(),
+				};
 
 				// User could want to select a manually created empty batch (no warehouse)
 				// or a pre-existing batch


### PR DESCRIPTION
## What changed

- Pass the Stock Entry posting date and time to the batch query for every stock entry purpose.

## Why

The batch query supports a posting timestamp cutoff. The direct Stock Entry batch field did not send the complete timestamp.

Material Issue sent neither value. Repack sent only the posting date. These requests used the current batch quantity instead.

This change makes the field show batches that were available at the Stock Entry posting timestamp.

Closes #40551

## Tests

- Targeted pre-commit checks for `stock_entry.js`
