### PR TITLE
fix: do not round up finished good qty for whole number UOM

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1015,6 +1015,33 @@ class TestWorkOrder(ERPNextTestSuite):
 		stock_entry = frappe.get_doc(make_stock_entry(wo.name, "Material Transfer for Manufacture"))
 		self.assertRaises(frappe.ValidationError, stock_entry.save)
 
+	def test_manufacture_entry_fg_qty_not_rounded_for_whole_number_uom(self):
+		from erpnext.utilities.transaction_base import UOMMustBeIntegerError
+
+		fg_item = "Test FG Item Whole Number UOM"
+		rm_item = "Test RM Item Whole Number UOM"
+		uom = "Test Whole Number UOM"
+
+		if not frappe.db.exists("UOM", uom):
+			frappe.get_doc({"doctype": "UOM", "uom_name": uom}).insert()
+		frappe.db.set_value("UOM", uom, "must_be_whole_number", 0)
+
+		make_item(fg_item, {"is_stock_item": 1, "include_item_in_manufacturing": 1, "stock_uom": uom})
+		make_item(rm_item, {"is_stock_item": 1, "include_item_in_manufacturing": 1})
+
+		if not frappe.db.exists("BOM", {"item": fg_item}):
+			make_bom(item=fg_item, raw_materials=[rm_item], rm_qty=1)
+
+		wo = make_wo_order_test_record(
+			item=fg_item, qty=2, skip_transfer=1, source_warehouse="_Test Warehouse - _TC"
+		)
+		frappe.db.set_value("UOM", uom, "must_be_whole_number", 1)
+
+		stock_entry = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 0.5))
+		fg_row = next(row for row in stock_entry.items if row.is_finished_item)
+		self.assertEqual(fg_row.qty, 0.5)
+		self.assertRaises(UOMMustBeIntegerError, stock_entry.save)
+
 	def test_wo_completion_with_pl_bom(self):
 		from erpnext.manufacturing.doctype.bom.test_bom import (
 			create_bom_with_process_loss_item,

--- a/erpnext/stock/doctype/stock_entry/services/manufacturing.py
+++ b/erpnext/stock/doctype/stock_entry/services/manufacturing.py
@@ -163,7 +163,7 @@ class BaseManufactureStockEntry(BaseStockEntry):
 			{
 				"conversion_factor": 1,
 				"uom": item_details.stock_uom,
-				"qty": ceil_qty_if_uom_has_whole_number(fg_item_qty, item_details.stock_uom),
+				"qty": fg_item_qty,
 				"t_warehouse": self.doc.to_warehouse
 				or frappe.get_cached_value("BOM", self.doc.bom_no, "default_target_warehouse"),
 				"s_warehouse": None,


### PR DESCRIPTION
The manufacture stock entry ceiled the finished good qty when the item's stock UOM has **Must be Whole Number** set, silently booking more produced stock than requested (a finish entry for 0.286 produced 1).

The ceil was introduced in fa842e87 for backflushed raw material rows, where rounding consumption up to a whole unit is legitimate. Applying it to the finished good row fabricates output instead. Keep the finished good qty as computed; `validate_uom_is_integer` already rejects a fractional qty with a clear error on save.