### PR TITLE
feat: keep packed rows in the warehouse their bundle item moves to 

### DIFF
--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -120,6 +120,7 @@ erpnext.sales_common = {
 
 				this.toggle_editable_price_list_rate();
 				this.change_warehouse_labels_for_return();
+				this.snapshot_item_warehouses();
 			}
 
 			company() {
@@ -285,7 +286,42 @@ erpnext.sales_common = {
 					frappe.model.set_value(cdt, cdn, "incoming_rate", 0.0);
 				}
 
+				this.move_packed_items_along(cdt, cdn, "warehouse");
 				this.set_actual_qty(doc, cdt, cdn);
+			}
+
+			target_warehouse(doc, cdt, cdn) {
+				this.move_packed_items_along(cdt, cdn, "target_warehouse");
+			}
+
+			snapshot_item_warehouses() {
+				// what each item row carried before the edit, to tell a packed row that was
+				// following its bundle item from one moved to a warehouse of its own
+				this._item_warehouses = {};
+				for (const item of this.frm.doc.items || []) {
+					this._item_warehouses[item.name] = {
+						warehouse: item.warehouse,
+						target_warehouse: item.target_warehouse,
+					};
+				}
+			}
+
+			move_packed_items_along(cdt, cdn, fieldname) {
+				// mirrors `keep_following_bundle_item` in packed_item.py, so the grid shows
+				// now what the next save would have done anyway. a row left on the packed
+				// item's own default is left to the save, which knows what that default is
+				const row = locals[cdt][cdn];
+				const stale = (this._item_warehouses || {})[row.name] || {};
+				const stale_warehouse = stale[fieldname];
+				this.snapshot_item_warehouses();
+
+				if (!stale_warehouse || row[fieldname] === stale_warehouse) return;
+
+				for (const packed of this.frm.doc.packed_items || []) {
+					if (packed.parent_detail_docname === row.name && packed[fieldname] === stale_warehouse) {
+						frappe.model.set_value(packed.doctype, packed.name, fieldname, row[fieldname]);
+					}
+				}
 			}
 
 			set_actual_qty(doc, cdt, cdn) {

--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -14,6 +14,8 @@ from frappe.utils import flt
 
 from erpnext.stock.get_item_details import get_item_details, get_price_list_rate
 
+WAREHOUSE_FIELDNAMES = ("warehouse", "target_warehouse")
+
 
 class PackedItem(Document):
 	# begin: auto-generated types
@@ -72,6 +74,7 @@ def make_packing_list(doc):
 	set_price_from_children = frappe.get_single_value("Selling Settings", "editable_bundle_item_rates")
 
 	stale_packed_items_table = get_indexed_packed_items_table(doc)
+	stale_item_warehouses = get_stale_item_warehouses(doc)
 
 	reset = reset_packing_list(doc)
 
@@ -96,7 +99,9 @@ def make_packing_list(doc):
 				pi_row.product_bundle = bundle_name
 				item_data = get_packed_item_details(bundle_item.item_code, doc.company)
 				update_packed_item_basic_data(item_row, pi_row, bundle_item, item_data)
-				update_packed_item_stock_data(item_row, pi_row, bundle_item, item_data, doc)
+				update_packed_item_stock_data(
+					item_row, pi_row, bundle_item, item_data, doc, stale_item_warehouses
+				)
 				update_packed_item_price_data(pi_row, item_data, doc)
 
 				if item_row.get("against_pick_list"):
@@ -115,6 +120,38 @@ def is_product_bundle(item_code: str) -> bool:
 	from erpnext.selling.doctype.product_bundle.product_bundle import get_active_product_bundle
 
 	return bool(get_active_product_bundle(item_code))
+
+
+def get_stale_item_warehouses(doc):
+	"""Warehouses each bundle item row carried when the document was last saved.
+
+	Used to tell a packed row that was following its bundle item from one that was
+	moved to a warehouse of its own.
+	"""
+	doc_before_save = doc.get_doc_before_save()
+	if not doc_before_save:
+		return {}
+
+	return {
+		item.name: {fieldname: item.get(fieldname) for fieldname in WAREHOUSE_FIELDNAMES}
+		for item in doc_before_save.get("items")
+	}
+
+
+def keep_following_bundle_item(pi_row, main_item_row, stale_warehouses, fieldname, packed_default=None):
+	"""Move a packed row along with its bundle item, unless it was moved on its own."""
+	warehouse = main_item_row.get(fieldname)
+	stale_warehouse = stale_warehouses.get(fieldname)
+	if not warehouse or warehouse == stale_warehouse:
+		return
+
+	# a bundle item that had no warehouse of its own was never something to be matched to,
+	# so a row still sitting on the packed item's default is following rather than placed
+	followed_warehouse = stale_warehouse or packed_default
+	if not followed_warehouse or pi_row.get(fieldname) != followed_warehouse:
+		return
+
+	pi_row.set(fieldname, warehouse)
 
 
 def get_indexed_packed_items_table(doc):
@@ -276,7 +313,9 @@ def update_packed_item_basic_data(main_item_row, pi_row, packing_item, item_data
 		pi_row.description = packing_item.get("description")
 
 
-def update_packed_item_stock_data(main_item_row, pi_row, packing_item, item_data, doc):
+def update_packed_item_stock_data(
+	main_item_row, pi_row, packing_item, item_data, doc, stale_item_warehouses=None
+):
 	# TODO batch_no, actual_batch_qty, incoming_rate
 	if main_item_row.get("so_detail"):
 		pi_row.warehouse = frappe.get_value(
@@ -299,6 +338,14 @@ def update_packed_item_stock_data(main_item_row, pi_row, packing_item, item_data
 
 	if not pi_row.target_warehouse:
 		pi_row.target_warehouse = main_item_row.get("target_warehouse")
+
+	# a row still sitting where the bundle item was keeps following it; one that was
+	# moved somewhere of its own is left alone
+	stale_warehouses = (stale_item_warehouses or {}).get(main_item_row.get("name")) or {}
+	keep_following_bundle_item(
+		pi_row, main_item_row, stale_warehouses, "warehouse", item_data.default_warehouse
+	)
+	keep_following_bundle_item(pi_row, main_item_row, stale_warehouses, "target_warehouse")
 
 	bin = get_packed_item_bin_qty(packing_item.item_code, pi_row.warehouse)
 	pi_row.actual_qty = flt(bin.get("actual_qty"))

--- a/erpnext/stock/doctype/packed_item/test_packed_item.py
+++ b/erpnext/stock/doctype/packed_item/test_packed_item.py
@@ -438,3 +438,69 @@ class TestPackedItem(ERPNextTestSuite):
 		for d in expected_returns:
 			d.qty /= 2
 		self.assertReturns(expected_returns, dn_ret.packed_items)
+
+	def test_changing_bundle_item_warehouse_moves_packed_rows(self):
+		"Test packed items follow the bundle item row when its warehouse is changed."
+		other_warehouse = "Stores - _TC"
+		so = make_sales_order(item_code=self.bundle, qty=1, warehouse=self.warehouse, do_not_submit=True)
+
+		self.assertEqual([row.warehouse for row in so.packed_items], [self.warehouse] * 2)
+
+		so.items[0].warehouse = other_warehouse
+		so.save()
+
+		self.assertEqual([row.warehouse for row in so.packed_items], [other_warehouse] * 2)
+
+	def test_overridden_packed_row_warehouse_is_kept(self):
+		"Test a packed row set to its own warehouse is left where it is."
+		other_warehouse = "Stores - _TC"
+		so = make_sales_order(item_code=self.bundle, qty=1, warehouse=self.warehouse, do_not_submit=True)
+
+		so.packed_items[0].warehouse = other_warehouse
+		so.save()
+
+		so.items[0].warehouse = "Finished Goods - _TC"
+		so.save()
+
+		# the row that was following the bundle item moves, the overridden one stays put
+		self.assertEqual(so.packed_items[0].warehouse, other_warehouse)
+		self.assertEqual(so.packed_items[1].warehouse, "Finished Goods - _TC")
+
+	def test_changing_bundle_item_target_warehouse_moves_packed_rows(self):
+		"Test packed items follow the bundle item row when its target warehouse is changed."
+		so = make_sales_order(item_code=self.bundle, qty=1, warehouse=self.warehouse, do_not_submit=True)
+		so.items[0].target_warehouse = "Stores - _TC"
+		so.save()
+
+		self.assertEqual([row.target_warehouse for row in so.packed_items], ["Stores - _TC"] * 2)
+
+		so.items[0].target_warehouse = "Finished Goods - _TC"
+		so.save()
+
+		self.assertEqual([row.target_warehouse for row in so.packed_items], ["Finished Goods - _TC"] * 2)
+
+	def test_packed_row_on_its_own_default_follows_a_late_warehouse(self):
+		"Test a packed row left on the packed item's default follows the bundle item later."
+		component = make_item(
+			properties={
+				"is_stock_item": 1,
+				"item_defaults": [{"company": "_Test Company", "default_warehouse": self.warehouse}],
+			}
+		).name
+		bundle = make_item(properties={"is_stock_item": 0}).name
+		bundle_doc = frappe.get_doc({"doctype": "Product Bundle", "new_item_code": bundle})
+		bundle_doc.append("items", {"item_code": component, "qty": 2})
+		bundle_doc.insert()
+		bundle_doc.submit()
+
+		so = make_sales_order(item_code=bundle, qty=1, do_not_submit=True)
+		# a bundle item row carrying no warehouse of its own: the packed row was left on the
+		# packed item's default, which `set_missing_values` would otherwise fill in for us
+		frappe.db.set_value("Sales Order Item", so.items[0].name, "warehouse", None)
+		frappe.db.set_value("Packed Item", so.packed_items[0].name, "warehouse", self.warehouse)
+		so.reload()
+
+		so.items[0].warehouse = "Stores - _TC"
+		so.save()
+
+		self.assertEqual(so.packed_items[0].warehouse, "Stores - _TC")


### PR DESCRIPTION
**Issue:**

- Changing the warehouse on a Product Bundle item row leaves its components behind in the warehouse they were first packed into. The same goes for the target warehouse.

**Fixes:** #11271

**Steps to Reproduce:**

- Create a Product Bundle item with two or more components.                                                                                                             - Add it to a Delivery Note (or Sales Order / Sales Invoice) with a waacking List rows pick up that warehouse.
- Change the warehouse on the bundle item row, and save again.
- Look at the Packing List: the component rows are still in the old warehouse.                                                                                          - Repeat with To Warehouse instead of From Warehouse — same result.

**Actual Behaviour:**

The components stay where they were first packed, however many times the row above them is moved. The delivery is then made from a warehouse the user never picked, and the stock check on the packing list reads against the wrong bin.

**Expected Behaviour:**

A component follows the bundle item it belongs to, unless it has been deliberately put somewhere of its own.

Backport Needed For V15 and V16