### PR TITLE
fix(permissions): grant select on link targets to roles with write access

### DIFF
--- a/erpnext/accounts/doctype/account/account.json
+++ b/erpnext/accounts/doctype/account/account.json
@@ -203,7 +203,7 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2026-04-14 18:14:42.202065",
+ "modified": "2026-08-21 23:11:37.851001",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Account",
@@ -263,6 +263,46 @@
   },
   {
    "role": "HR Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing Manager",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing User",
+   "select": 1
+  },
+  {
+   "role": "Purchase Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
    "select": 1
   }
  ],

--- a/erpnext/accounts/doctype/bank/bank.json
+++ b/erpnext/accounts/doctype/bank/bank.json
@@ -101,7 +101,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-27 13:06:36.896195",
+ "modified": "2026-08-21 23:11:39.423431",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank",
@@ -118,9 +118,18 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Accounts Manager",
+   "select": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/bank_account/bank_account.json
+++ b/erpnext/accounts/doctype/bank_account/bank_account.json
@@ -269,7 +269,7 @@
    "link_fieldname": "default_bank_account"
   }
  ],
- "modified": "2026-04-11 19:46:27.609994",
+ "modified": "2026-08-21 23:11:39.585456",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Account",
@@ -299,6 +299,22 @@
    "role": "Accounts User",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Purchase Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/accounts/doctype/cost_center/cost_center.json
+++ b/erpnext/accounts/doctype/cost_center/cost_center.json
@@ -126,7 +126,7 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2026-04-14 18:15:27.367298",
+ "modified": "2026-08-21 23:11:40.799391",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Cost Center",
@@ -180,6 +180,54 @@
   },
   {
    "role": "HR Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing Manager",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing User",
+   "select": 1
+  },
+  {
+   "role": "Projects Manager",
+   "select": 1
+  },
+  {
+   "role": "Projects User",
+   "select": 1
+  },
+  {
+   "role": "Purchase Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
    "select": 1
   }
  ],

--- a/erpnext/accounts/doctype/coupon_code/coupon_code.json
+++ b/erpnext/accounts/doctype/coupon_code/coupon_code.json
@@ -125,7 +125,7 @@
   }
  ],
  "links": [],
- "modified": "2024-11-19 16:35:11.836441",
+ "modified": "2026-08-21 23:11:41.010871",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Coupon Code",
@@ -179,8 +179,17 @@
    "role": "Website Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/finance_book/finance_book.json
+++ b/erpnext/accounts/doctype/finance_book/finance_book.json
@@ -20,7 +20,7 @@
  ],
  "icon": "fa fa-book",
  "links": [],
- "modified": "2024-03-27 13:09:44.514241",
+ "modified": "2026-08-21 23:11:42.386104",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Finance Book",
@@ -55,9 +55,22 @@
    "report": 1,
    "role": "Auditor",
    "share": 1
+  },
+  {
+   "role": "HR Manager",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing Manager",
+   "select": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "finance_book_name",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/erpnext/accounts/doctype/fiscal_year/fiscal_year.json
+++ b/erpnext/accounts/doctype/fiscal_year/fiscal_year.json
@@ -82,7 +82,7 @@
  "icon": "fa fa-calendar",
  "idx": 1,
  "links": [],
- "modified": "2024-05-27 17:29:55.560840",
+ "modified": "2026-08-21 23:11:42.509102",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Fiscal Year",
@@ -131,8 +131,13 @@
   {
    "read": 1,
    "role": "Auditor"
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "name",
  "sort_order": "DESC",

--- a/erpnext/accounts/doctype/item_tax_template/item_tax_template.json
+++ b/erpnext/accounts/doctype/item_tax_template/item_tax_template.json
@@ -57,7 +57,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-27 13:09:55.573483",
+ "modified": "2026-08-21 23:11:43.571355",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Item Tax Template",
@@ -95,8 +95,57 @@
    "report": 1,
    "role": "Accounts User",
    "share": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Item Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase User",
+   "select": 1
+  },
+  {
+   "role": "Sales Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
+  },
+  {
+   "role": "Stock User",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/erpnext/accounts/doctype/loyalty_program/loyalty_program.json
+++ b/erpnext/accounts/doctype/loyalty_program/loyalty_program.json
@@ -147,14 +147,14 @@
    "fieldtype": "Column Break"
   },
   {
-    "fieldname": "project",
-    "fieldtype": "Link",
-    "label": "Project",
-    "options": "Project"
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
   }
  ],
  "links": [],
- "modified": "2024-03-27 13:10:03.361383",
+ "modified": "2026-08-21 23:11:44.144864",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Loyalty Program",
@@ -171,9 +171,18 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
+   "select": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.json
+++ b/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.json
@@ -48,7 +48,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-14 18:16:47.795986",
+ "modified": "2026-08-21 23:11:44.763131",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Mode of Payment",
@@ -75,6 +75,30 @@
   },
   {
    "role": "HR Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Purchase Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase User",
+   "select": 1
+  },
+  {
+   "role": "Sales Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
    "select": 1
   }
  ],

