### PR TITLE
fix(journal-entry): avoid full grid re-render per row in set_exchange_rate

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -677,6 +677,6 @@ Object.assign(erpnext.journal_entry, {
 		} else {
 			erpnext.journal_entry.set_debit_credit_in_company_currency(frm, cdt, cdn);
 		}
-		frm.refresh_field("accounts");
+		frm.get_field("accounts").grid.refresh_row(cdn);
 	},
 });


### PR DESCRIPTION
## Summary
- Opening a Journal Entry with a large `accounts` child table was slow. `refresh()` loops over every row and calls `set_exchange_rate()` per row, which unconditionally ended with `frm.refresh_field("accounts")` — a full grid rebuild (header, pagination, current page) triggered once per row.
- Replaced it with `grid.refresh_row(cdn)`, which only re-renders the one row that changed and is a cheap no-op for rows outside the currently rendered page.
- No linked issue; found while investigating a user report of a 1000-line Journal Entry taking noticeably longer to open than in earlier versions.

## Test plan
Measured in a real headless-Chrome load of a 1000-row Journal Entry:

| | Before | After |
|---|---|---|
| Time to first rendered row | 8.52s | 2.32s |
| Time to network-idle | 9.33s | 2.87s |
| Main-thread blocking time | 7.85s | 1.95s |

- [x] Manually verified in browser that debit/credit/exchange rate still update correctly on `posting_date`, `debit_in_account_currency`, `credit_in_account_currency` changes for single- and multi-currency entries
- [x] `bench build --app erpnext` succeeds