### PR TITLE
fix(stock): preserve zero return incoming rates

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -813,7 +813,7 @@ def get_rate_for_return(
 	if not (rate and return_against) and voucher_type in ["Sales Invoice", "Delivery Note"]:
 		rate = frappe.db.get_value(f"{voucher_type} Item", voucher_detail_no, "incoming_rate")
 
-		if not rate and sle:
+		if rate is None and sle:
 			rate = get_incoming_rate(
 				{
 					"item_code": sle.item_code,


### PR DESCRIPTION
## Summary

- Preserve an explicit zero incoming rate for standalone sales returns.

## Root cause

`get_rate_for_return` treated zero as a missing value. It then recalculated the rate from the current stock queue.

## Impact

Returns that allow zero valuation now keep their explicit zero stock value during rate recalculation.

## Checks

- `pre-commit run --files erpnext/controllers/sales_and_purchase_return.py`

Closes #55910