--- a/erpnext/accounts/doctype/monthly_distribution/monthly_distribution.json
+++ b/erpnext/accounts/doctype/monthly_distribution/monthly_distribution.json
@@ -46,7 +46,7 @@
  "icon": "fa fa-bar-chart",
  "idx": 1,
  "links": [],
- "modified": "2024-03-27 13:10:05.873547",
+ "modified": "2026-08-21 23:11:44.908490",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Monthly Distribution",
@@ -69,8 +69,13 @@
    "read": 1,
    "report": 1,
    "role": "Accounts Manager"
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/accounts/doctype/payment_term/payment_term.json
+++ b/erpnext/accounts/doctype/payment_term/payment_term.json
@@ -116,7 +116,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-27 13:10:11.511137",
+ "modified": "2026-08-21 23:11:45.693762",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Term",
@@ -157,9 +157,34 @@
    "role": "Accounts User",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Purchase Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase User",
+   "select": 1
+  },
+  {
+   "role": "Sales Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
+   "select": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
@@ -1643,7 +1643,7 @@
  "icon": "fa fa-file-text",
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-12 12:00:00.000000",
+ "modified": "2026-08-21 23:11:45.029925",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice",
@@ -1686,6 +1686,14 @@
    "permlevel": 1,
    "read": 1,
    "role": "All"
+  },
+  {
+   "role": "Sales Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.json
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.json
@@ -582,7 +582,7 @@
    "link_fieldname": "pos_profile"
   }
  ],
- "modified": "2026-02-10 14:24:48.597412",
+ "modified": "2026-08-21 23:11:45.419667",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Profile",
@@ -606,6 +606,10 @@
    "read": 1,
    "report": 1,
    "role": "Accounts User"
+  },
+  {
+   "role": "Sales Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -1696,7 +1696,7 @@
  "idx": 204,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-12 12:00:00.000000",
+ "modified": "2026-08-21 23:11:46.733125",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice",
@@ -1749,6 +1749,18 @@
    "read": 1,
    "role": "Accounts Manager",
    "write": 1
+  },
+  {
+   "role": "Manufacturing Manager",
+   "select": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges_template/purchase_taxes_and_charges_template.json
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges_template/purchase_taxes_and_charges_template.json
@@ -77,7 +77,7 @@
  "icon": "fa fa-money",
  "idx": 1,
  "links": [],
- "modified": "2024-03-27 13:10:26.945131",
+ "modified": "2026-08-21 23:11:47.506282",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Taxes and Charges Template",
@@ -104,8 +104,25 @@
   {
    "read": 1,
    "role": "Purchase User"
+  },
+  {
+   "role": "Accounts Manager",
+   "select": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing Manager",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_title_field_in_link": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/erpnext/accounts/doctype/sales_taxes_and_charges_template/sales_taxes_and_charges_template.json
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges_template/sales_taxes_and_charges_template.json
@@ -79,7 +79,7 @@
  "icon": "fa fa-money",
  "idx": 1,
  "links": [],
- "modified": "2024-03-27 13:10:38.343481",
+ "modified": "2026-08-21 23:11:48.797423",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Taxes and Charges Template",
@@ -113,8 +113,29 @@
    "role": "Sales Master Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_title_field_in_link": 1,
  "sort_field": "creation",
  "sort_order": "ASC",

--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.json
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.json
@@ -149,7 +149,7 @@
  "icon": "fa fa-truck",
  "idx": 1,
  "links": [],
- "modified": "2026-07-22 14:53:27.315435",
+ "modified": "2026-08-21 23:11:49.532098",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Shipping Rule",
@@ -195,6 +195,38 @@
    "role": "Sales Master Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase User",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/accounts/doctype/tax_category/tax_category.json
+++ b/erpnext/accounts/doctype/tax_category/tax_category.json
@@ -29,7 +29,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:10:51.976600",
+ "modified": "2026-08-21 23:11:50.740962",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Tax Category",
@@ -68,9 +68,66 @@
    "report": 1,
    "role": "Accounts User",
    "share": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Item Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase User",
+   "select": 1
+  },
+  {
+   "role": "Sales Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
+  },
+  {
+   "role": "Stock User",
+   "select": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.json
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.json
@@ -100,7 +100,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-30 07:13:51.785735",
+ "modified": "2026-08-21 23:11:50.979676",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Tax Withholding Category",
@@ -142,6 +142,26 @@
    "role": "Accounts User",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Item Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/accounts/doctype/tax_withholding_group/tax_withholding_group.json
+++ b/erpnext/accounts/doctype/tax_withholding_group/tax_withholding_group.json
@@ -21,7 +21,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-29 05:25:50.243710",
+ "modified": "2026-08-21 23:11:51.176158",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Tax Withholding Group",
@@ -39,6 +39,30 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Accounts Manager",
+   "select": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
+  },
+  {
+   "role": "Purchase Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -627,7 +627,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2026-03-12 16:07:39.543227",
+ "modified": "2026-08-21 23:11:38.364997",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",
@@ -663,6 +663,30 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "role": "Manufacturing Manager",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing User",
+   "select": 1
+  },
+  {
+   "role": "Purchase Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase User",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
+  },
+  {
+   "role": "Stock User",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/assets/doctype/asset_category/asset_category.json
+++ b/erpnext/assets/doctype/asset_category/asset_category.json
@@ -73,7 +73,7 @@
   }
  ],
  "links": [],
- "modified": "2025-05-13 15:33:03.791814",
+ "modified": "2026-08-21 23:11:38.710171",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Category",
@@ -116,6 +116,10 @@
    "role": "Quality Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Item Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/assets/doctype/asset_maintenance_team/asset_maintenance_team.json
+++ b/erpnext/assets/doctype/asset_maintenance_team/asset_maintenance_team.json
@@ -61,7 +61,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:06:34.976117",
+ "modified": "2026-08-21 23:11:38.864427",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Maintenance Team",
@@ -78,9 +78,14 @@
    "role": "Manufacturing User",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/assets/doctype/asset_shift_factor/asset_shift_factor.json
+++ b/erpnext/assets/doctype/asset_shift_factor/asset_shift_factor.json
@@ -36,7 +36,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:06:35.869900",
+ "modified": "2026-08-21 23:11:39.003078",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Shift Factor",
@@ -66,8 +66,13 @@
    "role": "Accounts User",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/assets/doctype/location/location.json
+++ b/erpnext/assets/doctype/location/location.json
@@ -143,7 +143,7 @@
  ],
  "is_tree": 1,
  "links": [],
- "modified": "2025-04-29 13:53:13.488906",
+ "modified": "2026-08-21 23:11:43.994913",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Location",
@@ -198,6 +198,10 @@
    "role": "Stock Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
   }
  ],
  "quick_entry": 1,

--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -440,19 +440,19 @@
   },
   {
    "default": "0",
+   "description": "If checked, this Supplier is only available for transactions in the companies listed below.",
    "fieldname": "restrict_to_companies",
    "fieldtype": "Check",
    "label": "Restrict to Companies",
-   "description": "If checked, this Supplier is only available for transactions in the companies listed below.",
    "permlevel": 1
   },
   {
+   "depends_on": "eval:doc.restrict_to_companies",
    "fieldname": "allowed_companies",
    "fieldtype": "Table MultiSelect",
    "label": "Allowed Companies",
-   "options": "Company Restriction",
-   "depends_on": "eval:doc.restrict_to_companies",
    "mandatory_depends_on": "eval:doc.restrict_to_companies",
+   "options": "Company Restriction",
    "permlevel": 1
   },
   {
@@ -592,7 +592,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-08-14 16:10:58.600553",
+ "modified": "2026-08-21 23:11:49.780507",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",
@@ -654,6 +654,30 @@
    "read": 1,
    "role": "Purchase Master Manager",
    "write": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Website Manager",
+   "select": 1
   }
  ],
  "quick_entry": 1,

--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
@@ -948,7 +948,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-12 12:00:00.000000",
+ "modified": "2026-08-21 23:11:50.274992",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier Quotation",
@@ -1007,6 +1007,14 @@
    "read": 1,
    "role": "Purchase Manager",
    "write": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -543,7 +543,7 @@
  "idx": 5,
  "image_field": "image",
  "links": [],
- "modified": "2026-02-10 14:36:37.157961",
+ "modified": "2026-08-21 23:11:43.771048",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Lead",
@@ -600,6 +600,10 @@
    "read": 1,
    "report": 1,
    "role": "Sales User"
+  },
+  {
+   "role": "Support Team",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/crm/doctype/market_segment/market_segment.json
+++ b/erpnext/crm/doctype/market_segment/market_segment.json
@@ -18,7 +18,7 @@
   }
  ],
  "links": [],
- "modified": "2025-12-17 12:09:34.687368",
+ "modified": "2026-08-21 23:11:44.435488",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Market Segment",
@@ -36,6 +36,10 @@
    "role": "Sales Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
   }
  ],
  "quick_entry": 1,

--- a/erpnext/manufacturing/doctype/blanket_order/blanket_order.json
+++ b/erpnext/manufacturing/doctype/blanket_order/blanket_order.json
@@ -147,7 +147,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-05 15:44:21.520093",
+ "modified": "2026-08-21 23:11:40.122402",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Blanket Order",
@@ -167,9 +167,34 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Purchase Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase User",
+   "select": 1
+  },
+  {
+   "role": "Sales Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
+   "select": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "blanket_order_type, to_date",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/erpnext/manufacturing/doctype/bom/bom.json
+++ b/erpnext/manufacturing/doctype/bom/bom.json
@@ -771,7 +771,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-19 14:00:00.000000",
+ "modified": "2026-08-21 23:11:39.133941",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM",
@@ -802,6 +802,30 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Purchase Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase User",
+   "select": 1
+  },
+  {
+   "role": "Sales Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/manufacturing/doctype/plant_floor/plant_floor.json
+++ b/erpnext/manufacturing/doctype/plant_floor/plant_floor.json
@@ -74,7 +74,7 @@
  "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-17 11:53:17.940039",
+ "modified": "2026-08-21 23:11:45.858553",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Plant Floor",
@@ -92,6 +92,10 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Manufacturing User",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/manufacturing/doctype/sales_forecast/sales_forecast.json
+++ b/erpnext/manufacturing/doctype/sales_forecast/sales_forecast.json
@@ -158,7 +158,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-01-02 15:09:32.165242",
+ "modified": "2026-08-21 23:11:47.893072",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Sales Forecast",
@@ -234,6 +234,10 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/projects/doctype/activity_type/activity_type.json
+++ b/erpnext/projects/doctype/activity_type/activity_type.json
@@ -47,7 +47,7 @@
  "icon": "icon-flag",
  "idx": 1,
  "links": [],
- "modified": "2026-04-17 15:24:16.754519",
+ "modified": "2026-08-21 23:11:38.223497",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Activity Type",
@@ -91,6 +91,18 @@
    "role": "HR Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
+  },
+  {
+   "role": "HR User",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing User",
+   "select": 1
   }
  ],
  "quick_entry": 1,

--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -484,7 +484,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "max_attachments": 4,
- "modified": "2026-07-21 11:23:22.000000",
+ "modified": "2026-08-21 23:11:46.332012",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project",
@@ -547,6 +547,78 @@
   },
   {
    "role": "HR Manager",
+   "select": 1
+  },
+  {
+   "role": "Accounts Manager",
+   "select": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing Manager",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing User",
+   "select": 1
+  },
+  {
+   "role": "Purchase Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Purchase User",
+   "select": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
+  },
+  {
+   "role": "Stock User",
+   "select": 1
+  },
+  {
+   "role": "Support Team",
    "select": 1
   }
  ],

--- a/erpnext/projects/doctype/project_template/project_template.json
+++ b/erpnext/projects/doctype/project_template/project_template.json
@@ -34,7 +34,7 @@
   }
  ],
  "links": [],
- "modified": "2025-03-12 14:20:57.301906",
+ "modified": "2026-08-21 23:11:46.618525",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project Template",
@@ -52,6 +52,14 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Projects Manager",
+   "select": 1
+  },
+  {
+   "role": "Projects User",
+   "select": 1
   }
  ],
  "quick_entry": 1,

--- a/erpnext/projects/doctype/task/task.json
+++ b/erpnext/projects/doctype/task/task.json
@@ -423,7 +423,7 @@
  "is_tree": 1,
  "links": [],
  "max_attachments": 5,
- "modified": "2026-04-09 19:12:27.153143",
+ "modified": "2026-08-21 23:11:50.547292",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Task",
@@ -455,6 +455,18 @@
    "role": "HR Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
+  },
+  {
+   "role": "Employee",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing User",
+   "select": 1
   }
  ],
  "quick_entry": 1,

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -730,7 +730,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-08-14 16:10:58.600553",
+ "modified": "2026-08-21 23:11:41.175219",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",
@@ -800,6 +800,62 @@
    "read": 1,
    "report": 1,
    "role": "Accounts Manager"
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Employee",
+   "select": 1
+  },
+  {
+   "role": "Fulfillment User",
+   "select": 1
+  },
+  {
+   "role": "HR Manager",
+   "select": 1
+  },
+  {
+   "role": "HR User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Projects Manager",
+   "select": 1
+  },
+  {
+   "role": "Projects User",
+   "select": 1
+  },
+  {
+   "role": "Purchase Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
+  },
+  {
+   "role": "Support Team",
+   "select": 1
+  },
+  {
+   "role": "Website Manager",
+   "select": 1
   }
  ],
  "quick_entry": 1,

--- a/erpnext/selling/doctype/product_bundle/product_bundle.json
+++ b/erpnext/selling/doctype/product_bundle/product_bundle.json
@@ -104,7 +104,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-06-10 12:00:00.000000",
+ "modified": "2026-08-21 23:11:46.161457",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Product Bundle",
@@ -144,8 +144,33 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "role": "Accounts Manager",
+   "select": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "new_item_code,description",
  "sort_field": "creation",
  "sort_order": "ASC",

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -1826,7 +1826,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-14 12:43:19.480555",
+ "modified": "2026-08-21 23:11:48.053347",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",
@@ -1893,6 +1893,14 @@
    "read": 1,
    "role": "Sales Manager",
    "write": 1
+  },
+  {
+   "role": "Projects Manager",
+   "select": 1
+  },
+  {
+   "role": "Projects User",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/selling/doctype/sales_partner_type/sales_partner_type.json
+++ b/erpnext/selling/doctype/sales_partner_type/sales_partner_type.json
@@ -19,7 +19,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-27 13:10:37.773308",
+ "modified": "2026-08-21 23:11:48.555976",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Partner Type",
@@ -37,9 +37,14 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/setup/doctype/brand/brand.json
+++ b/erpnext/setup/doctype/brand/brand.json
@@ -56,7 +56,7 @@
  "idx": 1,
  "image_field": "image",
  "links": [],
- "modified": "2024-08-20 14:10:21.377962",
+ "modified": "2026-08-21 23:11:40.278512",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Brand",
@@ -103,9 +103,14 @@
    "read": 1,
    "report": 1,
    "role": "Accounts User"
+  },
+  {
+   "role": "Website Manager",
+   "select": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "creation",
  "sort_order": "ASC",

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -1159,7 +1159,7 @@
  "image_field": "company_logo",
  "is_tree": 1,
  "links": [],
- "modified": "2026-07-26 21:14:52.739814",
+ "modified": "2026-08-21 23:11:40.429841",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Company",
@@ -1229,6 +1229,10 @@
    "report": 1,
    "role": "HR Manager",
    "write": 1
+  },
+  {
+   "role": "Desk User",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/setup/doctype/customer_group/customer_group.json
+++ b/erpnext/setup/doctype/customer_group/customer_group.json
@@ -140,7 +140,7 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2025-12-02 13:58:03.378607",
+ "modified": "2026-08-21 23:11:41.519748",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Customer Group",
@@ -207,6 +207,26 @@
    "report": 1,
    "role": "Accounts User",
    "share": 1
+  },
+  {
+   "role": "Item Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Purchase Manager",
+   "select": 1
+  },
+  {
+   "role": "Website Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/setup/doctype/department/department.json
+++ b/erpnext/setup/doctype/department/department.json
@@ -90,7 +90,7 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2024-06-12 16:10:31.451257",
+ "modified": "2026-08-21 23:11:41.697649",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Department",
@@ -136,8 +136,25 @@
   {
    "role": "Employee",
    "select": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
+  },
+  {
+   "role": "Projects Manager",
+   "select": 1
+  },
+  {
+   "role": "Projects User",
+   "select": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "creation",
  "sort_order": "ASC",

--- a/erpnext/setup/doctype/driver/driver.json
+++ b/erpnext/setup/doctype/driver/driver.json
@@ -130,7 +130,7 @@
  ],
  "icon": "fa fa-user",
  "links": [],
- "modified": "2026-06-16 16:04:12.762960",
+ "modified": "2026-08-21 23:11:41.847540",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Driver",
@@ -173,6 +173,22 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Fulfillment User",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
+  },
+  {
+   "role": "Stock User",
+   "select": 1
   }
  ],
  "quick_entry": 1,

--- a/erpnext/setup/doctype/employee/employee.json
+++ b/erpnext/setup/doctype/employee/employee.json
@@ -834,7 +834,7 @@
  "image_field": "image",
  "is_tree": 1,
  "links": [],
- "modified": "2026-03-23 15:26:05.149280",
+ "modified": "2026-08-21 23:11:42.091886",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Employee",
@@ -874,6 +874,46 @@
    "role": "HR Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Accounts Manager",
+   "select": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Fleet Manager",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing Manager",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing User",
+   "select": 1
+  },
+  {
+   "role": "Projects User",
+   "select": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/setup/doctype/holiday_list/holiday_list.json
+++ b/erpnext/setup/doctype/holiday_list/holiday_list.json
@@ -153,7 +153,7 @@
  "icon": "fa fa-calendar",
  "idx": 1,
  "links": [],
- "modified": "2026-04-14 18:21:08.018741",
+ "modified": "2026-08-21 23:11:42.675539",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Holiday List",
@@ -173,6 +173,26 @@
   },
   {
    "role": "HR User",
+   "select": 1
+  },
+  {
+   "role": "Accounts Manager",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing User",
+   "select": 1
+  },
+  {
+   "role": "Projects Manager",
+   "select": 1
+  },
+  {
+   "role": "Projects User",
+   "select": 1
+  },
+  {
+   "role": "Sales Manager",
    "select": 1
   }
  ],

--- a/erpnext/setup/doctype/incoterm/incoterm.json
+++ b/erpnext/setup/doctype/incoterm/incoterm.json
@@ -87,7 +87,7 @@
    "link_fieldname": "incoterm"
   }
  ],
- "modified": "2022-11-17 22:35:52.084553",
+ "modified": "2026-08-21 23:11:42.839127",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Incoterm",
@@ -157,8 +157,25 @@
   {
    "read": 1,
    "role": "Stock User"
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_title_field_in_link": 1,
  "sort_field": "name",
  "sort_order": "ASC",

--- a/erpnext/setup/doctype/sales_partner/sales_partner.json
+++ b/erpnext/setup/doctype/sales_partner/sales_partner.json
@@ -192,7 +192,7 @@
  "icon": "fa fa-user",
  "idx": 1,
  "links": [],
- "modified": "2024-03-27 13:10:37.455664",
+ "modified": "2026-08-21 23:11:48.371608",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Sales Partner",
@@ -221,8 +221,45 @@
    "role": "Sales Master Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Accounts Manager",
+   "select": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Purchase Manager",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
+  },
+  {
+   "role": "Website Manager",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "creation",
  "sort_order": "ASC",

--- a/erpnext/setup/doctype/sales_person/sales_person.json
+++ b/erpnext/setup/doctype/sales_person/sales_person.json
@@ -145,7 +145,7 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2026-06-21 12:52:33.742603",
+ "modified": "2026-08-21 23:11:48.642478",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Sales Person",
@@ -177,8 +177,37 @@
    "role": "Sales Master Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Accounts Manager",
+   "select": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "parent_sales_person",
  "show_name_in_global_search": 1,
  "sort_field": "creation",

--- a/erpnext/setup/doctype/supplier_group/supplier_group.json
+++ b/erpnext/setup/doctype/supplier_group/supplier_group.json
@@ -109,7 +109,7 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2025-12-02 13:57:57.814686",
+ "modified": "2026-08-21 23:11:50.079034",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Supplier Group",
@@ -167,6 +167,14 @@
    "report": 1,
    "role": "Accounts User",
    "share": 1
+  },
+  {
+   "role": "Sales Manager",
+   "select": 1
+  },
+  {
+   "role": "Website Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/setup/doctype/terms_and_conditions/terms_and_conditions.json
+++ b/erpnext/setup/doctype/terms_and_conditions/terms_and_conditions.json
@@ -89,7 +89,7 @@
  "icon": "icon-legal",
  "idx": 1,
  "links": [],
- "modified": "2026-06-06 16:35:34.394675",
+ "modified": "2026-08-21 23:11:51.312054",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Terms and Conditions",
@@ -161,6 +161,22 @@
    "report": 1,
    "role": "Accounts User",
    "share": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
   }
  ],
  "quick_entry": 1,

--- a/erpnext/setup/doctype/territory/territory.json
+++ b/erpnext/setup/doctype/territory/territory.json
@@ -124,7 +124,7 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2025-12-02 13:58:55.190485",
+ "modified": "2026-08-21 23:11:51.487537",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Territory",
@@ -183,6 +183,22 @@
    "report": 1,
    "role": "Accounts User",
    "share": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Website Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/setup/doctype/uom/uom.json
+++ b/erpnext/setup/doctype/uom/uom.json
@@ -75,7 +75,7 @@
  "icon": "fa fa-compass",
  "idx": 1,
  "links": [],
- "modified": "2026-04-14 21:20:16.983514",
+ "modified": "2026-08-21 23:11:51.629905",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "UOM",
@@ -126,6 +126,10 @@
    "report": 1,
    "role": "Sales Manager",
    "share": 1
+  },
+  {
+   "role": "Desk User",
+   "select": 1
   }
  ],
  "quick_entry": 1,

--- a/erpnext/setup/doctype/vehicle/vehicle.json
+++ b/erpnext/setup/doctype/vehicle/vehicle.json
@@ -204,7 +204,7 @@
   }
  ],
  "links": [],
- "modified": "2025-01-24 06:22:33.129805",
+ "modified": "2026-08-21 23:11:51.754251",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Vehicle",
@@ -238,9 +238,18 @@
    "role": "Delivery Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Fulfillment User",
+   "select": 1
+  },
+  {
+   "role": "Stock User",
+   "select": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "license_plate,location,model",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/erpnext/stock/doctype/batch/batch.json
+++ b/erpnext/stock/doctype/batch/batch.json
@@ -215,7 +215,7 @@
  "image_field": "image",
  "links": [],
  "max_attachments": 5,
- "modified": "2026-06-17 16:01:26.556324",
+ "modified": "2026-08-21 23:11:39.905227",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Batch",
@@ -234,6 +234,58 @@
    "role": "Item Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Accounts Manager",
+   "select": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing Manager",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing User",
+   "select": 1
+  },
+  {
+   "role": "Purchase Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales Master Manager",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
+   "select": 1
   }
  ],
  "quick_entry": 1,

--- a/erpnext/stock/doctype/manufacturer/manufacturer.json
+++ b/erpnext/stock/doctype/manufacturer/manufacturer.json
@@ -87,7 +87,7 @@
  ],
  "icon": "fa fa-certificate",
  "links": [],
- "modified": "2024-03-27 13:10:04.558108",
+ "modified": "2026-08-21 23:11:44.296381",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Manufacturer",
@@ -113,8 +113,17 @@
    "report": 1,
    "role": "Stock User",
    "share": 1
+  },
+  {
+   "role": "Accounts Manager",
+   "select": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "short_name, full_name",
  "show_name_in_global_search": 1,
  "sort_field": "creation",

--- a/erpnext/stock/doctype/material_request/material_request.json
+++ b/erpnext/stock/doctype/material_request/material_request.json
@@ -377,7 +377,7 @@
  "idx": 70,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-07 10:30:00.000000",
+ "modified": "2026-08-21 23:11:44.554719",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Material Request",
@@ -441,6 +441,18 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
   }
  ],
  "quick_entry": 1,

--- a/erpnext/stock/doctype/price_list/price_list.json
+++ b/erpnext/stock/doctype/price_list/price_list.json
@@ -84,7 +84,7 @@
  "idx": 1,
  "links": [],
  "max_attachments": 1,
- "modified": "2024-08-16 19:41:19.591111",
+ "modified": "2026-08-21 23:11:45.985667",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Price List",
@@ -124,8 +124,41 @@
   {
    "read": 1,
    "role": "Manufacturing User"
+  },
+  {
+   "role": "Accounts Manager",
+   "select": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
+  },
+  {
+   "role": "Website Manager",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "currency",
  "show_name_in_global_search": 1,
  "sort_field": "creation",

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
@@ -1294,7 +1294,7 @@
  "idx": 261,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-12 12:00:00.000000",
+ "modified": "2026-08-21 23:11:47.160738",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt",
@@ -1353,6 +1353,18 @@
    "read": 1,
    "role": "Stock Manager",
    "write": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.json
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.json
@@ -278,7 +278,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-12-24 15:21:03.240008",
+ "modified": "2026-08-21 23:11:47.694751",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Quality Inspection",
@@ -298,6 +298,46 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "role": "Accounts Manager",
+   "select": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing Manager",
+   "select": 1
+  },
+  {
+   "role": "Manufacturing User",
+   "select": 1
+  },
+  {
+   "role": "Purchase User",
+   "select": 1
+  },
+  {
+   "role": "Sales User",
+   "select": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
+  },
+  {
+   "role": "Stock User",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
@@ -252,7 +252,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-24 16:24:48.154853",
+ "modified": "2026-08-21 23:11:49.103080",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Serial and Batch Bundle",
@@ -384,6 +384,26 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "role": "Accounts Manager",
+   "select": 1
+  },
+  {
+   "role": "Accounts User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/stock/doctype/serial_no/serial_no.json
+++ b/erpnext/stock/doctype/serial_no/serial_no.json
@@ -312,7 +312,7 @@
  "icon": "fa fa-barcode",
  "idx": 1,
  "links": [],
- "modified": "2025-12-24 20:14:52.942251",
+ "modified": "2026-08-21 23:11:48.936205",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Serial No",
@@ -348,6 +348,22 @@
    "read": 1,
    "report": 1,
    "role": "Stock User"
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/stock/doctype/shipment_parcel_template/shipment_parcel_template.json
+++ b/erpnext/stock/doctype/shipment_parcel_template/shipment_parcel_template.json
@@ -52,7 +52,7 @@
   }
  ],
  "links": [],
- "modified": "2026-03-29 00:00:00.000000",
+ "modified": "2026-08-21 23:11:49.416348",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Shipment Parcel Template",
@@ -69,9 +69,14 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Stock Manager",
+   "select": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/stock/doctype/warehouse/warehouse.json
+++ b/erpnext/stock/doctype/warehouse/warehouse.json
@@ -286,7 +286,7 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2026-02-05 18:17:11.035097",
+ "modified": "2026-08-21 23:11:51.906705",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Warehouse",
@@ -337,6 +337,34 @@
   {
    "read": 1,
    "role": "Manufacturing User"
+  },
+  {
+   "role": "Delivery Manager",
+   "select": 1
+  },
+  {
+   "role": "Delivery User",
+   "select": 1
+  },
+  {
+   "role": "HR Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance Manager",
+   "select": 1
+  },
+  {
+   "role": "Maintenance User",
+   "select": 1
+  },
+  {
+   "role": "Quality Manager",
+   "select": 1
+  },
+  {
+   "role": "Website Manager",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/erpnext/support/doctype/issue/issue.json
+++ b/erpnext/support/doctype/issue/issue.json
@@ -393,7 +393,7 @@
  "icon": "fa fa-ticket",
  "idx": 7,
  "links": [],
- "modified": "2026-04-09 19:14:57.692236",
+ "modified": "2026-08-21 23:11:43.274229",
  "modified_by": "Administrator",
  "module": "Support",
  "name": "Issue",
@@ -417,6 +417,10 @@
   },
   {
    "role": "HR User",
+   "select": 1
+  },
+  {
+   "role": "Projects User",
    "select": 1
   }
  ],

--- a/erpnext/support/doctype/issue_priority/issue_priority.json
+++ b/erpnext/support/doctype/issue_priority/issue_priority.json
@@ -15,7 +15,7 @@
   }
  ],
  "links": [],
- "modified": "2024-08-16 19:23:40.697426",
+ "modified": "2026-08-21 23:11:43.457613",
  "modified_by": "Administrator",
  "module": "Support",
  "name": "Issue Priority",
@@ -32,9 +32,14 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "Support Team",
+   "select": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "ASC",
  "states": [],


### PR DESCRIPTION
## The problem

A role holds `write` on a DocType but has neither `read` nor `select` on a DocType the form links to.

Saving still works — `_validate_links` does not check permissions. The link picker does not: `frappe.desk.search.search_widget` goes through `frappe.get_list`, which enforces `select`/`read` on the target. The user gets an empty dropdown, and on a mandatory field the document cannot be completed at all.

The two sharpest cases:

- **Accounts User and Accounts Manager cannot select a UOM.** `uom` is mandatory on `Sales Invoice Item`, `Purchase Invoice Item` and `POS Invoice Item`, and `UOM` grants read only to Item Manager, Stock Manager, Stock User, Sales User and Sales Manager. An accounts-only user cannot add an invoice line by hand.
- **Maintenance User is locked out of its own documents.** The role has `write` on `Sales Order`, `Quotation`, `Maintenance Visit` and `Warranty Claim`, but no access to `Company`, `Customer`, `Currency`, `Price List` or `UOM` — every mandatory link on those forms.

`Project` is the widest: the `project` link sits on almost every transaction and child table, but the DocType grants `read` only to Projects User and Projects Manager, plus `select` to Employee, HR User and HR Manager. Every accounts, stock, purchase, manufacturing and sales role gets an empty Project picker.

## How the gaps were found

For every erpnext DocType, for every role holding `write`, for every `Link` field on the DocType **and on its child tables**, resolve the target and check whether the role can select it. The framework rules are encoded rather than assumed:

- `select` is implied by `read` (`frappe/permissions.py:216`)
- only `permlevel: 0` rows gate doctype-level access (`permissions.py:320`)
- `All` and `Desk User` are automatic roles, so a grant to either satisfies every desk role
- `DocType` link searches run with `ignore_permissions=True` (`desk/search.py:289`), so they are excluded
- child-table, Single and virtual targets are excluded — they inherit or bypass permissions
- hidden, read-only and `fetch_from` fields are excluded — no picker, no breakage
- `DEFAULT_ROLE_PROFILES` in `erpnext/setup/install.py` bundles roles, so gaps masked by a companion role in the same bundle are reported separately

That found **1625 gaps**, 1064 of them not covered by any default role profile, **129 blocking a mandatory field**.

## The change

313 `select`-only rows across 69 DocTypes, following the pattern already used for `HR User` on `Account`:

```json
{
 "role": "Maintenance User",
 "select": 1
}
```

Two rules decide which form each fix takes:

1. **One `Desk User` row**, and only for concepts every desk user already needs regardless of what they do — `Company`, `Currency`, `UOM`, `UOM Category`, `UOM Conversion Factor`.
2. **Per-role rows** for everything else, listing only the roles that actually showed a gap. That covers all accounting and stock configuration — `Account`, `Cost Center`, `Warehouse`, `Batch`, `Price List`, `Tax Category`, `Item Tax Template` — as well as party and HR data.

The wildcard stays deliberately small. `Desk User` is not a desk-power marker: `frappe/permissions.py:569` appends it to every System User, so an Auditor, or a customer or supplier contact given a desk login with one narrow role, holds it too.

`select` exposes names in a picker and nothing else. User Permissions still filter the result set, and `read` on the document itself is unaffected.

## Applying it

The rows were added through the ORM in developer mode rather than by hand-editing JSON, so frappe exported the files itself. Note that `DocPerm` defaults `read`, `write`, `create`, `delete`, `report`, `export`, `share`, `print` and `email` to `1` — every Check field has to be zeroed explicitly or the role silently gets full access. The diff is `select` rows plus the `modified` bump; the added-line audit confirms nothing beyond `role` and `select` was granted.

A few files also pick up `"row_format": "Dynamic"` and key-sort normalisation from frappe's own `as_json` export. 275 of 644 committed erpnext DocType JSONs already carry `row_format`.

## Out of scope

- **Other apps.** 46 gaps point at frappe (`Currency`, `Role`, `Email Account`, `Error Log`, `Auto Repeat`) and payments (`Payment Gateway`). Those belong in those repos.
- **`System Manager`.** 209 gaps across 68 DocTypes, all one shape: DocType creation adds a `System Manager` read/write/create row and nobody removes it. Granting System Manager `select` on the chart of accounts is the wrong direction — the fix is to drop the boilerplate row where the domain roles are already present, or to add the domain roles where `System Manager` is the only one (`Invoice Discounting`). That changes behaviour on existing sites, so it is left for a separate discussion.