### PR TITLE
feat: use valuation rate option for BOM secondary items

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -151,7 +151,7 @@ class SubcontractingController(StockController):
 					).format(item.idx, get_link_to_form("Item", item.item_code))
 				)
 
-			if not item.get("secondary_item_type") and not item.get("is_legacy_scrap_item"):
+			if not item.get("secondary_item_type") and not item.get("use_valuation_rate"):
 				if not is_sub_contracted_item:
 					frappe.throw(
 						_("Row {0}: Item {1} must be a subcontracted item.").format(item.idx, item.item_name)
@@ -1248,10 +1248,10 @@ class SubcontractingController(StockController):
 				total_amt = sum(
 					flt(item.amount)
 					for item in self.get("items")
-					if not item.get("secondary_item_type") and not item.get("is_legacy_scrap_item")
+					if not item.get("secondary_item_type") and not item.get("use_valuation_rate")
 				)
 				for item in self.items:
-					if not item.get("secondary_item_type") and not item.get("is_legacy_scrap_item"):
+					if not item.get("secondary_item_type") and not item.get("use_valuation_rate"):
 						item.additional_cost_per_qty = (
 							(item.amount * self.total_additional_costs) / total_amt
 						) / item.qty
@@ -1259,15 +1259,15 @@ class SubcontractingController(StockController):
 				total_qty = sum(
 					flt(item.qty)
 					for item in self.get("items")
-					if not item.get("secondary_item_type") and not item.get("is_legacy_scrap_item")
+					if not item.get("secondary_item_type") and not item.get("use_valuation_rate")
 				)
 				additional_cost_per_qty = self.total_additional_costs / total_qty
 				for item in self.items:
-					if not item.get("secondary_item_type") and not item.get("is_legacy_scrap_item"):
+					if not item.get("secondary_item_type") and not item.get("use_valuation_rate"):
 						item.additional_cost_per_qty = additional_cost_per_qty
 		else:
 			for item in self.items:
-				if not item.get("secondary_item_type") and not item.get("is_legacy_scrap_item"):
+				if not item.get("secondary_item_type") and not item.get("use_valuation_rate"):
 					item.additional_cost_per_qty = 0
 
 	@frappe.whitelist()

--- a/erpnext/controllers/subcontracting_inward_controller.py
+++ b/erpnext/controllers/subcontracting_inward_controller.py
@@ -243,7 +243,7 @@ class SubcontractingInwardController:
 			for item in self.get("items")
 			if not item.is_finished_item
 			and not item.secondary_item_type
-			and not item.is_legacy_scrap_item
+			and not item.use_valuation_rate
 			and frappe.get_cached_value("Item", item.item_code, "is_customer_provided_item")
 		]
 
@@ -380,7 +380,7 @@ class SubcontractingInwardController:
 			if self.purpose in ["Subcontracting Delivery", "Subcontracting Return", "Manufacture"]:
 				for item in self.items:
 					if (
-						item.is_finished_item or item.secondary_item_type or item.is_legacy_scrap_item
+						item.is_finished_item or item.secondary_item_type or item.use_valuation_rate
 					) and item.valuation_rate == 0:
 						item.allow_zero_valuation_rate = 1
 
@@ -480,7 +480,7 @@ class SubcontractingInwardController:
 				self.validate_delivery_on_save()
 			else:
 				for item in self.items:
-					if not item.secondary_item_type and not item.is_legacy_scrap_item:
+					if not item.secondary_item_type and not item.use_valuation_rate:
 						delivered_qty, returned_qty = frappe.get_value(
 							"Subcontracting Inward Order Item",
 							item.scio_detail,
@@ -550,7 +550,7 @@ class SubcontractingInwardController:
 						bold(
 							frappe.get_cached_value(
 								"Subcontracting Inward Order Item"
-								if not item.secondary_item_type and not item.is_legacy_scrap_item
+								if not item.secondary_item_type and not item.use_valuation_rate
 								else "Subcontracting Inward Order Secondary Item",
 								item.scio_detail,
 								"stock_uom",
@@ -602,7 +602,7 @@ class SubcontractingInwardController:
 				)
 
 			for item in [item for item in self.items if not item.is_finished_item]:
-				if item.secondary_item_type or item.is_legacy_scrap_item:
+				if item.secondary_item_type or item.use_valuation_rate:
 					scio_secondary_item = frappe.get_value(
 						"Subcontracting Inward Order Secondary Item",
 						{
@@ -661,7 +661,7 @@ class SubcontractingInwardController:
 			for item in self.items:
 				doctype = (
 					"Subcontracting Inward Order Item"
-					if not item.secondary_item_type and not item.is_legacy_scrap_item
+					if not item.secondary_item_type and not item.use_valuation_rate
 					else "Subcontracting Inward Order Secondary Item"
 				)
 				qty_map[doctype][item.scio_detail] += (
@@ -802,7 +802,7 @@ class SubcontractingInwardController:
 		items = [
 			item
 			for item in self.items
-			if not item.is_finished_item and not item.secondary_item_type and not item.is_legacy_scrap_item
+			if not item.is_finished_item and not item.secondary_item_type and not item.use_valuation_rate
 		]
 		if not items:
 			return
@@ -913,7 +913,7 @@ class SubcontractingInwardController:
 	def update_inward_order_secondary_items(self):
 		if (scio := self.subcontracting_inward_order) and self.purpose == "Manufacture":
 			secondary_items_list = [
-				item for item in self.items if item.secondary_item_type or item.is_legacy_scrap_item
+				item for item in self.items if item.secondary_item_type or item.use_valuation_rate
 			]
 
 			secondary_items = defaultdict(float)

--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -767,8 +767,7 @@ var get_bom_material_detail = function (doc, cdt, cdn, secondary_items) {
 				conversion_factor: d.conversion_factor,
 				sourced_by_supplier: d.sourced_by_supplier,
 				do_not_explode: d.do_not_explode,
-				fetch_rate: !secondary_items || !!d.use_valuation_rate,
-				use_valuation_rate: d.use_valuation_rate,
+				fetch_rate: !secondary_items,
 			},
 			callback: function (r) {
 				$.extend(d, r.message);
@@ -791,11 +790,10 @@ cur_frm.cscript.qty = function (doc) {
 
 cur_frm.cscript.rate = function (doc, cdt, cdn) {
 	var d = locals[cdt][cdn];
-	const is_secondary_item = cdt == "BOM Secondary Item";
 
 	if (d.bom_no) {
 		frappe.msgprint(__("You cannot change the rate if BOM is mentioned against any Item."));
-		get_bom_material_detail(doc, cdt, cdn, is_secondary_item);
+		get_bom_material_detail(doc, cdt, cdn, false);
 	} else {
 		erpnext.bom.calculate_rm_cost(doc);
 		erpnext.bom.calculate_total(doc);
@@ -1034,9 +1032,6 @@ frappe.ui.form.on("BOM Secondary Item", {
 		const row = locals[cdt][cdn];
 		if (row.use_valuation_rate) {
 			frappe.model.set_value(cdt, cdn, "cost_allocation_per", 0);
-			get_bom_material_detail(frm.doc, cdt, cdn, true);
-		} else {
-			frappe.model.set_value(cdt, cdn, "rate", 0);
 		}
 	},
 });

--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -1032,6 +1032,8 @@ frappe.ui.form.on("BOM Secondary Item", {
 		const row = locals[cdt][cdn];
 		if (row.use_valuation_rate) {
 			frappe.model.set_value(cdt, cdn, "cost_allocation_per", 0);
+		} else {
+			frappe.model.set_value(cdt, cdn, { cost: 0, base_cost: 0 });
 		}
 	},
 });

--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -767,7 +767,7 @@ var get_bom_material_detail = function (doc, cdt, cdn, secondary_items) {
 				conversion_factor: d.conversion_factor,
 				sourced_by_supplier: d.sourced_by_supplier,
 				do_not_explode: d.do_not_explode,
-				source_warehouse: d.source_warehouse,
+				source_warehouse: d.source_warehouse || doc.default_source_warehouse,
 				fetch_rate: !secondary_items,
 			},
 			callback: function (r) {

--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -767,7 +767,8 @@ var get_bom_material_detail = function (doc, cdt, cdn, secondary_items) {
 				conversion_factor: d.conversion_factor,
 				sourced_by_supplier: d.sourced_by_supplier,
 				do_not_explode: d.do_not_explode,
-				fetch_rate: !secondary_items,
+				fetch_rate: !secondary_items || !!d.use_valuation_rate,
+				use_valuation_rate: d.use_valuation_rate,
 			},
 			callback: function (r) {
 				$.extend(d, r.message);
@@ -1029,8 +1030,14 @@ frappe.tour["BOM"] = [
 ];
 
 frappe.ui.form.on("BOM Secondary Item", {
-	item_code(frm, cdt, cdn) {
-		const { item_code } = locals[cdt][cdn];
+	use_valuation_rate(frm, cdt, cdn) {
+		const row = locals[cdt][cdn];
+		if (row.use_valuation_rate) {
+			frappe.model.set_value(cdt, cdn, "cost_allocation_per", 0);
+			get_bom_material_detail(frm.doc, cdt, cdn, true);
+		} else {
+			frappe.model.set_value(cdt, cdn, "rate", 0);
+		}
 	},
 });
 

--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -767,6 +767,7 @@ var get_bom_material_detail = function (doc, cdt, cdn, secondary_items) {
 				conversion_factor: d.conversion_factor,
 				sourced_by_supplier: d.sourced_by_supplier,
 				do_not_explode: d.do_not_explode,
+				source_warehouse: d.source_warehouse,
 				fetch_rate: !secondary_items,
 			},
 			callback: function (r) {
@@ -954,6 +955,9 @@ frappe.ui.form.on("BOM Operation", "workstation_type", function (frm, cdt, cdn) 
 
 frappe.ui.form.on("BOM Item", {
 	do_not_explode: function (frm, cdt, cdn) {
+		get_bom_material_detail(frm.doc, cdt, cdn, false);
+	},
+	source_warehouse: function (frm, cdt, cdn) {
 		get_bom_material_detail(frm.doc, cdt, cdn, false);
 	},
 });

--- a/erpnext/manufacturing/doctype/bom/bom.json
+++ b/erpnext/manufacturing/doctype/bom/bom.json
@@ -402,7 +402,7 @@
   {
    "fetch_from": "item.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Item Description",
    "read_only": 1
   },
@@ -771,7 +771,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-19 14:00:00.000000",
+ "modified": "2026-08-23 15:20:11.032436",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM",

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -156,7 +156,7 @@ class BOM(WebsiteGenerator):
 		currency: DF.Link
 		default_source_warehouse: DF.Link | None
 		default_target_warehouse: DF.Link | None
-		description: DF.SmallText | None
+		description: DF.TextEditor | None
 		exploded_items: DF.Table[BOMExplosionItem]
 		fg_based_operating_cost: DF.Check
 		has_variants: DF.Check

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -395,7 +395,18 @@ class BOM(WebsiteGenerator):
 			)
 
 	def validate_secondary_items(self):
+		seen_items = set()
 		for item in self.secondary_items:
+			# every consumer merges secondary rows by item code, so duplicates cannot keep
+			# their own quantities, percentages or valuation mode
+			if item.item_code in seen_items:
+				frappe.throw(
+					_("Row #{0}: Item {1} is added more than once in the Secondary Items table.").format(
+						item.idx, get_link_to_form("Item", item.item_code)
+					)
+				)
+			seen_items.add(item.item_code)
+
 			if not item.use_valuation_rate and item.item_code == self.item:
 				frappe.throw(
 					_(

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -397,15 +397,16 @@ class BOM(WebsiteGenerator):
 	def validate_secondary_items(self):
 		seen_items = set()
 		for item in self.secondary_items:
-			# every consumer merges secondary rows by item code, so duplicates cannot keep
-			# their own quantities, percentages or valuation mode
-			if item.item_code in seen_items:
+			# every consumer merges secondary rows by item and type, so duplicates cannot
+			# keep their own quantities, percentages or valuation mode
+			key = (item.item_code, item.secondary_item_type or "")
+			if key in seen_items:
 				frappe.throw(
-					_("Row #{0}: Item {1} is added more than once in the Secondary Items table.").format(
-						item.idx, get_link_to_form("Item", item.item_code)
-					)
+					_(
+						"Row #{0}: Item {1} is already added with the same Type in the Secondary Items table."
+					).format(item.idx, get_link_to_form("Item", item.item_code))
 				)
-			seen_items.add(item.item_code)
+			seen_items.add(key)
 
 			if not item.use_valuation_rate and item.item_code == self.item:
 				frappe.throw(
@@ -1491,17 +1492,18 @@ def _add_exploded_item_columns(query, t, bom, amount_col, stock_item_condition):
 
 
 def _add_secondary_item_columns(query, t, stock_item_condition):
-	# non-grouped columns are constant per grouped item_code -> Max() keeps the GROUP BY valid on
-	# postgres while returning the same value MySQL picked arbitrarily.
+	# grouped by (item_code, secondary_item_type), which the BOM keeps unique, so every Max()
+	# below returns the single grouped row's own value while keeping the GROUP BY valid on
+	# postgres.
 	query = query.select(
 		Max(t.item_doc.description).as_("description"),
 		Max(t.bom_item.cost_allocation_per).as_("cost_allocation_per"),
 		Max(t.bom_item.process_loss_per).as_("process_loss_per"),
-		Max(t.bom_item.secondary_item_type).as_("secondary_item_type"),
+		t.bom_item.secondary_item_type,
 		Max(t.bom_item.name).as_("name"),
 	).where(stock_item_condition)
 
-	return query, [t.bom_item.item_code]
+	return query, [t.bom_item.item_code, t.bom_item.secondary_item_type]
 
 
 def _add_normal_item_columns(query, t, amount_col, stock_item_condition, track_semi_finished_goods):
@@ -1541,6 +1543,9 @@ def _add_normal_item_columns(query, t, amount_col, stock_item_condition, track_s
 
 def _add_bom_item_to_dict(item_dict, item, company, opts):
 	key = item.item_code
+	if opts.fetch_secondary_items:
+		key = (item.item_code, item.secondary_item_type or "")
+
 	if item.operation_row_id:
 		key = (item.item_code, item.operation_row_id)
 

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -488,13 +488,19 @@ class BOM(WebsiteGenerator):
 
 	def set_fg_cost_allocation(self):
 		total_secondary_items_per = 0
+		valuation_rate_cost = 0
 		for item in self.secondary_items:
+			if item.use_valuation_rate:
+				item.cost_allocation_per = 0
+				valuation_rate_cost += flt(item.cost)
 			total_secondary_items_per += item.cost_allocation_per
 
 		if self.cost_allocation_per == 100 and total_secondary_items_per:
 			self.cost_allocation_per -= total_secondary_items_per
 
-		self.cost_allocation = self.raw_material_cost * (self.cost_allocation_per / 100)
+		self.cost_allocation = (self.raw_material_cost - valuation_rate_cost) * (
+			self.cost_allocation_per / 100
+		)
 
 	def validate_total_cost_allocation(self):
 		total_cost_allocation_per = self.cost_allocation_per

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -575,7 +575,7 @@ class BOM(WebsiteGenerator):
 					"conversion_factor": item.conversion_factor,
 					"sourced_by_supplier": item.sourced_by_supplier,
 					"do_not_explode": item.do_not_explode,
-					"source_warehouse": item.source_warehouse,
+					"source_warehouse": item.source_warehouse or self.default_source_warehouse,
 					"fetch_rate": True,
 				}
 			)
@@ -1217,7 +1217,9 @@ def _get_price_list_item_rate(args, bom_doc):
 
 def get_valuation_rate(data):
 	"""
-	1) Get average valuation rate from the row's source warehouse if set, else from all warehouses
+	1) Get average valuation rate from the scoping warehouse if one is passed
+	   (source warehouse for raw materials, default target warehouse for secondary
+	   items), else from all warehouses
 	2) If no value, get last valuation rate from SLE
 	3) If no value, get valuation rate from Item
 	"""

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -340,7 +340,6 @@ class BOM(WebsiteGenerator):
 		self.set_default_uom()
 		self.validate_semi_finished_goods()
 		self.validate_secondary_items()
-		self.set_fg_cost_allocation()
 		self.validate_total_cost_allocation()
 
 	def set_operation_finished_goods(self):

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -397,7 +397,7 @@ class BOM(WebsiteGenerator):
 
 	def validate_secondary_items(self):
 		for item in self.secondary_items:
-			if not item.is_legacy and item.item_code == self.item:
+			if not item.use_valuation_rate and item.item_code == self.item:
 				frappe.throw(
 					_(
 						"Row #{0}: Finished Good Item {1} cannot be added in the Secondary Items table."
@@ -1087,7 +1087,8 @@ class BOM(WebsiteGenerator):
 
 	def has_scrap_items(self):
 		return any(
-			d.get("secondary_item_type") == "Scrap" or d.get("is_legacy") for d in self.get("secondary_items")
+			d.get("secondary_item_type") == "Scrap" or d.get("use_valuation_rate")
+			for d in self.get("secondary_items")
 		)
 
 	def validate_bom_currency(self, item):
@@ -1475,7 +1476,7 @@ def _add_secondary_item_columns(query, t, stock_item_condition):
 		Max(t.bom_item.process_loss_per).as_("process_loss_per"),
 		Max(t.bom_item.secondary_item_type).as_("secondary_item_type"),
 		Max(t.bom_item.name).as_("name"),
-		Max(t.bom_item.is_legacy).as_("is_legacy"),
+		Max(t.bom_item.use_valuation_rate).as_("use_valuation_rate"),
 	).where(stock_item_condition)
 
 	return query, [t.bom_item.item_code]

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1488,7 +1488,6 @@ def _add_secondary_item_columns(query, t, stock_item_condition):
 		Max(t.bom_item.process_loss_per).as_("process_loss_per"),
 		Max(t.bom_item.secondary_item_type).as_("secondary_item_type"),
 		Max(t.bom_item.name).as_("name"),
-		Max(t.bom_item.use_valuation_rate).as_("use_valuation_rate"),
 	).where(stock_item_condition)
 
 	return query, [t.bom_item.item_code]

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -575,6 +575,7 @@ class BOM(WebsiteGenerator):
 					"conversion_factor": item.conversion_factor,
 					"sourced_by_supplier": item.sourced_by_supplier,
 					"do_not_explode": item.do_not_explode,
+					"source_warehouse": item.source_warehouse,
 					"fetch_rate": True,
 				}
 			)
@@ -1216,7 +1217,7 @@ def _get_price_list_item_rate(args, bom_doc):
 
 def get_valuation_rate(data):
 	"""
-	1) Get average valuation rate from all warehouses
+	1) Get average valuation rate from the row's source warehouse if set, else from all warehouses
 	2) If no value, get last valuation rate from SLE
 	3) If no value, get valuation rate from Item
 	"""
@@ -1255,8 +1256,12 @@ def _get_avg_valuation_rate_from_bins(item_code, company, data):
 		.where((bin_table.item_code == item_code) & (wh_table.company == company))
 	)
 
+	warehouse = data.get("source_warehouse")
 	if data.get("set_rate_based_on_warehouse") and data.get("warehouse"):
-		item_valuation = item_valuation.where(bin_table.warehouse == data.get("warehouse"))
+		warehouse = data.get("warehouse")
+
+	if warehouse:
+		item_valuation = item_valuation.where(bin_table.warehouse == warehouse)
 
 	return item_valuation.run(as_dict=True)[0].get("valuation_rate")
 

--- a/erpnext/manufacturing/doctype/bom/services/costing.py
+++ b/erpnext/manufacturing/doctype/bom/services/costing.py
@@ -267,7 +267,7 @@ class BOMCostingService:
 		precision = self.doc.precision("raw_material_cost")
 
 		for d in self.doc.get("secondary_items"):
-			if not d.is_legacy:
+			if not d.use_valuation_rate:
 				d.cost = flt(self.doc.raw_material_cost * (d.cost_allocation_per / 100), precision)
 				d.base_cost = flt(d.cost * self.doc.conversion_rate, precision)
 

--- a/erpnext/manufacturing/doctype/bom/services/costing.py
+++ b/erpnext/manufacturing/doctype/bom/services/costing.py
@@ -9,7 +9,7 @@ delegating stubs so external callers (bom_update_log, etc.) keep working.
 
 import frappe
 from frappe import _
-from frappe.utils import flt, nowdate, nowtime
+from frappe.utils import flt
 
 
 class BOMCostingService:
@@ -37,14 +37,10 @@ class BOMCostingService:
 
 	def _raw_material_rate(self, arg, notify):
 		from erpnext.manufacturing.doctype.bom.bom import get_bom_item_rate, get_valuation_rate
-		from erpnext.stock.utils import get_incoming_rate
 
-		# Valuation-rate secondary items ignore the BOM's rm_cost_as_per method: incoming
-		# rate at the target warehouse when one is set, else the same all-warehouse
-		# average the raw materials use.
+		# Valuation-rate secondary items ignore the BOM's rm_cost_as_per method: bin-average
+		# valuation like the raw materials, scoped to the default target warehouse when set.
 		if arg.get("use_valuation_rate"):
-			if arg.get("warehouse"):
-				return get_incoming_rate(arg, raise_error_if_no_rate=False)
 			return get_valuation_rate(arg)
 
 		# Customer Provided parts and Supplier sourced parts will have zero rate
@@ -257,7 +253,7 @@ class BOMCostingService:
 			"conversion_factor": d.conversion_factor,
 			"sourced_by_supplier": d.sourced_by_supplier,
 			"is_phantom_item": d.is_phantom_item,
-			"source_warehouse": d.source_warehouse,
+			"source_warehouse": d.source_warehouse or self.doc.default_source_warehouse,
 		}
 
 	def _set_item_amounts(self, d):
@@ -313,9 +309,7 @@ class BOMCostingService:
 			"item_code": d.item_code,
 			"company": self.doc.company,
 			"warehouse": self.doc.default_target_warehouse,
-			"posting_date": nowdate(),
-			"posting_time": nowtime(),
-			"qty": d.stock_qty,
+			"set_rate_based_on_warehouse": 1,
 			"use_valuation_rate": 1,
 		}
 

--- a/erpnext/manufacturing/doctype/bom/services/costing.py
+++ b/erpnext/manufacturing/doctype/bom/services/costing.py
@@ -9,7 +9,7 @@ delegating stubs so external callers (bom_update_log, etc.) keep working.
 
 import frappe
 from frappe import _
-from frappe.utils import flt
+from frappe.utils import flt, nowdate, nowtime
 
 
 class BOMCostingService:
@@ -36,12 +36,13 @@ class BOMCostingService:
 		return flt(rate) * flt(self.doc.plc_conversion_rate or 1) / (self.doc.conversion_rate or 1)
 
 	def _raw_material_rate(self, arg, notify):
-		from erpnext.manufacturing.doctype.bom.bom import get_bom_item_rate, get_valuation_rate
+		from erpnext.manufacturing.doctype.bom.bom import get_bom_item_rate
+		from erpnext.stock.utils import get_incoming_rate
 
-		# Valuation-rate secondary items are always valued at valuation rate,
+		# Valuation-rate secondary items are always valued at their incoming rate,
 		# regardless of the BOM's rm_cost_as_per method.
 		if arg.get("use_valuation_rate"):
-			return get_valuation_rate(arg)
+			return get_incoming_rate(arg, raise_error_if_no_rate=False)
 
 		# Customer Provided parts and Supplier sourced parts will have zero rate
 		if frappe.db.get_value("Item", arg["item_code"], "is_customer_provided_item") or arg.get(
@@ -294,16 +295,25 @@ class BOMCostingService:
 			if not d.use_valuation_rate:
 				continue
 
-			d.rate = self.get_rm_rate(
-				{"item_code": d.item_code, "company": self.doc.company, "use_valuation_rate": 1}
-			)
-			d.cost = flt(flt(d.rate) * flt(d.stock_qty), precision)
+			rate = self.get_rm_rate(self._secondary_item_rate_args(d))
+			d.cost = flt(flt(rate) * flt(d.stock_qty), precision)
 			d.base_cost = flt(d.cost * self.doc.conversion_rate, precision)
 			total += d.cost
 			if save:
 				d.db_update()
 
 		return total
+
+	def _secondary_item_rate_args(self, d):
+		return {
+			"item_code": d.item_code,
+			"company": self.doc.company,
+			"warehouse": self.doc.default_target_warehouse,
+			"posting_date": nowdate(),
+			"posting_time": nowtime(),
+			"qty": d.stock_qty,
+			"use_valuation_rate": 1,
+		}
 
 	def calculate_exploded_cost(self):
 		"Set exploded row cost from it's parent BOM."

--- a/erpnext/manufacturing/doctype/bom/services/costing.py
+++ b/erpnext/manufacturing/doctype/bom/services/costing.py
@@ -36,13 +36,16 @@ class BOMCostingService:
 		return flt(rate) * flt(self.doc.plc_conversion_rate or 1) / (self.doc.conversion_rate or 1)
 
 	def _raw_material_rate(self, arg, notify):
-		from erpnext.manufacturing.doctype.bom.bom import get_bom_item_rate
+		from erpnext.manufacturing.doctype.bom.bom import get_bom_item_rate, get_valuation_rate
 		from erpnext.stock.utils import get_incoming_rate
 
-		# Valuation-rate secondary items are always valued at their incoming rate,
-		# regardless of the BOM's rm_cost_as_per method.
+		# Valuation-rate secondary items ignore the BOM's rm_cost_as_per method: incoming
+		# rate at the target warehouse when one is set, else the same all-warehouse
+		# average the raw materials use.
 		if arg.get("use_valuation_rate"):
-			return get_incoming_rate(arg, raise_error_if_no_rate=False)
+			if arg.get("warehouse"):
+				return get_incoming_rate(arg, raise_error_if_no_rate=False)
+			return get_valuation_rate(arg)
 
 		# Customer Provided parts and Supplier sourced parts will have zero rate
 		if frappe.db.get_value("Item", arg["item_code"], "is_customer_provided_item") or arg.get(

--- a/erpnext/manufacturing/doctype/bom/services/costing.py
+++ b/erpnext/manufacturing/doctype/bom/services/costing.py
@@ -36,7 +36,12 @@ class BOMCostingService:
 		return flt(rate) * flt(self.doc.plc_conversion_rate or 1) / (self.doc.conversion_rate or 1)
 
 	def _raw_material_rate(self, arg, notify):
-		from erpnext.manufacturing.doctype.bom.bom import get_bom_item_rate
+		from erpnext.manufacturing.doctype.bom.bom import get_bom_item_rate, get_valuation_rate
+
+		# Valuation-rate secondary items are always valued at valuation rate,
+		# regardless of the BOM's rm_cost_as_per method.
+		if arg.get("use_valuation_rate"):
+			return get_valuation_rate(arg)
 
 		# Customer Provided parts and Supplier sourced parts will have zero rate
 		if frappe.db.get_value("Item", arg["item_code"], "is_customer_provided_item") or arg.get(
@@ -261,23 +266,44 @@ class BOMCostingService:
 		)
 
 	def calculate_secondary_items_costs(self, save=False):
-		"""Fetch RM rate as per today's valuation rate and calculate totals"""
+		"""Cost valuation-rate rows at valuation rate, then split the remaining raw
+		material cost among the other rows by their cost allocation percentage."""
 		total_sm_cost = 0
 		base_total_sm_cost = 0
 		precision = self.doc.precision("raw_material_cost")
+		allocation_basis = flt(self.doc.raw_material_cost) - self._set_valuation_rate_secondary_costs(
+			precision, save
+		)
 
 		for d in self.doc.get("secondary_items"):
 			if not d.use_valuation_rate:
-				d.cost = flt(self.doc.raw_material_cost * (d.cost_allocation_per / 100), precision)
+				d.cost = flt(allocation_basis * (d.cost_allocation_per / 100), precision)
 				d.base_cost = flt(d.cost * self.doc.conversion_rate, precision)
-
-				total_sm_cost += d.cost
-				base_total_sm_cost += d.base_cost
 				if save:
 					d.db_update()
 
+			total_sm_cost += d.cost
+			base_total_sm_cost += d.base_cost
+
 		self.doc.secondary_items_cost = total_sm_cost
 		self.doc.base_secondary_items_cost = base_total_sm_cost
+
+	def _set_valuation_rate_secondary_costs(self, precision, save) -> float:
+		total = 0.0
+		for d in self.doc.get("secondary_items"):
+			if not d.use_valuation_rate:
+				continue
+
+			d.rate = self.get_rm_rate(
+				{"item_code": d.item_code, "company": self.doc.company, "use_valuation_rate": 1}
+			)
+			d.cost = flt(flt(d.rate) * flt(d.stock_qty), precision)
+			d.base_cost = flt(d.cost * self.doc.conversion_rate, precision)
+			total += d.cost
+			if save:
+				d.db_update()
+
+		return total
 
 	def calculate_exploded_cost(self):
 		"Set exploded row cost from it's parent BOM."

--- a/erpnext/manufacturing/doctype/bom/services/costing.py
+++ b/erpnext/manufacturing/doctype/bom/services/costing.py
@@ -254,6 +254,7 @@ class BOMCostingService:
 			"conversion_factor": d.conversion_factor,
 			"sourced_by_supplier": d.sourced_by_supplier,
 			"is_phantom_item": d.is_phantom_item,
+			"source_warehouse": d.source_warehouse,
 		}
 
 	def _set_item_amounts(self, d):

--- a/erpnext/manufacturing/doctype/bom/services/costing.py
+++ b/erpnext/manufacturing/doctype/bom/services/costing.py
@@ -147,6 +147,7 @@ class BOMCostingService:
 		self.calculate_op_cost(update_hour_rate)
 		self.calculate_rm_cost(save=save_updates)
 		self.calculate_secondary_items_costs(save=save_updates)
+		self.doc.set_fg_cost_allocation()
 		if save_updates:
 			# not via doc event, table is not regenerated and needs updation
 			self.calculate_exploded_cost()

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -697,6 +697,7 @@ class TestBOM(ERPNextTestSuite):
 
 		self.assertEqual(bom_doc.secondary_items[0].cost, 160)
 		self.assertEqual(bom_doc.total_cost, 840)
+		self.assertEqual(bom_doc.cost_allocation, 840)
 
 	@timeout
 	def test_bom_item_query(self):

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -543,7 +543,7 @@ class TestBOM(ERPNextTestSuite):
 		fg_item_non_whole, fg_item_whole, bom_item = create_process_loss_bom_items()
 
 		bom_doc = create_bom_with_process_loss_item(
-			fg_item_non_whole, bom_item, scrap_qty=2, scrap_rate=0, process_loss_percentage=110
+			fg_item_non_whole, bom_item, scrap_qty=2, process_loss_percentage=110
 		)
 		#  PL can't be > 100
 		self.assertRaises(frappe.ValidationError, bom_doc.submit)
@@ -605,7 +605,6 @@ class TestBOM(ERPNextTestSuite):
 		bom_doc.save()
 
 		scrap_row = bom_doc.secondary_items[0]
-		self.assertEqual(scrap_row.rate, 50)
 		self.assertEqual(scrap_row.cost, 100)
 		self.assertEqual(scrap_row.cost_allocation_per, 0)
 
@@ -640,7 +639,6 @@ class TestBOM(ERPNextTestSuite):
 		bom_doc.update_cost()
 		bom_doc.reload()
 
-		self.assertEqual(bom_doc.secondary_items[0].rate, 80)
 		self.assertEqual(bom_doc.secondary_items[0].cost, 160)
 		self.assertEqual(bom_doc.total_cost, 840)
 
@@ -1344,7 +1342,7 @@ def reset_item_valuation_rate(item_code, warehouse_list=None, qty=None, rate=Non
 
 
 def create_bom_with_process_loss_item(
-	fg_item, bom_item, scrap_qty=0, scrap_rate=0, fg_qty=2, process_loss_percentage=0, company=None
+	fg_item, bom_item, scrap_qty=0, fg_qty=2, process_loss_percentage=0, company=None
 ):
 	bom_doc = frappe.new_doc("BOM")
 	bom_doc.item = fg_item.item_code
@@ -1370,7 +1368,6 @@ def create_bom_with_process_loss_item(
 				"stock_qty": scrap_qty,
 				"uom": fg_item.stock_uom,
 				"stock_uom": fg_item.stock_uom,
-				"rate": scrap_rate,
 			},
 		)
 

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -594,14 +594,13 @@ class TestBOM(ERPNextTestSuite):
 		)
 		bom_doc.append(
 			"secondary_items",
-			{
-				"item_code": scrap_item,
-				"secondary_item_type": "By-Product",
-				"qty": 1,
-				"cost_allocation_per": 10,
-			},
+			{"item_code": scrap_item, "secondary_item_type": "Scrap", "qty": 1, "cost_allocation_per": 10},
 		)
 		self.assertRaises(frappe.ValidationError, bom_doc.save)
+
+		# the same item with a different type is a distinct secondary output
+		bom_doc.secondary_items[1].secondary_item_type = "By-Product"
+		bom_doc.save()
 
 	@timeout
 	def test_secondary_item_use_valuation_rate(self):

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -617,6 +617,29 @@ class TestBOM(ERPNextTestSuite):
 		self.assertEqual(bom_doc.total_cost, 810)
 
 	@timeout
+	def test_rm_rate_scoped_to_source_warehouse(self):
+		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+		fg_item = make_item(properties={"is_stock_item": 1}).name
+		rm_item = make_item(properties={"is_stock_item": 1}).name
+
+		make_stock_entry(item_code=rm_item, target="_Test Warehouse - _TC", qty=10, basic_rate=100)
+		make_stock_entry(item_code=rm_item, target="_Test Warehouse 1 - _TC", qty=10, basic_rate=50)
+
+		bom_doc = frappe.new_doc("BOM")
+		bom_doc.item = fg_item
+		bom_doc.quantity = 1
+		bom_doc.company = "_Test Company"
+		bom_doc.currency = "INR"
+		bom_doc.append("items", {"item_code": rm_item, "qty": 1, "source_warehouse": "_Test Warehouse - _TC"})
+		bom_doc.save()
+		self.assertEqual(bom_doc.items[0].rate, 100)
+
+		bom_doc.items[0].source_warehouse = None
+		bom_doc.save()
+		self.assertEqual(bom_doc.items[0].rate, 75)
+
+	@timeout
 	def test_secondary_item_valuation_rate_refreshed_on_update_cost(self):
 		fg_item = make_item(properties={"is_stock_item": 1}).name
 		rm_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 100}).name

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -639,6 +639,39 @@ class TestBOM(ERPNextTestSuite):
 		bom_doc.save()
 		self.assertEqual(bom_doc.items[0].rate, 75)
 
+		bom_doc.default_source_warehouse = "_Test Warehouse 1 - _TC"
+		bom_doc.save()
+		self.assertEqual(bom_doc.items[0].rate, 50)
+
+	@timeout
+	def test_secondary_item_rate_scoped_to_target_warehouse(self):
+		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+		fg_item = make_item(properties={"is_stock_item": 1}).name
+		rm_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 100}).name
+		scrap_item = make_item(properties={"is_stock_item": 1}).name
+
+		make_stock_entry(item_code=scrap_item, target="_Test Warehouse - _TC", qty=10, basic_rate=40)
+		make_stock_entry(item_code=scrap_item, target="_Test Warehouse 1 - _TC", qty=10, basic_rate=20)
+
+		bom_doc = frappe.new_doc("BOM")
+		bom_doc.item = fg_item
+		bom_doc.quantity = 1
+		bom_doc.company = "_Test Company"
+		bom_doc.currency = "INR"
+		bom_doc.default_target_warehouse = "_Test Warehouse - _TC"
+		bom_doc.append("items", {"item_code": rm_item, "qty": 10, "rate": 100.0})
+		bom_doc.append(
+			"secondary_items",
+			{"item_code": scrap_item, "secondary_item_type": "Scrap", "qty": 1, "use_valuation_rate": 1},
+		)
+		bom_doc.save()
+		self.assertEqual(bom_doc.secondary_items[0].cost, 40)
+
+		bom_doc.default_target_warehouse = None
+		bom_doc.save()
+		self.assertEqual(bom_doc.secondary_items[0].cost, 30)
+
 	@timeout
 	def test_secondary_item_valuation_rate_refreshed_on_update_cost(self):
 		fg_item = make_item(properties={"is_stock_item": 1}).name

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -577,6 +577,33 @@ class TestBOM(ERPNextTestSuite):
 		self.assertRaises(frappe.ValidationError, bom_doc.save)
 
 	@timeout
+	def test_duplicate_secondary_item_not_allowed(self):
+		fg_item = make_item(properties={"is_stock_item": 1}).name
+		rm_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 100}).name
+		scrap_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 50}).name
+
+		bom_doc = frappe.new_doc("BOM")
+		bom_doc.item = fg_item
+		bom_doc.quantity = 1
+		bom_doc.company = "_Test Company"
+		bom_doc.currency = "INR"
+		bom_doc.append("items", {"item_code": rm_item, "qty": 1, "rate": 100.0})
+		bom_doc.append(
+			"secondary_items",
+			{"item_code": scrap_item, "secondary_item_type": "Scrap", "qty": 1, "use_valuation_rate": 1},
+		)
+		bom_doc.append(
+			"secondary_items",
+			{
+				"item_code": scrap_item,
+				"secondary_item_type": "By-Product",
+				"qty": 1,
+				"cost_allocation_per": 10,
+			},
+		)
+		self.assertRaises(frappe.ValidationError, bom_doc.save)
+
+	@timeout
 	def test_secondary_item_use_valuation_rate(self):
 		fg_item = make_item(properties={"is_stock_item": 1}).name
 		rm_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 100}).name

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -577,6 +577,74 @@ class TestBOM(ERPNextTestSuite):
 		self.assertRaises(frappe.ValidationError, bom_doc.save)
 
 	@timeout
+	def test_secondary_item_use_valuation_rate(self):
+		fg_item = make_item(properties={"is_stock_item": 1}).name
+		rm_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 100}).name
+		scrap_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 50}).name
+		by_product = make_item(properties={"is_stock_item": 1}).name
+
+		bom_doc = frappe.new_doc("BOM")
+		bom_doc.item = fg_item
+		bom_doc.quantity = 1
+		bom_doc.company = "_Test Company"
+		bom_doc.currency = "INR"
+		bom_doc.append("items", {"item_code": rm_item, "qty": 10, "rate": 100.0})
+		bom_doc.append(
+			"secondary_items",
+			{"item_code": scrap_item, "secondary_item_type": "Scrap", "qty": 2, "use_valuation_rate": 1},
+		)
+		bom_doc.append(
+			"secondary_items",
+			{
+				"item_code": by_product,
+				"secondary_item_type": "By-Product",
+				"qty": 1,
+				"cost_allocation_per": 10,
+			},
+		)
+		bom_doc.save()
+
+		scrap_row = bom_doc.secondary_items[0]
+		self.assertEqual(scrap_row.rate, 50)
+		self.assertEqual(scrap_row.cost, 100)
+		self.assertEqual(scrap_row.cost_allocation_per, 0)
+
+		# the by-product's percentage applies to the cost net of the valuation rate rows
+		self.assertEqual(bom_doc.raw_material_cost, 1000)
+		self.assertEqual(bom_doc.secondary_items[1].cost, 90)
+		self.assertEqual(bom_doc.cost_allocation_per, 90)
+		self.assertEqual(bom_doc.cost_allocation, 810)
+		self.assertEqual(bom_doc.secondary_items_cost, 190)
+		self.assertEqual(bom_doc.total_cost, 810)
+
+	@timeout
+	def test_secondary_item_valuation_rate_refreshed_on_update_cost(self):
+		fg_item = make_item(properties={"is_stock_item": 1}).name
+		rm_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 100}).name
+		scrap_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 50}).name
+
+		bom_doc = frappe.new_doc("BOM")
+		bom_doc.item = fg_item
+		bom_doc.quantity = 1
+		bom_doc.company = "_Test Company"
+		bom_doc.currency = "INR"
+		bom_doc.append("items", {"item_code": rm_item, "qty": 10, "rate": 100.0})
+		bom_doc.append(
+			"secondary_items",
+			{"item_code": scrap_item, "secondary_item_type": "Scrap", "qty": 2, "use_valuation_rate": 1},
+		)
+		bom_doc.save()
+		bom_doc.submit()
+
+		frappe.db.set_value("Item", scrap_item, "valuation_rate", 80)
+		bom_doc.update_cost()
+		bom_doc.reload()
+
+		self.assertEqual(bom_doc.secondary_items[0].rate, 80)
+		self.assertEqual(bom_doc.secondary_items[0].cost, 160)
+		self.assertEqual(bom_doc.total_cost, 840)
+
+	@timeout
 	def test_bom_item_query(self):
 		query = partial(
 			item_query,

--- a/erpnext/manufacturing/doctype/bom/test_records.json
+++ b/erpnext/manufacturing/doctype/bom/test_records.json
@@ -46,7 +46,7 @@
    "rate": 2000.0,
    "stock_uom": "_Test UOM",
    "secondary_item_type": "Scrap",
-   "is_legacy": 1
+   "use_valuation_rate": 1
   }
   ],
   "items": [

--- a/erpnext/manufacturing/doctype/bom/test_records.json
+++ b/erpnext/manufacturing/doctype/bom/test_records.json
@@ -38,12 +38,10 @@
  {
   "secondary_items":[
   {
-   "amount": 2000.0,
    "doctype": "BOM Secondary Item",
    "item_code": "_Test Item Home Desktop 100",
    "parentfield": "secondary_items",
    "stock_qty": 1.0,
-   "rate": 2000.0,
    "stock_uom": "_Test UOM",
    "secondary_item_type": "Scrap",
    "use_valuation_rate": 1

--- a/erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.json
+++ b/erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.json
@@ -180,7 +180,7 @@
   },
   {
    "default": "0",
-   "description": "Value this item at its incoming rate and deduct it from the raw material cost, like the pre-v16 scrap items. The remaining cost is allocated by percentage among the other items.",
+   "description": "Value this item at its valuation rate and deduct it from the raw material cost, like the pre-v16 scrap items. The remaining cost is allocated by percentage among the other items.",
    "fieldname": "use_valuation_rate",
    "fieldtype": "Check",
    "label": "Use Valuation Rate",

--- a/erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.json
+++ b/erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.json
@@ -8,7 +8,7 @@
  "field_order": [
   "rate",
   "column_break_gres",
-  "is_legacy",
+  "use_valuation_rate",
   "section_break_sbnk",
   "item_code",
   "item_name",
@@ -34,12 +34,12 @@
  ],
  "fields": [
   {
-   "depends_on": "eval:!doc.is_legacy",
+   "depends_on": "eval:!doc.use_valuation_rate",
    "fieldname": "secondary_item_type",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Type",
-   "mandatory_depends_on": "eval:!doc.is_legacy",
+   "mandatory_depends_on": "eval:!doc.use_valuation_rate",
    "options": "\nCo-Product\nBy-Product\nScrap\nAdditional Finished Good"
   },
   {
@@ -103,7 +103,7 @@
    "reqd": 1
   },
   {
-   "depends_on": "eval:!doc.is_legacy",
+   "depends_on": "eval:!doc.use_valuation_rate",
    "fieldname": "section_break_ielf",
    "fieldtype": "Section Break"
   },
@@ -187,15 +187,15 @@
   },
   {
    "default": "0",
-   "depends_on": "is_legacy",
-   "fieldname": "is_legacy",
+   "depends_on": "use_valuation_rate",
+   "fieldname": "use_valuation_rate",
    "fieldtype": "Check",
-   "label": "Is Legacy",
+   "label": "Use Valuation Rate",
    "no_copy": 1,
    "read_only": 1
   },
   {
-   "depends_on": "eval:doc.is_legacy",
+   "depends_on": "eval:doc.use_valuation_rate",
    "fieldname": "rate",
    "fieldtype": "Currency",
    "label": "Rate",

--- a/erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.json
+++ b/erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.json
@@ -6,9 +6,6 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "rate",
-  "column_break_gres",
-  "use_valuation_rate",
   "section_break_sbnk",
   "item_code",
   "item_name",
@@ -25,16 +22,17 @@
   "column_break_wsra",
   "image_nygv",
   "section_break_ielf",
+  "use_valuation_rate",
   "cost_allocation_per",
   "process_loss_per",
   "column_break_gtbl",
+  "rate",
   "cost",
   "base_cost",
   "process_loss_qty"
  ],
  "fields": [
   {
-   "depends_on": "eval:!doc.use_valuation_rate",
    "fieldname": "secondary_item_type",
    "fieldtype": "Select",
    "in_list_view": 1,
@@ -103,7 +101,6 @@
    "reqd": 1
   },
   {
-   "depends_on": "eval:!doc.use_valuation_rate",
    "fieldname": "section_break_ielf",
    "fieldtype": "Section Break"
   },
@@ -143,6 +140,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:!doc.use_valuation_rate",
    "fieldname": "cost_allocation_per",
    "fieldtype": "Percent",
    "label": "Cost Allocation %",
@@ -182,17 +180,11 @@
    "reqd": 1
   },
   {
-   "fieldname": "column_break_gres",
-   "fieldtype": "Column Break"
-  },
-  {
    "default": "0",
-   "depends_on": "use_valuation_rate",
+   "description": "Value this item at its valuation rate and deduct it from the raw material cost, like the pre-v16 scrap items. The remaining cost is allocated by percentage among the other items.",
    "fieldname": "use_valuation_rate",
    "fieldtype": "Check",
-   "label": "Use Valuation Rate",
-   "no_copy": 1,
-   "read_only": 1
+   "label": "Use Valuation Rate"
   },
   {
    "depends_on": "eval:doc.use_valuation_rate",

--- a/erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.json
+++ b/erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.json
@@ -26,7 +26,6 @@
   "cost_allocation_per",
   "process_loss_per",
   "column_break_gtbl",
-  "rate",
   "cost",
   "base_cost",
   "process_loss_qty"
@@ -181,19 +180,11 @@
   },
   {
    "default": "0",
-   "description": "Value this item at its valuation rate and deduct it from the raw material cost, like the pre-v16 scrap items. The remaining cost is allocated by percentage among the other items.",
+   "description": "Value this item at its incoming rate and deduct it from the raw material cost, like the pre-v16 scrap items. The remaining cost is allocated by percentage among the other items.",
    "fieldname": "use_valuation_rate",
    "fieldtype": "Check",
-   "label": "Use Valuation Rate"
-  },
-  {
-   "depends_on": "eval:doc.use_valuation_rate",
-   "fieldname": "rate",
-   "fieldtype": "Currency",
-   "label": "Rate",
-   "no_copy": 1,
-   "non_negative": 1,
-   "read_only": 1
+   "label": "Use Valuation Rate",
+   "show_description_on_click": 1
   },
   {
    "default": "0",

--- a/erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.py
+++ b/erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.py
@@ -28,7 +28,6 @@ class BOMSecondaryItem(Document):
 		process_loss_per: DF.Percent
 		process_loss_qty: DF.Float
 		qty: DF.Float
-		rate: DF.Currency
 		secondary_item_type: DF.Literal["", "Co-Product", "By-Product", "Scrap", "Additional Finished Good"]
 		stock_qty: DF.Float
 		stock_uom: DF.Link | None

--- a/erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.py
+++ b/erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.py
@@ -20,7 +20,6 @@ class BOMSecondaryItem(Document):
 		cost_allocation_per: DF.Percent
 		description: DF.TextEditor | None
 		image: DF.AttachImage | None
-		is_legacy: DF.Check
 		item_code: DF.Link
 		item_name: DF.Data | None
 		parent: DF.Data
@@ -34,6 +33,7 @@ class BOMSecondaryItem(Document):
 		stock_qty: DF.Float
 		stock_uom: DF.Link | None
 		uom: DF.Link
+		use_valuation_rate: DF.Check
 	# end: auto-generated types
 
 	pass

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -304,8 +304,9 @@ class JobCard(Document):
 			fetch_exploded=0,
 			fetch_secondary_items=1,
 		)
-		for item_code, values in items_dict.items():
-			self.append_secondary_item(item_code, frappe._dict(values))
+		for values in items_dict.values():
+			values = frappe._dict(values)
+			self.append_secondary_item(values.item_code, values)
 
 	def append_secondary_item(self, item_code, values):
 		secondary_item = {

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -317,11 +317,10 @@ class JobCard(Document):
 			"bom_secondary_item": values.name,
 		}
 
-		if not values.use_valuation_rate:
-			secondary_item["stock_qty"] -= flt(
-				secondary_item["stock_qty"] * (values.process_loss_per / 100),
-				self.precision("for_quantity"),
-			)
+		secondary_item["stock_qty"] -= flt(
+			secondary_item["stock_qty"] * (flt(values.process_loss_per) / 100),
+			self.precision("for_quantity"),
+		)
 
 		self.append("secondary_items", secondary_item)
 

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -317,7 +317,7 @@ class JobCard(Document):
 			"bom_secondary_item": values.name,
 		}
 
-		if not values.is_legacy:
+		if not values.use_valuation_rate:
 			secondary_item["stock_qty"] -= flt(
 				secondary_item["stock_qty"] * (values.process_loss_per / 100),
 				self.precision("for_quantity"),
@@ -1878,7 +1878,7 @@ class JobCard(Document):
 		add_additional_cost(ste.stock_entry, wo_doc, self)
 		ManufactureStockEntry(ste.stock_entry).add_secondary_items_from_job_card()
 		for row in ste.stock_entry.items:
-			if (row.secondary_item_type or row.is_legacy_scrap_item) and not row.t_warehouse:
+			if (row.secondary_item_type or row.use_valuation_rate) and not row.t_warehouse:
 				row.t_warehouse = self.target_warehouse
 
 

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -2804,7 +2804,7 @@ class TestJobCard(ERPNextTestSuite):
 		frappe.db.set_value(
 			"Stock Entry Detail",
 			s.items[3].name,
-			{"secondary_item_type": None, "is_legacy_scrap_item": 1},
+			{"secondary_item_type": None, "use_valuation_rate": 1},
 		)
 
 		from erpnext.stock.doctype.stock_entry.services.manufacturing import ManufactureStockEntry

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -2813,6 +2813,88 @@ class TestJobCard(ERPNextTestSuite):
 		used_secondary_items = ManufactureStockEntry(stock_entry).get_used_secondary_items()
 		self.assertEqual(used_secondary_items[("_Test Item", "Scrap")], 2)
 
+	def test_secondary_items_from_multiple_boms_stay_separate(self):
+		"""Rows linked to different BOM rows keep their own quantity and valuation mode."""
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		secondary_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 50}).name
+
+		bom_links = []
+		for cost_allocation_per in (0, 10):
+			fg_item = make_item(properties={"is_stock_item": 1}).name
+			rm_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 100}).name
+
+			bom_doc = frappe.new_doc("BOM")
+			bom_doc.item = fg_item
+			bom_doc.quantity = 1
+			bom_doc.company = "_Test Company"
+			bom_doc.currency = "INR"
+			bom_doc.append("items", {"item_code": rm_item, "qty": 1, "rate": 100.0})
+			bom_doc.append(
+				"secondary_items",
+				{
+					"item_code": secondary_item,
+					"secondary_item_type": "Scrap",
+					"qty": 1,
+					"cost_allocation_per": cost_allocation_per,
+					"use_valuation_rate": 0 if cost_allocation_per else 1,
+				},
+			)
+			bom_doc.save()
+			bom_doc.submit()
+			bom_links.append(bom_doc.secondary_items[0].name)
+
+		for row in frappe.get_doc("BOM", self.work_order.bom_no).items:
+			make_stock_entry(
+				item_code=row.item_code,
+				target="_Test Warehouse - _TC",
+				qty=10,
+				basic_rate=100,
+			)
+
+		job_card = frappe.get_last_doc("Job Card", {"work_order": self.work_order.name})
+		job_card.append(
+			"secondary_items",
+			{
+				"item_code": secondary_item,
+				"stock_qty": 2,
+				"secondary_item_type": "Scrap",
+				"bom_secondary_item": bom_links[0],
+			},
+		)
+		job_card.append(
+			"secondary_items",
+			{
+				"item_code": secondary_item,
+				"stock_qty": 3,
+				"secondary_item_type": "Scrap",
+				"bom_secondary_item": bom_links[1],
+			},
+		)
+		job_card.append(
+			"time_logs",
+			{
+				"from_time": "2009-01-01 12:06:25",
+				"to_time": "2009-01-01 12:37:25",
+				"completed_qty": job_card.for_quantity,
+			},
+		)
+		job_card.save()
+		job_card.submit()
+
+		from erpnext.manufacturing.doctype.work_order.mapper import (
+			make_stock_entry as make_stock_entry_for_wo,
+		)
+
+		s = frappe.get_doc(make_stock_entry_for_wo(self.work_order.name, "Manufacture"))
+
+		rows = {d.bom_secondary_item: d for d in s.items if d.item_code == secondary_item}
+		self.assertEqual(len(rows), 2)
+		self.assertEqual(rows[bom_links[0]].qty, 2)
+		self.assertTrue(rows[bom_links[0]].use_valuation_rate)
+		self.assertEqual(rows[bom_links[1]].qty, 3)
+		self.assertFalse(rows[bom_links[1]].use_valuation_rate)
+
 	@ERPNextTestSuite.change_settings(
 		"Manufacturing Settings", {"overproduction_percentage_for_work_order": 100}
 	)

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1133,7 +1133,7 @@ class TestWorkOrder(ERPNextTestSuite):
 
 		stock_entry = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 10))
 		for row in stock_entry.items:
-			if row.secondary_item_type or row.is_legacy_scrap_item:
+			if row.secondary_item_type or row.use_valuation_rate:
 				self.assertEqual(row.qty, 1)
 
 		# Partial Job Card 1 with qty 10
@@ -1145,7 +1145,7 @@ class TestWorkOrder(ERPNextTestSuite):
 
 		stock_entry = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 10))
 		for row in stock_entry.items:
-			if row.secondary_item_type or row.is_legacy_scrap_item:
+			if row.secondary_item_type or row.use_valuation_rate:
 				self.assertEqual(row.qty, 2)
 
 		# Partial Job Card 2 with qty 10
@@ -2918,7 +2918,7 @@ class TestWorkOrder(ERPNextTestSuite):
 		self.assertTrue(se_doc.additional_costs)
 		secondary_items = []
 		for item in se_doc.items:
-			if item.secondary_item_type or item.is_legacy_scrap_item:
+			if item.secondary_item_type or item.use_valuation_rate:
 				secondary_items.append(item.item_code)
 
 		self.assertEqual(
@@ -5811,7 +5811,9 @@ def prepare_boms_for_sub_assembly_test():
 			do_not_submit=True,
 		)
 
-		bom.append("secondary_items", {"item_code": "Test Final Scrap Item 1", "qty": 1, "is_legacy": 1})
+		bom.append(
+			"secondary_items", {"item_code": "Test Final Scrap Item 1", "qty": 1, "use_valuation_rate": 1}
+		)
 
 		bom.submit()
 
@@ -5824,7 +5826,9 @@ def prepare_boms_for_sub_assembly_test():
 			do_not_submit=True,
 		)
 
-		bom.append("secondary_items", {"item_code": "Test Final Scrap Item 2", "qty": 1, "is_legacy": 1})
+		bom.append(
+			"secondary_items", {"item_code": "Test Final Scrap Item 2", "qty": 1, "use_valuation_rate": 1}
+		)
 
 		bom.submit()
 

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -208,7 +208,7 @@ class WorkOrder(Document):
 			.where(
 				(parent.work_order == self.name)
 				& (parent.docstatus == 1)
-				& ((child.secondary_item_type != "") | (child.is_legacy_scrap_item == 1))
+				& ((child.secondary_item_type != "") | (child.use_valuation_rate == 1))
 			)
 			.select(
 				child.item_code,

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -514,3 +514,4 @@ erpnext.patches.v16_0.recalculate_purchase_receipt_billing_status
 erpnext.patches.v16_0.recalculate_mixed_purchase_receipt_billing_status
 erpnext.patches.v16_0.repair_work_order_material_transfer
 erpnext.patches.v16_0.remove_frappe_crm_custom_fields
+erpnext.patches.v16_0.rename_is_legacy_to_use_valuation_rate

--- a/erpnext/patches/v16_0/co_by_product_patch.py
+++ b/erpnext/patches/v16_0/co_by_product_patch.py
@@ -40,7 +40,7 @@ def insert_into_bom():
 					"uom": item.stock_uom,
 					"conversion_factor": 1,
 					"qty": item.stock_qty,
-					"is_legacy": 1,
+					"use_valuation_rate": 1,
 					"secondary_item_type": "Scrap",
 				}
 			)
@@ -100,12 +100,12 @@ def bulk_insert(parent_doctype, old_doctype, new_doctype, old_fields, new_fields
 def rename_fields():
 	rename_field("BOM", "scrap_material_cost", "secondary_items_cost")
 	rename_field("BOM", "base_scrap_material_cost", "base_secondary_items_cost")
-	rename_field("Stock Entry Detail", "is_scrap_item", "is_legacy_scrap_item")
+	rename_field("Stock Entry Detail", "is_scrap_item", "use_valuation_rate")
 	rename_field(
 		"Manufacturing Settings",
 		"set_op_cost_and_scrap_from_sub_assemblies",
 		"set_op_cost_and_secondary_items_from_sub_assemblies",
 	)
 	rename_field("Selling Settings", "deliver_scrap_items", "deliver_secondary_items")
-	rename_field("Subcontracting Receipt Item", "is_scrap_item", "is_legacy_scrap_item")
+	rename_field("Subcontracting Receipt Item", "is_scrap_item", "use_valuation_rate")
 	rename_field("Subcontracting Receipt Item", "scrap_cost_per_qty", "secondary_items_cost_per_qty")

--- a/erpnext/patches/v16_0/co_by_product_patch.py
+++ b/erpnext/patches/v16_0/co_by_product_patch.py
@@ -22,8 +22,10 @@ def copy_doctypes():
 
 
 def insert_into_bom():
-	fields = ["item_code", "item_name", "stock_uom", "stock_qty", "rate"]
-	data = frappe.get_all("BOM Scrap Item", {"docstatus": ("<", 2)}, ["parent", *fields])
+	fields = ["item_code", "item_name", "stock_uom", "stock_qty"]
+	data = frappe.get_all(
+		"BOM Scrap Item", {"docstatus": ("<", 2)}, ["parent", *fields, "amount", "base_amount"]
+	)
 	grouped_data = defaultdict(list)
 	for item in data:
 		grouped_data[item.parent].append(item)
@@ -42,6 +44,8 @@ def insert_into_bom():
 					"qty": item.stock_qty,
 					"use_valuation_rate": 1,
 					"secondary_item_type": "Scrap",
+					"cost": item.amount,
+					"base_cost": item.base_amount,
 				}
 			)
 			secondary_item.insert()

--- a/erpnext/patches/v16_0/rename_is_legacy_to_use_valuation_rate.py
+++ b/erpnext/patches/v16_0/rename_is_legacy_to_use_valuation_rate.py
@@ -1,4 +1,6 @@
+import frappe
 from frappe.model.utils.rename_field import rename_field
+from frappe.utils import flt
 
 
 def execute():
@@ -10,3 +12,36 @@ def execute():
 	rename_field("BOM Secondary Item", "is_legacy", "use_valuation_rate")
 	rename_field("Stock Entry Detail", "is_legacy_scrap_item", "use_valuation_rate")
 	rename_field("Subcontracting Receipt Item", "is_legacy_scrap_item", "use_valuation_rate")
+	backfill_cost_from_rate()
+
+
+def backfill_cost_from_rate():
+	"""Earlier v16 builds stored the migrated scrap rate on the removed rate field."""
+	if not frappe.db.has_column("BOM Secondary Item", "rate"):
+		return
+
+	rows = frappe.db.sql(
+		"""select name, parent, rate, stock_qty from `tabBOM Secondary Item`
+		where use_valuation_rate = 1 and cost = 0 and rate > 0""",
+		as_dict=True,
+	)
+	if not rows:
+		return
+
+	conversion_rates = dict(
+		frappe.get_all(
+			"BOM",
+			filters={"name": ("in", {row.parent for row in rows})},
+			fields=["name", "conversion_rate"],
+			as_list=True,
+		)
+	)
+
+	for row in rows:
+		cost = flt(row.rate) * flt(row.stock_qty)
+		frappe.db.set_value(
+			"BOM Secondary Item",
+			row.name,
+			{"cost": cost, "base_cost": cost * flt(conversion_rates.get(row.parent) or 1)},
+			update_modified=False,
+		)

--- a/erpnext/patches/v16_0/rename_is_legacy_to_use_valuation_rate.py
+++ b/erpnext/patches/v16_0/rename_is_legacy_to_use_valuation_rate.py
@@ -1,0 +1,12 @@
+from frappe.model.utils.rename_field import rename_field
+
+
+def execute():
+	"""Rename for sites that migrated before is_legacy was replaced by use_valuation_rate.
+
+	Fresh migrations get use_valuation_rate directly from co_by_product_patch; rename_field
+	is a no-op there because the old columns never existed.
+	"""
+	rename_field("BOM Secondary Item", "is_legacy", "use_valuation_rate")
+	rename_field("Stock Entry Detail", "is_legacy_scrap_item", "use_valuation_rate")
+	rename_field("Subcontracting Receipt Item", "is_legacy_scrap_item", "use_valuation_rate")

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -24,7 +24,7 @@ erpnext.stock.is_incoming_qi_purpose = (purpose) =>
 erpnext.stock.row_requires_quality_inspection = (purpose, row) => {
 	if (
 		erpnext.stock.secondary_item_purposes.includes(purpose) &&
-		(row.secondary_item_type || row.is_legacy_scrap_item)
+		(row.secondary_item_type || row.use_valuation_rate)
 	)
 		return false;
 	if (purpose === "Manufacture") return !!row.is_finished_item;

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -446,7 +446,7 @@ def item_query(doctype: Any, txt: str | None, searchfield: Any, start: int, page
 					"and",
 					["items.secondary_item_type", "is", "not set"],
 					"and",
-					["items.is_legacy_scrap_item", "=", 0],
+					["items.use_valuation_rate", "=", 0],
 				]
 			)
 			if purpose == "Manufacture":

--- a/erpnext/stock/doctype/stock_entry/services/disassemble.py
+++ b/erpnext/stock/doctype/stock_entry/services/disassemble.py
@@ -230,7 +230,7 @@ class DisassembleStockEntry(BaseStockEntry):
 			"t_warehouse": t_warehouse,
 			"is_finished_item": source_row.is_finished_item,
 			"secondary_item_type": source_row.secondary_item_type,
-			"is_legacy_scrap_item": source_row.is_legacy_scrap_item,
+			"use_valuation_rate": source_row.use_valuation_rate,
 			"bom_secondary_item": source_row.bom_secondary_item,
 			"bom_no": source_row.bom_no,
 			"use_serial_batch_fields": 1 if (source_row.batch_no or source_row.serial_no) else 0,
@@ -284,7 +284,7 @@ class DisassembleStockEntry(BaseStockEntry):
 			for field in fields:
 				item_args[field] = row.get(field)
 
-			item_args["is_legacy_scrap_item"] = row.get("is_legacy")
+			item_args["use_valuation_rate"] = row.get("use_valuation_rate")
 			item_args["s_warehouse"] = self.doc.from_warehouse
 			item_args["uom"] = item_args.get("uom") or item_args.get("stock_uom")
 			item_args["bom_secondary_item"] = row.get("name")
@@ -330,7 +330,7 @@ class DisassembleStockEntry(BaseStockEntry):
 			SED.conversion_factor,
 			SED.is_finished_item,
 			SED.secondary_item_type,
-			SED.is_legacy_scrap_item,
+			SED.use_valuation_rate,
 			SED.bom_secondary_item,
 			SED.batch_no,
 			SED.serial_no,
@@ -397,7 +397,7 @@ class DisassembleStockEntry(BaseStockEntry):
 				SED.stock_uom,
 				SED.is_finished_item,
 				SED.secondary_item_type,
-				SED.is_legacy_scrap_item,
+				SED.use_valuation_rate,
 				SED.bom_secondary_item,
 				SED.batch_no,
 				SED.serial_no,

--- a/erpnext/stock/doctype/stock_entry/services/gl_composer.py
+++ b/erpnext/stock/doctype/stock_entry/services/gl_composer.py
@@ -102,11 +102,7 @@ class StockEntryGLComposer(BaseStockGLComposer):
 		if not item.t_warehouse or item.s_warehouse:
 			return 0.0
 
-		if (
-			item.get("is_finished_item")
-			or item.get("secondary_item_type")
-			or item.get("is_legacy_scrap_item")
-		):
+		if item.get("is_finished_item") or item.get("secondary_item_type") or item.get("use_valuation_rate"):
 			return 0.0
 
 		if get_valuation_method(item.item_code, self.doc.company) != "Standard Cost":

--- a/erpnext/stock/doctype/stock_entry/services/manufacturing.py
+++ b/erpnext/stock/doctype/stock_entry/services/manufacturing.py
@@ -1103,7 +1103,7 @@ def get_bom_items(bom_no, use_multi_level_bom=None, qty=None, fetch_secondary_it
 		table_name = "BOM Explosion Item" if use_multi_level_bom else "BOM Item"
 
 	items = _run_bom_items_query(bom_no, table_name, qty)
-	return _deduplicate_bom_items(items)
+	return _deduplicate_bom_items(items, by_type=fetch_secondary_items)
 
 
 def _run_bom_items_query(bom_no, table_name, qty):
@@ -1145,13 +1145,14 @@ def _add_bom_table_specific_fields(query, doctype, table_name):
 	return query
 
 
-def _deduplicate_bom_items(items):
+def _deduplicate_bom_items(items, by_type=False):
 	item_dict = {}
 	for item in items:
-		if item.item_code in item_dict:
-			item_dict[item.item_code].qty += item.qty
+		key = (item.item_code, item.get("secondary_item_type") or "") if by_type else item.item_code
+		if key in item_dict:
+			item_dict[key].qty += item.qty
 		else:
-			item_dict[item.item_code] = item
+			item_dict[key] = item
 	return list(item_dict.values())
 
 

--- a/erpnext/stock/doctype/stock_entry/services/manufacturing.py
+++ b/erpnext/stock/doctype/stock_entry/services/manufacturing.py
@@ -861,6 +861,7 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 			return
 
 		secondary_items = self.get_secondary_items_from_job_card()
+		use_valuation_rate_map = self.get_use_valuation_rate_map(secondary_items)
 		for row in secondary_items:
 			if row.stock_qty <= 0:
 				continue
@@ -870,15 +871,24 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 			row.transfer_qty = row.qty
 			row.s_warehouse = None
 			row.t_warehouse = row.warehouse or self.doc.to_warehouse
-			row.use_valuation_rate = self.get_use_valuation_rate(row.bom_secondary_item)
+			row.use_valuation_rate = use_valuation_rate_map.get(row.bom_secondary_item, 0)
 			row.secondary_item_type = row.get("secondary_item_type")
 
 			self.doc.append("items", row)
 
-	def get_use_valuation_rate(self, bom_secondary_item) -> int:
-		if not bom_secondary_item:
-			return 0
-		return cint(frappe.db.get_value("BOM Secondary Item", bom_secondary_item, "use_valuation_rate"))
+	def get_use_valuation_rate_map(self, secondary_items) -> dict:
+		names = [row.bom_secondary_item for row in secondary_items if row.bom_secondary_item]
+		if not names:
+			return {}
+
+		return dict(
+			frappe.get_all(
+				"BOM Secondary Item",
+				filters={"name": ("in", names)},
+				fields=["name", "use_valuation_rate"],
+				as_list=True,
+			)
+		)
 
 	def get_secondary_items_from_job_card(self):
 		if not self.wo_doc.operations:

--- a/erpnext/stock/doctype/stock_entry/services/manufacturing.py
+++ b/erpnext/stock/doctype/stock_entry/services/manufacturing.py
@@ -40,7 +40,7 @@ class BaseManufactureStockEntry(BaseStockEntry):
 				not row.s_warehouse
 				and self.doc.from_warehouse
 				and not row.is_finished_item
-				and not row.is_legacy_scrap_item
+				and not row.use_valuation_rate
 				and not row.secondary_item_type
 			):
 				row.s_warehouse = self.doc.from_warehouse
@@ -49,7 +49,7 @@ class BaseManufactureStockEntry(BaseStockEntry):
 			elif (
 				not row.t_warehouse
 				and self.doc.to_warehouse
-				and (row.is_finished_item or row.is_legacy_scrap_item or row.secondary_item_type)
+				and (row.is_finished_item or row.use_valuation_rate or row.secondary_item_type)
 			):
 				row.t_warehouse = self.doc.to_warehouse
 				row.s_warehouse = None
@@ -98,7 +98,7 @@ class BaseManufactureStockEntry(BaseStockEntry):
 		secondary_items = get_secondary_items(self.doc.bom_no, self.doc.work_order)
 		for row in secondary_items:
 			item_args = self.get_item_dict(row)
-			item_args["is_legacy_scrap_item"] = bool(row.get("is_legacy"))
+			item_args["use_valuation_rate"] = bool(row.get("use_valuation_rate"))
 			item_args["secondary_item_type"] = row.secondary_item_type
 			item_args["bom_secondary_item"] = row.name
 
@@ -870,7 +870,6 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 			row.transfer_qty = row.qty
 			row.s_warehouse = None
 			row.t_warehouse = row.warehouse or self.doc.to_warehouse
-			row.is_legacy_scrap_item = row.is_legacy
 			row.secondary_item_type = row.get("secondary_item_type")
 
 			self.doc.append("items", row)
@@ -899,7 +898,7 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 		data = self._query_used_secondary_items()
 		used_secondary_items = defaultdict(float)
 		for row in data:
-			secondary_item_type = row.secondary_item_type or ("Scrap" if row.is_legacy_scrap_item else "")
+			secondary_item_type = row.secondary_item_type or ("Scrap" if row.use_valuation_rate else "")
 			key = (row.item_code, secondary_item_type)
 			used_secondary_items[key] += row.qty
 		return used_secondary_items
@@ -911,10 +910,10 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 			frappe.qb.from_(se)
 			.inner_join(sed)
 			.on(sed.parent == se.name)
-			.select(sed.item_code, sed.secondary_item_type, sed.is_legacy_scrap_item, sed.qty)
+			.select(sed.item_code, sed.secondary_item_type, sed.use_valuation_rate, sed.qty)
 			.where(
 				(se.work_order == self.doc.work_order)
-				& ((sed.secondary_item_type.isnotnull()) | (sed.is_legacy_scrap_item == 1))
+				& ((sed.secondary_item_type.isnotnull()) | (sed.use_valuation_rate == 1))
 				& (se.docstatus == 1)
 				& (se.purpose.isin(["Repack", "Manufacture"]))
 			)
@@ -1120,7 +1119,7 @@ def _add_bom_table_specific_fields(query, doctype, table_name):
 			doctype.uom,
 			doctype.process_loss_per,
 			doctype.secondary_item_type,
-			doctype.is_legacy,
+			doctype.use_valuation_rate,
 			doctype.conversion_factor,
 		)
 	if table_name == "BOM Item":

--- a/erpnext/stock/doctype/stock_entry/services/manufacturing.py
+++ b/erpnext/stock/doctype/stock_entry/services/manufacturing.py
@@ -1109,7 +1109,6 @@ def _run_bom_items_query(bom_no, table_name, qty):
 			doctype.stock_uom,
 			doctype.description,
 			(doctype.stock_qty / bom_doc.quantity.as_("qty") * qty).as_("qty"),
-			doctype.rate.as_("basic_rate"),
 		)
 		.where((bom_doc.name == bom_no) & (bom_doc.docstatus == 1))
 		.orderby(doctype.idx)
@@ -1128,6 +1127,7 @@ def _add_bom_table_specific_fields(query, doctype, table_name):
 			doctype.use_valuation_rate,
 			doctype.conversion_factor,
 		)
+	query = query.select(doctype.rate.as_("basic_rate"))
 	if table_name == "BOM Item":
 		return query.select(
 			doctype.allow_alternative_item, doctype.uom, doctype.conversion_factor, doctype.bom_no

--- a/erpnext/stock/doctype/stock_entry/services/manufacturing.py
+++ b/erpnext/stock/doctype/stock_entry/services/manufacturing.py
@@ -870,9 +870,15 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 			row.transfer_qty = row.qty
 			row.s_warehouse = None
 			row.t_warehouse = row.warehouse or self.doc.to_warehouse
+			row.use_valuation_rate = self.get_use_valuation_rate(row.bom_secondary_item)
 			row.secondary_item_type = row.get("secondary_item_type")
 
 			self.doc.append("items", row)
+
+	def get_use_valuation_rate(self, bom_secondary_item) -> int:
+		if not bom_secondary_item:
+			return 0
+		return cint(frappe.db.get_value("BOM Secondary Item", bom_secondary_item, "use_valuation_rate"))
 
 	def get_secondary_items_from_job_card(self):
 		if not self.wo_doc.operations:

--- a/erpnext/stock/doctype/stock_entry/services/manufacturing.py
+++ b/erpnext/stock/doctype/stock_entry/services/manufacturing.py
@@ -906,17 +906,14 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 
 	def _adjust_secondary_item_qtys(self, secondary_items, used_secondary_items, pending_qty):
 		for row in secondary_items:
-			key = (row.item_code, row.secondary_item_type or "")
-			row.stock_qty -= flt(used_secondary_items.get(key))
+			row.stock_qty -= flt(used_secondary_items.get(get_secondary_item_key(row)))
 			row.stock_qty = row.stock_qty * flt(self.doc.fg_completed_qty) / flt(pending_qty)
 
 	def get_used_secondary_items(self):
 		data = self._query_used_secondary_items()
 		used_secondary_items = defaultdict(float)
 		for row in data:
-			secondary_item_type = row.secondary_item_type or ("Scrap" if row.use_valuation_rate else "")
-			key = (row.item_code, secondary_item_type)
-			used_secondary_items[key] += row.qty
+			used_secondary_items[get_secondary_item_key(row)] += row.qty
 		return used_secondary_items
 
 	def _query_used_secondary_items(self):
@@ -926,7 +923,13 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 			frappe.qb.from_(se)
 			.inner_join(sed)
 			.on(sed.parent == se.name)
-			.select(sed.item_code, sed.secondary_item_type, sed.use_valuation_rate, sed.qty)
+			.select(
+				sed.item_code,
+				sed.secondary_item_type,
+				sed.use_valuation_rate,
+				sed.qty,
+				sed.bom_secondary_item,
+			)
 			.where(
 				(se.work_order == self.doc.work_order)
 				& ((sed.secondary_item_type.isnotnull()) | (sed.use_valuation_rate == 1))
@@ -1182,6 +1185,18 @@ def get_secondary_items_from_sub_assemblies(bom_no):
 	return items
 
 
+def get_secondary_item_key(row):
+	"""Identity of a secondary output: its BOM row when linked, else (item, type).
+
+	Grouping only by (item, type) would merge rows that different BOMs of the same work
+	order produce, and one BOM row's percentage or valuation mode would then govern the
+	other BOMs' quantities too."""
+	if row.get("bom_secondary_item"):
+		return row.bom_secondary_item
+
+	return (row.item_code, row.secondary_item_type or ("Scrap" if row.get("use_valuation_rate") else ""))
+
+
 def get_secondary_items_from_job_card(work_order, jc_name=None):
 	job_card = frappe.qb.DocType("Job Card")
 	job_card_secondary_item = frappe.qb.DocType("Job Card Secondary Item")
@@ -1191,12 +1206,12 @@ def get_secondary_items_from_job_card(work_order, jc_name=None):
 		.select(
 			Sum(job_card_secondary_item.stock_qty).as_("stock_qty"),
 			job_card_secondary_item.item_code,
-			# stock_uom and the secondary-item BOM link are constant per grouped
-			# (item_code, secondary_item_type) -> Max() returns their single value. item_name and
-			# description are editable per line, so they come from a representative line below.
+			# stock_uom is constant per grouped item_code -> Max() returns its single value.
+			# item_name and description are editable per line, so they come from a
+			# representative line below.
 			Max(job_card_secondary_item.stock_uom).as_("stock_uom"),
 			job_card_secondary_item.secondary_item_type,
-			Max(job_card_secondary_item.bom_secondary_item).as_("bom_secondary_item"),
+			job_card_secondary_item.bom_secondary_item,
 		)
 		.join(job_card_secondary_item)
 		.on(job_card_secondary_item.parent == job_card.name)
@@ -1205,7 +1220,11 @@ def get_secondary_items_from_job_card(work_order, jc_name=None):
 			& (job_card.work_order == work_order)
 			& (job_card.docstatus == 1)
 		)
-		.groupby(job_card_secondary_item.item_code, job_card_secondary_item.secondary_item_type)
+		.groupby(
+			job_card_secondary_item.item_code,
+			job_card_secondary_item.secondary_item_type,
+			job_card_secondary_item.bom_secondary_item,
+		)
 		.orderby(Min(job_card_secondary_item.idx))
 	)
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -83,7 +83,7 @@ def is_costed_out_of_finished_item(row) -> bool:
 	A secondary item that is not linked to a BOM has no cost allocation of its own, so it is
 	valued the way the legacy scrap item was: its cost is deducted from the finished good.
 	"""
-	return bool(row.is_legacy_scrap_item or (row.secondary_item_type and not row.bom_secondary_item))
+	return bool(row.use_valuation_rate or (row.secondary_item_type and not row.bom_secondary_item))
 
 
 class StockEntry(StockController, SubcontractingInwardController):
@@ -804,7 +804,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 
 	def _validate_no_raw_materials_in_manufacture_entry(self, settings):
 		for item in self.items:
-			if not item.is_finished_item and not item.secondary_item_type and not item.is_legacy_scrap_item:
+			if not item.is_finished_item and not item.secondary_item_type and not item.use_valuation_rate:
 				label = frappe.get_meta(settings.doctype).get_translated_label(
 					"get_rm_cost_from_consumption_entry"
 				)
@@ -944,7 +944,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 
 		for d in self.items:
 			if d.t_warehouse and not d.s_warehouse:
-				if d.secondary_item_type or d.is_legacy_scrap_item:
+				if d.secondary_item_type or d.use_valuation_rate:
 					d.is_finished_item = 0
 				elif self.purpose == "Repack" or d.item_code == finished_item:
 					d.is_finished_item = 1

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -683,10 +683,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 
 			if self.bom_no:
 				d.basic_rate *= bom_cost_allocation_per / 100
-		elif is_costed_out_of_finished_item(d):
-			d.basic_rate = get_incoming_rate(self.get_args_for_incoming_rate(d), raise_error_if_no_rate)
-			has_derived_rate = True
-		elif d.secondary_item_type and d.bom_secondary_item:
+		elif d.secondary_item_type and d.bom_secondary_item and not d.use_valuation_rate:
 			cost_allocation_per = flt(
 				frappe.get_value("BOM Secondary Item", d.bom_secondary_item, "cost_allocation_per")
 			)

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -683,7 +683,12 @@ class StockEntry(StockController, SubcontractingInwardController):
 
 			if self.bom_no:
 				d.basic_rate *= bom_cost_allocation_per / 100
-		elif d.secondary_item_type and d.bom_secondary_item and not d.use_valuation_rate:
+		elif is_costed_out_of_finished_item(d):
+			# Recomputed every time: a rate fetched before the target warehouse was set
+			# must not stick to the row.
+			d.basic_rate = self.get_row_valuation_rate(d, raise_error_if_no_rate)
+			has_derived_rate = True
+		elif d.secondary_item_type and d.bom_secondary_item:
 			cost_allocation_per = flt(
 				frappe.get_value("BOM Secondary Item", d.bom_secondary_item, "cost_allocation_per")
 			)
@@ -695,22 +700,25 @@ class StockEntry(StockController, SubcontractingInwardController):
 		# A rate of zero that was derived rather than left unset is a real cost. Falling back to
 		# the item's valuation here would value free inputs, or an unallocated row, as output.
 		if not d.basic_rate and not d.allow_zero_valuation_rate and not has_derived_rate:
-			d.basic_rate = get_valuation_rate(
-				d.item_code,
-				d.t_warehouse,
-				self.doctype,
-				self.name,
-				d.allow_zero_valuation_rate,
-				currency=erpnext.get_company_currency(self.company),
-				company=self.company,
-				raise_error_if_no_rate=raise_error_if_no_rate,
-				batch_no=d.batch_no,
-				serial_and_batch_bundle=d.serial_and_batch_bundle,
-			)
+			d.basic_rate = self.get_row_valuation_rate(d, raise_error_if_no_rate)
 
 		# do not round off basic rate to avoid precision loss
 		d.basic_rate = flt(d.basic_rate)
 		d.basic_amount = flt(flt(d.transfer_qty) * flt(d.basic_rate), d.precision("basic_amount"))
+
+	def get_row_valuation_rate(self, d, raise_error_if_no_rate):
+		return get_valuation_rate(
+			d.item_code,
+			d.t_warehouse,
+			self.doctype,
+			self.name,
+			d.allow_zero_valuation_rate,
+			currency=erpnext.get_company_currency(self.company),
+			company=self.company,
+			raise_error_if_no_rate=raise_error_if_no_rate,
+			batch_no=d.batch_no,
+			serial_and_batch_bundle=d.serial_and_batch_bundle,
+		)
 
 	def _notify_zero_valuation_rate(self, items):
 		if len(items) > 1:

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -683,7 +683,10 @@ class StockEntry(StockController, SubcontractingInwardController):
 
 			if self.bom_no:
 				d.basic_rate *= bom_cost_allocation_per / 100
-		elif d.secondary_item_type and d.bom_secondary_item and not d.use_valuation_rate:
+		elif is_costed_out_of_finished_item(d):
+			d.basic_rate = get_incoming_rate(self.get_args_for_incoming_rate(d), raise_error_if_no_rate)
+			has_derived_rate = True
+		elif d.secondary_item_type and d.bom_secondary_item:
 			cost_allocation_per = flt(
 				frappe.get_value("BOM Secondary Item", d.bom_secondary_item, "cost_allocation_per")
 			)

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -587,7 +587,12 @@ class StockEntry(StockController, SubcontractingInwardController):
 		secondary_items_cost_basis = self.get_secondary_items_cost_basis(outgoing_items_cost)
 
 		zero_valuation_items = []
-		finished_items_last = sorted(self.get("items"), key=lambda row: cint(row.is_finished_item))
+		# Valuation-rate rows first: their value is deducted from the basis the percentage
+		# allocated rows and the finished good split, so it must be known before those.
+		finished_items_last = sorted(
+			self.get("items"),
+			key=lambda row: (cint(row.is_finished_item), cint(not is_costed_out_of_finished_item(row))),
+		)
 		for d in finished_items_last:
 			if d.s_warehouse or d.set_basic_rate_manually:
 				continue
@@ -678,12 +683,13 @@ class StockEntry(StockController, SubcontractingInwardController):
 
 			if self.bom_no:
 				d.basic_rate *= bom_cost_allocation_per / 100
-		elif d.secondary_item_type and d.bom_secondary_item:
+		elif d.secondary_item_type and d.bom_secondary_item and not d.use_valuation_rate:
 			cost_allocation_per = flt(
 				frappe.get_value("BOM Secondary Item", d.bom_secondary_item, "cost_allocation_per")
 			)
 			if flt(d.transfer_qty):
-				d.basic_rate = (secondary_items_cost_basis * (cost_allocation_per / 100)) / d.transfer_qty
+				allocation_basis = secondary_items_cost_basis - self.get_costed_out_items_cost()
+				d.basic_rate = (allocation_basis * (cost_allocation_per / 100)) / d.transfer_qty
 				has_derived_rate = True
 
 		# A rate of zero that was derived rather than left unset is a real cost. Falling back to
@@ -771,13 +777,15 @@ class StockEntry(StockController, SubcontractingInwardController):
 				)
 				return flt(outgoing_items_cost / total_fg_qty)
 
+	def get_costed_out_items_cost(self) -> float:
+		"""Total value of the rows that are deducted from the cost the other incoming rows split."""
+		return sum(flt(d.basic_amount) for d in self.get("items") if is_costed_out_of_finished_item(d))
+
 	def get_basic_rate_for_manufactured_item(
 		self, finished_item_qty, outgoing_items_cost=0, has_consumption_basis=False
 	) -> float:
 		settings = frappe.get_single("Manufacturing Settings")
-		scrap_items_cost = sum(
-			[flt(d.basic_amount) for d in self.get("items") if is_costed_out_of_finished_item(d)]
-		)
+		scrap_items_cost = self.get_costed_out_items_cost()
 
 		if settings.material_consumption:
 			outgoing_items_cost = self._get_rm_cost_for_manufacture(

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1090,7 +1090,7 @@ class TestStockEntry(ERPNextTestSuite):
 				rm_cost += d.amount
 		fg_cost = next(filter(lambda x: x.item_code == "_Test FG Item", s.get("items"))).amount
 		secondary_item_cost = next(
-			filter(lambda x: x.secondary_item_type or x.is_legacy_scrap_item, s.get("items"))
+			filter(lambda x: x.secondary_item_type or x.use_valuation_rate, s.get("items"))
 		).amount
 
 		self.assertEqual(fg_cost, flt(rm_cost - secondary_item_cost, 2))
@@ -1210,7 +1210,7 @@ class TestStockEntry(ERPNextTestSuite):
 					basic_rate=row.basic_rate or 100,
 				)
 
-			if row.secondary_item_type or row.is_legacy_scrap_item:
+			if row.secondary_item_type or row.use_valuation_rate:
 				row.item_code = secondary_item
 				row.uom = frappe.db.get_value("Item", secondary_item, "stock_uom")
 				row.stock_uom = frappe.db.get_value("Item", secondary_item, "stock_uom")
@@ -1219,15 +1219,11 @@ class TestStockEntry(ERPNextTestSuite):
 		stock_entry.save()
 
 		self.assertTrue(
-			[
-				row.item_code
-				for row in stock_entry.items
-				if row.secondary_item_type or row.is_legacy_scrap_item
-			]
+			[row.item_code for row in stock_entry.items if row.secondary_item_type or row.use_valuation_rate]
 		)
 
 		for row in stock_entry.items:
-			if not row.secondary_item_type and not row.is_legacy_scrap_item:
+			if not row.secondary_item_type and not row.use_valuation_rate:
 				qc = frappe.get_doc(
 					{
 						"doctype": "Quality Inspection",
@@ -1247,7 +1243,7 @@ class TestStockEntry(ERPNextTestSuite):
 		stock_entry.reload()
 		stock_entry.submit()
 		for row in stock_entry.items:
-			if row.secondary_item_type or row.is_legacy_scrap_item:
+			if row.secondary_item_type or row.use_valuation_rate:
 				self.assertFalse(row.quality_inspection)
 			else:
 				self.assertTrue(row.quality_inspection)

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1251,6 +1251,18 @@ class TestStockEntry(ERPNextTestSuite):
 		scrap_row = next(d for d in entry.items if d.use_valuation_rate)
 		self.assertEqual(scrap_row.basic_rate, 50)
 
+	def test_valuation_rate_lookup_without_voucher_no(self):
+		from erpnext.stock.stock_ledger import get_valuation_rate
+
+		item = make_item(properties={"is_stock_item": 1}).name
+		make_stock_entry(item_code=item, target="_Test Warehouse - _TC", qty=5, basic_rate=77)
+
+		# unsaved documents pass no voucher_no; the lookup must still find the last SLE
+		rate = get_valuation_rate(
+			item, "_Test Warehouse - _TC", "Stock Entry", None, raise_error_if_no_rate=False
+		)
+		self.assertEqual(rate, 77)
+
 	def test_quality_check_for_secondary_item(self):
 		from erpnext.manufacturing.doctype.work_order.mapper import (
 			make_stock_entry as _make_stock_entry,

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1172,6 +1172,79 @@ class TestStockEntry(ERPNextTestSuite):
 
 		self.assertRaises(frappe.ValidationError, ste.submit)
 
+	def test_manufacture_entry_with_use_valuation_rate_secondary_item(self):
+		from erpnext.manufacturing.doctype.work_order.mapper import (
+			make_stock_entry as _make_stock_entry,
+		)
+
+		fg_item = make_item(properties={"is_stock_item": 1}).name
+		rm_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 100}).name
+		scrap_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 50}).name
+		by_product = make_item(properties={"is_stock_item": 1}).name
+
+		make_stock_entry(item_code=rm_item, target="_Test Warehouse - _TC", qty=10, basic_rate=100)
+
+		bom_doc = frappe.new_doc("BOM")
+		bom_doc.item = fg_item
+		bom_doc.quantity = 1
+		bom_doc.company = "_Test Company"
+		bom_doc.currency = "INR"
+		bom_doc.append(
+			"items",
+			{"item_code": rm_item, "qty": 10, "rate": 100.0, "source_warehouse": "_Test Warehouse - _TC"},
+		)
+		bom_doc.append(
+			"secondary_items",
+			{"item_code": scrap_item, "secondary_item_type": "Scrap", "qty": 2, "use_valuation_rate": 1},
+		)
+		bom_doc.append(
+			"secondary_items",
+			{
+				"item_code": by_product,
+				"secondary_item_type": "By-Product",
+				"qty": 1,
+				"cost_allocation_per": 10,
+			},
+		)
+		bom_doc.save()
+		bom_doc.submit()
+
+		work_order = frappe.new_doc("Work Order")
+		work_order.update(
+			{
+				"company": "_Test Company",
+				"fg_warehouse": "_Test Warehouse 1 - _TC",
+				"production_item": fg_item,
+				"bom_no": bom_doc.name,
+				"qty": 1.0,
+				"stock_uom": frappe.db.get_value("Item", fg_item, "stock_uom"),
+				"skip_transfer": 1,
+			}
+		)
+		work_order.get_items_and_operations_from_bom()
+		work_order.submit()
+
+		entry = frappe.get_doc(_make_stock_entry(work_order.name, "Manufacture", 1))
+		entry.insert()
+
+		rm_cost = sum(d.basic_amount for d in entry.items if d.s_warehouse)
+		self.assertEqual(rm_cost, 1000)
+
+		# valuation rate row is valued at its valuation rate and deducted from the
+		# basis; the percentage rows and the finished good split the remainder
+		scrap_row = next(d for d in entry.items if d.use_valuation_rate)
+		self.assertEqual(scrap_row.basic_rate, 50)
+		self.assertEqual(scrap_row.basic_amount, 100)
+
+		by_product_row = next(d for d in entry.items if d.secondary_item_type == "By-Product")
+		self.assertEqual(by_product_row.basic_amount, 90)
+
+		fg_row = next(d for d in entry.items if d.is_finished_item)
+		self.assertEqual(fg_row.basic_amount, 810)
+
+		incoming_cost = sum(d.basic_amount for d in entry.items if not d.s_warehouse)
+		self.assertEqual(incoming_cost, rm_cost)
+
 	def test_quality_check_for_secondary_item(self):
 		from erpnext.manufacturing.doctype.work_order.mapper import (
 			make_stock_entry as _make_stock_entry,

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1245,6 +1245,12 @@ class TestStockEntry(ERPNextTestSuite):
 		incoming_cost = sum(d.basic_amount for d in entry.items if not d.s_warehouse)
 		self.assertEqual(incoming_cost, rm_cost)
 
+		# a stale rate, e.g. fetched before the target warehouse was set, must not stick
+		scrap_row.basic_rate = 999
+		entry.save()
+		scrap_row = next(d for d in entry.items if d.use_valuation_rate)
+		self.assertEqual(scrap_row.basic_rate, 50)
+
 	def test_quality_check_for_secondary_item(self):
 		from erpnext.manufacturing.doctype.work_order.mapper import (
 			make_stock_entry as _make_stock_entry,

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1090,8 +1090,8 @@ class TestStockEntry(ERPNextTestSuite):
 				rm_cost += d.amount
 		fg_cost = next(filter(lambda x: x.item_code == "_Test FG Item", s.get("items"))).amount
 		secondary_item_cost = next(
-			filter(lambda x: x.secondary_item_type or x.use_valuation_rate, s.get("items"))
-		).amount
+			x.amount for x in s.get("items") if x.secondary_item_type or x.use_valuation_rate
+		)
 
 		self.assertEqual(fg_cost, flt(rm_cost - secondary_item_cost, 2))
 

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1251,6 +1251,79 @@ class TestStockEntry(ERPNextTestSuite):
 		scrap_row = next(d for d in entry.items if d.use_valuation_rate)
 		self.assertEqual(scrap_row.basic_rate, 50)
 
+	def test_manufacture_entry_with_same_item_secondary_types(self):
+		from erpnext.manufacturing.doctype.work_order.mapper import (
+			make_stock_entry as _make_stock_entry,
+		)
+
+		fg_item = make_item(properties={"is_stock_item": 1}).name
+		rm_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 100}).name
+		secondary_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 50}).name
+
+		make_stock_entry(item_code=rm_item, target="_Test Warehouse - _TC", qty=10, basic_rate=100)
+
+		bom_doc = frappe.new_doc("BOM")
+		bom_doc.item = fg_item
+		bom_doc.quantity = 1
+		bom_doc.company = "_Test Company"
+		bom_doc.currency = "INR"
+		bom_doc.append(
+			"items",
+			{"item_code": rm_item, "qty": 10, "rate": 100.0, "source_warehouse": "_Test Warehouse - _TC"},
+		)
+		bom_doc.append(
+			"secondary_items",
+			{
+				"item_code": secondary_item,
+				"secondary_item_type": "Scrap",
+				"qty": 2,
+				"use_valuation_rate": 1,
+			},
+		)
+		bom_doc.append(
+			"secondary_items",
+			{
+				"item_code": secondary_item,
+				"secondary_item_type": "By-Product",
+				"qty": 1,
+				"cost_allocation_per": 10,
+			},
+		)
+		bom_doc.save()
+		bom_doc.submit()
+
+		work_order = frappe.new_doc("Work Order")
+		work_order.update(
+			{
+				"company": "_Test Company",
+				"fg_warehouse": "_Test Warehouse 1 - _TC",
+				"production_item": fg_item,
+				"bom_no": bom_doc.name,
+				"qty": 1.0,
+				"stock_uom": frappe.db.get_value("Item", fg_item, "stock_uom"),
+				"skip_transfer": 1,
+			}
+		)
+		work_order.get_items_and_operations_from_bom()
+		work_order.submit()
+
+		entry = frappe.get_doc(_make_stock_entry(work_order.name, "Manufacture", 1))
+		entry.insert()
+
+		# both rows of the same item keep their own type and costing mode
+		secondary_rows = [d for d in entry.items if d.item_code == secondary_item]
+		self.assertEqual(len(secondary_rows), 2)
+
+		scrap_row = next(d for d in secondary_rows if d.use_valuation_rate)
+		self.assertEqual(scrap_row.basic_amount, 100)
+
+		by_product_row = next(d for d in secondary_rows if not d.use_valuation_rate)
+		self.assertEqual(by_product_row.secondary_item_type, "By-Product")
+		self.assertEqual(by_product_row.basic_amount, 90)
+
+		fg_row = next(d for d in entry.items if d.is_finished_item)
+		self.assertEqual(fg_row.basic_amount, 810)
+
 	def test_valuation_rate_lookup_without_voucher_no(self):
 		from erpnext.stock.stock_ledger import get_valuation_rate
 

--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
@@ -18,7 +18,7 @@
   "item_name",
   "col_break2",
   "is_finished_item",
-  "is_legacy_scrap_item",
+  "use_valuation_rate",
   "secondary_item_type",
   "quality_inspection",
   "subcontracted_item",
@@ -572,7 +572,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:!doc.is_legacy_scrap_item && !doc.secondary_item_type",
+   "depends_on": "eval:!doc.use_valuation_rate && !doc.secondary_item_type",
    "fieldname": "is_finished_item",
    "fieldtype": "Check",
    "label": "Is Finished Item",
@@ -674,7 +674,7 @@
    "set_only_once": 1
   },
   {
-   "depends_on": "eval:parent.purpose == \"Manufacture\" && doc.t_warehouse && !doc.is_finished_item && !doc.is_legacy_scrap_item",
+   "depends_on": "eval:parent.purpose == \"Manufacture\" && doc.t_warehouse && !doc.is_finished_item && !doc.use_valuation_rate",
    "fieldname": "secondary_item_type",
    "fieldtype": "Select",
    "label": "Type",
@@ -689,10 +689,10 @@
   },
   {
    "default": "0",
-   "depends_on": "is_legacy_scrap_item",
-   "fieldname": "is_legacy_scrap_item",
+   "depends_on": "use_valuation_rate",
+   "fieldname": "use_valuation_rate",
    "fieldtype": "Check",
-   "label": "Is Legacy Scrap Item",
+   "label": "Use Valuation Rate",
    "read_only": 1
   }
  ],

--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.py
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.py
@@ -46,7 +46,6 @@ class StockEntryDetail(Document):
 		has_item_scanned: DF.Check
 		image: DF.Attach | None
 		is_finished_item: DF.Check
-		is_legacy_scrap_item: DF.Check
 		item_code: DF.Link
 		item_group: DF.Data | None
 		item_name: DF.Data | None
@@ -82,6 +81,7 @@ class StockEntryDetail(Document):
 		secondary_item_type: DF.Literal["", "Co-Product", "By-Product", "Scrap", "Additional Finished Good"]
 		uom: DF.Link
 		use_serial_batch_fields: DF.Check
+		use_valuation_rate: DF.Check
 		valuation_rate: DF.Currency
 	# end: auto-generated types
 

--- a/erpnext/stock/services/quality_inspection_service.py
+++ b/erpnext/stock/services/quality_inspection_service.py
@@ -55,7 +55,7 @@ SECONDARY_ITEM_PURPOSES = ("Manufacture", "Repack", "Disassemble")
 
 def is_inspection_exempt_secondary_row(doc, row) -> bool:
 	"""Whether the row is a secondary item on a document that produces secondary items."""
-	if not (row.get("secondary_item_type") or row.get("is_legacy_scrap_item")):
+	if not (row.get("secondary_item_type") or row.get("use_valuation_rate")):
 		return False
 
 	if doc.doctype == "Stock Entry":
@@ -67,7 +67,7 @@ def is_inspection_exempt_secondary_row(doc, row) -> bool:
 def stock_entry_row_requires_inspection(purpose, row):
 	"""Check if this Stock Entry row need a Quality Inspection."""
 	if purpose in SECONDARY_ITEM_PURPOSES and (
-		row.get("secondary_item_type") or row.get("is_legacy_scrap_item")
+		row.get("secondary_item_type") or row.get("use_valuation_rate")
 	):
 		return False
 	if purpose == "Manufacture":

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -2170,9 +2170,11 @@ def get_valuation_rate(
 				& (table.warehouse == warehouse)
 				& (table.batch_no == batch_no)
 				& (table.is_cancelled == 0)
-				& ((table.voucher_no != voucher_no) | (table.voucher_type != voucher_type))
 			)
 		)
+		if voucher_no:
+			# Comparing against a None voucher_no yields NULL, which filters out every row
+			query = query.where((table.voucher_no != voucher_no) | (table.voucher_type != voucher_type))
 
 		last_valuation_rate = query.run()
 		if last_valuation_rate and last_valuation_rate[0][0] is not None:
@@ -2198,7 +2200,7 @@ def get_valuation_rate(
 
 	# Get valuation rate from last sle for the same item and warehouse
 	sle_entry = frappe.qb.DocType("Stock Ledger Entry")
-	if last_valuation_rate := (
+	last_sle_query = (
 		frappe.qb.from_(sle_entry)
 		.select(sle_entry.valuation_rate)
 		.where(
@@ -2206,12 +2208,18 @@ def get_valuation_rate(
 			& (sle_entry.warehouse == warehouse)
 			& (sle_entry.valuation_rate >= 0)
 			& (sle_entry.is_cancelled == 0)
-			& ~((sle_entry.voucher_no == voucher_no) & (sle_entry.voucher_type == voucher_type))
 		)
 		.orderby(sle_entry.posting_datetime, order=frappe.qb.desc)
 		.orderby(sle_entry.creation, order=frappe.qb.desc)
 		.limit(1)
-	).run():
+	)
+	if voucher_no:
+		# Comparing against a None voucher_no yields NULL, which filters out every row
+		last_sle_query = last_sle_query.where(
+			~((sle_entry.voucher_no == voucher_no) & (sle_entry.voucher_type == voucher_type))
+		)
+
+	if last_valuation_rate := last_sle_query.run():
 		return flt(last_valuation_rate[0][0])
 
 	if fallbacks:

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -16,7 +16,7 @@ from erpnext.setup.doctype.item_group.item_group import get_item_group_defaults
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
 from erpnext.stock.doctype.item.item import get_item_defaults
 from erpnext.stock.get_item_details import get_default_cost_center, get_default_expense_account
-from erpnext.stock.stock_ledger import get_valuation_rate
+from erpnext.stock.utils import get_incoming_rate
 
 from .mapper import (
 	make_purchase_receipt,
@@ -403,13 +403,18 @@ class SubcontractingReceipt(SubcontractingController):
 							* (secondary_item.cost_allocation_per / 100)
 						) / qty
 					else:
-						rate = get_valuation_rate(
-							secondary_item.item_code,
-							self.set_warehouse,
-							self.doctype,
-							self.name,
-							currency=erpnext.get_company_currency(self.company),
-							company=self.company,
+						rate = get_incoming_rate(
+							{
+								"item_code": secondary_item.item_code,
+								"warehouse": self.set_warehouse,
+								"posting_date": self.posting_date,
+								"posting_time": self.posting_time,
+								"qty": received_qty,
+								"company": self.company,
+								"voucher_type": self.doctype,
+								"voucher_no": self.name,
+							},
+							raise_error_if_no_rate=False,
 						)
 						if not rate and secondary_item.stock_qty:
 							rate = flt(secondary_item.cost) / flt(secondary_item.stock_qty)

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -403,17 +403,16 @@ class SubcontractingReceipt(SubcontractingController):
 							* (secondary_item.cost_allocation_per / 100)
 						) / qty
 					else:
-						rate = (
-							get_valuation_rate(
-								secondary_item.item_code,
-								self.set_warehouse,
-								self.doctype,
-								self.name,
-								currency=erpnext.get_company_currency(self.company),
-								company=self.company,
-							)
-							or secondary_item.rate
+						rate = get_valuation_rate(
+							secondary_item.item_code,
+							self.set_warehouse,
+							self.doctype,
+							self.name,
+							currency=erpnext.get_company_currency(self.company),
+							company=self.company,
 						)
+						if not rate and secondary_item.stock_qty:
+							rate = flt(secondary_item.cost) / flt(secondary_item.stock_qty)
 
 					self.append(
 						"items",

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -16,7 +16,7 @@ from erpnext.setup.doctype.item_group.item_group import get_item_group_defaults
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
 from erpnext.stock.doctype.item.item import get_item_defaults
 from erpnext.stock.get_item_details import get_default_cost_center, get_default_expense_account
-from erpnext.stock.utils import get_incoming_rate
+from erpnext.stock.stock_ledger import get_valuation_rate
 
 from .mapper import (
 	make_purchase_receipt,
@@ -403,18 +403,13 @@ class SubcontractingReceipt(SubcontractingController):
 							* (secondary_item.cost_allocation_per / 100)
 						) / qty
 					else:
-						rate = get_incoming_rate(
-							{
-								"item_code": secondary_item.item_code,
-								"warehouse": self.set_warehouse,
-								"posting_date": self.posting_date,
-								"posting_time": self.posting_time,
-								"qty": received_qty,
-								"company": self.company,
-								"voucher_type": self.doctype,
-								"voucher_no": self.name,
-							},
-							raise_error_if_no_rate=False,
+						rate = get_valuation_rate(
+							secondary_item.item_code,
+							self.set_warehouse,
+							self.doctype,
+							self.name,
+							currency=erpnext.get_company_currency(self.company),
+							company=self.company,
 						)
 						if not rate and secondary_item.stock_qty:
 							rate = flt(secondary_item.cost) / flt(secondary_item.stock_qty)

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -147,10 +147,12 @@ class SubcontractingReceipt(SubcontractingController):
 
 		super().validate()
 
-		if self.is_new() and self.get("_action") == "save" and not frappe.in_test:
-			self.get_secondary_items()
-
 		self.set_missing_values()
+
+		# after set_missing_values, so the secondary rates are computed from the same
+		# calculated per-qty costs the Get Secondary Items button uses
+		if self.is_new() and self.get("_action") == "save" and not frappe.in_test:
+			self.get_secondary_items(recalculate_rate=True)
 
 		if self.get("_action") == "submit":
 			self.validate_secondary_items()
@@ -380,6 +382,7 @@ class SubcontractingReceipt(SubcontractingController):
 		for item in list(self.items):
 			if item.bom:
 				bom = frappe.get_doc("BOM", item.bom)
+				warehouse = self.set_warehouse or item.warehouse
 				for secondary_item in bom.secondary_items:
 					per_unit = secondary_item.stock_qty / bom.quantity
 					received_qty = flt(item.received_qty * per_unit, item.precision("received_qty"))
@@ -398,14 +401,11 @@ class SubcontractingReceipt(SubcontractingController):
 							+ flt(lcv_cost_per_qty)
 							+ flt(item.service_cost_per_qty)
 						) * flt(item.received_qty)
-						rate = (
-							(item.amount if self.is_new() else fg_item_cost)
-							* (secondary_item.cost_allocation_per / 100)
-						) / qty
+						rate = (fg_item_cost * (secondary_item.cost_allocation_per / 100)) / qty
 					else:
 						rate = get_valuation_rate(
 							secondary_item.item_code,
-							self.set_warehouse,
+							warehouse,
 							self.doctype,
 							self.name,
 							currency=erpnext.get_company_currency(self.company),
@@ -434,7 +434,7 @@ class SubcontractingReceipt(SubcontractingController):
 							"additional_cost_per_qty": 0,
 							"secondary_items_cost_per_qty": 0,
 							"amount": qty * rate,
-							"warehouse": self.set_warehouse,
+							"warehouse": warehouse,
 							"rejected_warehouse": self.rejected_warehouse,
 						},
 					)

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -387,7 +387,7 @@ class SubcontractingReceipt(SubcontractingController):
 						item.received_qty * (per_unit - (secondary_item.process_loss_qty / bom.quantity)),
 						item.precision("qty"),
 					)
-					if not secondary_item.is_legacy:
+					if not secondary_item.use_valuation_rate:
 						lcv_cost_per_qty = (
 							flt(item.landed_cost_voucher_amount) / flt(item.qty) if flt(item.qty) else 0.0
 						)
@@ -419,12 +419,12 @@ class SubcontractingReceipt(SubcontractingController):
 						"items",
 						{
 							"secondary_item_type": secondary_item.secondary_item_type,
-							"is_legacy_scrap_item": secondary_item.is_legacy,
+							"use_valuation_rate": secondary_item.use_valuation_rate,
 							"reference_name": item.name,
 							"item_code": secondary_item.item_code,
 							"item_name": secondary_item.item_name,
 							"qty": received_qty
-							if not secondary_item.is_legacy
+							if not secondary_item.use_valuation_rate
 							else flt(item.qty) * (flt(secondary_item.stock_qty) / flt(bom.quantity)),
 							"received_qty": received_qty,
 							"process_loss_qty": received_qty - qty,
@@ -446,7 +446,7 @@ class SubcontractingReceipt(SubcontractingController):
 
 	def remove_secondary_items(self):
 		for item in list(self.items):
-			if item.secondary_item_type or item.is_legacy_scrap_item:
+			if item.secondary_item_type or item.use_valuation_rate:
 				self.remove(item)
 			else:
 				item.secondary_items_cost_per_qty = 0
@@ -505,10 +505,10 @@ class SubcontractingReceipt(SubcontractingController):
 
 		secondary_items_cost_map = {}
 		for item in self.get("items") or []:
-			if item.secondary_item_type or item.is_legacy_scrap_item:
+			if item.secondary_item_type or item.use_valuation_rate:
 				qty = (
 					flt(item.qty)
-					if item.is_legacy_scrap_item
+					if item.use_valuation_rate
 					else (flt(item.received_qty) - flt(item.process_loss_qty))
 				)
 				item.amount = qty * flt(item.rate)
@@ -520,7 +520,7 @@ class SubcontractingReceipt(SubcontractingController):
 
 		total_qty = total_amount = 0
 		for item in self.get("items") or []:
-			if not item.secondary_item_type and not item.is_legacy_scrap_item:
+			if not item.secondary_item_type and not item.use_valuation_rate:
 				if item.qty:
 					if item.name in rm_cost_map:
 						item.rm_supp_cost = rm_cost_map[item.name]
@@ -563,7 +563,7 @@ class SubcontractingReceipt(SubcontractingController):
 
 	def validate_secondary_items(self):
 		for item in self.items:
-			if item.secondary_item_type or item.is_legacy_scrap_item:
+			if item.secondary_item_type or item.use_valuation_rate:
 				if not item.qty:
 					frappe.throw(
 						_("Row #{0}: Secondary Item Qty cannot be zero").format(item.idx),

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -443,6 +443,20 @@ class SubcontractingReceipt(SubcontractingController):
 			self.calculate_additional_costs()
 			self.calculate_items_qty_and_amount()
 
+	def get_secondary_item_valuation_rate(self, item):
+		"""Valuation at the row's warehouse; keeps the stored rate when none is found."""
+		return (
+			get_valuation_rate(
+				item.item_code,
+				item.warehouse or self.set_warehouse,
+				self.doctype,
+				self.name,
+				currency=erpnext.get_company_currency(self.company),
+				company=self.company,
+			)
+			or item.rate
+		)
+
 	def remove_secondary_items(self):
 		for item in list(self.items):
 			if item.secondary_item_type or item.use_valuation_rate:
@@ -505,6 +519,10 @@ class SubcontractingReceipt(SubcontractingController):
 		secondary_items_cost_map = {}
 		for item in self.get("items") or []:
 			if item.secondary_item_type or item.use_valuation_rate:
+				if item.use_valuation_rate:
+					# Recomputed every time: a rate fetched against another warehouse
+					# must not stick to the row when the warehouse changes.
+					item.rate = self.get_secondary_item_valuation_rate(item)
 				qty = (
 					flt(item.qty)
 					if item.use_valuation_rate

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -1224,6 +1224,14 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 		self.assertEqual(len(scr.items), 3)  # 1 FG Item + 2 Scrap Items
 		self.assertEqual(scr_secondary_items, set(secondary_items))
 
+		# without a document level warehouse the rows fall back to the FG row's warehouse
+		scr.set_warehouse = None
+		scr.get_secondary_items()
+		fg_warehouse = next(item.warehouse for item in scr.items if item.bom)
+		for item in scr.items:
+			if item.secondary_item_type or item.use_valuation_rate:
+				self.assertEqual(item.warehouse, fg_warehouse)
+
 		scr.submit()
 
 	def test_subcontracting_receipt_cancel_with_batch(self):

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -1194,7 +1194,7 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 					"item_code": item,
 					"stock_qty": 1 * (idx + 1),
 					"rate": 10 * (idx + 1),
-					"is_legacy": 1,
+					"use_valuation_rate": 1,
 				},
 			)
 		bom.save()
@@ -1220,7 +1220,7 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 		scr.get_secondary_items()
 
 		scr_secondary_items = set(
-			[item.item_code for item in scr.items if item.secondary_item_type or item.is_legacy_scrap_item]
+			[item.item_code for item in scr.items if item.secondary_item_type or item.use_valuation_rate]
 		)
 		self.assertEqual(len(scr.items), 3)  # 1 FG Item + 2 Scrap Items
 		self.assertEqual(scr_secondary_items, set(secondary_items))

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -1193,7 +1193,6 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 				{
 					"item_code": item,
 					"stock_qty": 1 * (idx + 1),
-					"rate": 10 * (idx + 1),
 					"use_valuation_rate": 1,
 				},
 			)

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -1232,6 +1232,14 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 			if item.secondary_item_type or item.use_valuation_rate:
 				self.assertEqual(item.warehouse, fg_warehouse)
 
+		# valuation rate rows are repriced at their warehouse on every save
+		make_stock_entry(item_code=secondary_item_1, target="_Test Warehouse - _TC", qty=5, basic_rate=40)
+		vr_row = next(item for item in scr.items if item.item_code == secondary_item_1)
+		vr_row.warehouse = "_Test Warehouse - _TC"
+		scr.save()
+		vr_row = next(item for item in scr.items if item.item_code == secondary_item_1)
+		self.assertEqual(vr_row.rate, 40)
+
 		scr.submit()
 
 	def test_subcontracting_receipt_cancel_with_batch(self):

--- a/erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
@@ -8,7 +8,7 @@
  "engine": "InnoDB",
  "field_order": [
   "item_code",
-  "is_legacy_scrap_item",
+  "use_valuation_rate",
   "secondary_item_type",
   "column_break_2",
   "item_name",
@@ -166,12 +166,12 @@
    "label": "Accepted Qty",
    "no_copy": 1,
    "print_width": "100px",
-   "read_only_depends_on": "eval:doc.secondary_item_type || doc.is_legacy_scrap_item",
+   "read_only_depends_on": "eval:doc.secondary_item_type || doc.use_valuation_rate",
    "width": "100px"
   },
   {
    "columns": 1,
-   "depends_on": "eval:!parent.is_return && !doc.secondary_item_type && !doc.is_legacy_scrap_item",
+   "depends_on": "eval:!parent.is_return && !doc.secondary_item_type && !doc.use_valuation_rate",
    "fieldname": "rejected_qty",
    "fieldtype": "Float",
    "in_list_view": 1,
@@ -179,7 +179,7 @@
    "no_copy": 1,
    "print_hide": 1,
    "print_width": "100px",
-   "read_only_depends_on": "eval:doc.secondary_item_type || doc.is_legacy_scrap_item",
+   "read_only_depends_on": "eval:doc.secondary_item_type || doc.use_valuation_rate",
    "width": "100px"
   },
   {
@@ -239,7 +239,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:!doc.secondary_item_type && !doc.is_legacy_scrap_item",
+   "depends_on": "eval:!doc.secondary_item_type && !doc.use_valuation_rate",
    "fieldname": "rm_cost_per_qty",
    "fieldtype": "Currency",
    "label": "Raw Material Cost Per Qty",
@@ -249,7 +249,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:!doc.secondary_item_type && !doc.is_legacy_scrap_item",
+   "depends_on": "eval:!doc.secondary_item_type && !doc.use_valuation_rate",
    "fieldname": "service_cost_per_qty",
    "fieldtype": "Currency",
    "label": "Service Cost Per Qty",
@@ -259,7 +259,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:!doc.secondary_item_type && !doc.is_legacy_scrap_item",
+   "depends_on": "eval:!doc.secondary_item_type && !doc.use_valuation_rate",
    "fieldname": "additional_cost_per_qty",
    "fieldtype": "Currency",
    "label": "Additional Cost Per Qty",
@@ -283,7 +283,7 @@
    "width": "100px"
   },
   {
-   "depends_on": "eval: !parent.is_return && !doc.secondary_item_type && !doc.is_legacy_scrap_item",
+   "depends_on": "eval: !parent.is_return && !doc.secondary_item_type && !doc.use_valuation_rate",
    "fieldname": "rejected_warehouse",
    "fieldtype": "Link",
    "ignore_user_permissions": 1,
@@ -295,7 +295,7 @@
    "width": "100px"
   },
   {
-   "depends_on": "eval:!doc.__islocal && !doc.secondary_item_type && !doc.is_legacy_scrap_item",
+   "depends_on": "eval:!doc.__islocal && !doc.secondary_item_type && !doc.use_valuation_rate",
    "fieldname": "quality_inspection",
    "fieldtype": "Link",
    "label": "Quality Inspection",
@@ -377,7 +377,7 @@
    "no_copy": 1,
    "options": "BOM",
    "print_hide": 1,
-   "read_only_depends_on": "eval:doc.secondary_item_type || doc.is_legacy_scrap_item"
+   "read_only_depends_on": "eval:doc.secondary_item_type || doc.use_valuation_rate"
   },
   {
    "fetch_from": "item_code.brand",
@@ -504,7 +504,7 @@
    "print_hide": 1
   },
   {
-   "depends_on": "eval:(doc.use_serial_batch_fields === 0 || doc.docstatus === 1) && !doc.secondary_item_type && !doc.is_legacy_scrap_item",
+   "depends_on": "eval:(doc.use_serial_batch_fields === 0 || doc.docstatus === 1) && !doc.secondary_item_type && !doc.use_valuation_rate",
    "fieldname": "rejected_serial_and_batch_bundle",
    "fieldtype": "Link",
    "label": "Rejected Serial and Batch Bundle",
@@ -587,7 +587,7 @@
    "label": "Add Serial / Batch Bundle"
   },
   {
-   "depends_on": "eval:doc.use_serial_batch_fields === 0 && !doc.secondary_item_type && !doc.is_legacy_scrap_item",
+   "depends_on": "eval:doc.use_serial_batch_fields === 0 && !doc.secondary_item_type && !doc.use_valuation_rate",
    "fieldname": "add_serial_batch_for_rejected_qty",
    "fieldtype": "Button",
    "label": "Add Serial / Batch No (Rejected Qty)"
@@ -601,7 +601,7 @@
    "search_index": 1
   },
   {
-   "depends_on": "eval:!doc.secondary_item_type && !doc.is_legacy_scrap_item",
+   "depends_on": "eval:!doc.secondary_item_type && !doc.use_valuation_rate",
    "fieldname": "landed_cost_voucher_amount",
    "fieldtype": "Currency",
    "label": "Landed Cost Voucher Amount",
@@ -629,7 +629,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:!doc.secondary_item_type && !doc.is_legacy_scrap_item",
+   "depends_on": "eval:!doc.secondary_item_type && !doc.use_valuation_rate",
    "fieldname": "secondary_items_cost_per_qty",
    "fieldtype": "Currency",
    "label": "Secondary Items Cost Per Qty",
@@ -640,10 +640,10 @@
   },
   {
    "default": "0",
-   "depends_on": "is_legacy_scrap_item",
-   "fieldname": "is_legacy_scrap_item",
+   "depends_on": "use_valuation_rate",
+   "fieldname": "use_valuation_rate",
    "fieldtype": "Check",
-   "label": "Is Legacy Scrap Item",
+   "label": "Use Valuation Rate",
    "read_only": 1
   },
   {

--- a/erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.py
@@ -25,7 +25,6 @@ class SubcontractingReceiptItem(Document):
 		expense_account: DF.Link | None
 		image: DF.Attach | None
 		include_exploded_items: DF.Check
-		is_legacy_scrap_item: DF.Check
 		item_code: DF.Link
 		item_name: DF.Data | None
 		job_card: DF.Link | None
@@ -64,6 +63,7 @@ class SubcontractingReceiptItem(Document):
 		subcontracting_receipt_item: DF.Data | None
 		secondary_item_type: DF.Literal["", "Co-Product", "By-Product", "Scrap", "Additional Finished Good"]
 		use_serial_batch_fields: DF.Check
+		use_valuation_rate: DF.Check
 		warehouse: DF.Link | None
 	# end: auto-generated types
 


### PR DESCRIPTION
Before v16, scrap items in a Manufacture entry were valued at their valuation rate and the remaining consumed cost went to the finished good. The secondary items rework replaced that with percentage-based allocation only, leaving no way to value scrap at its actual rate.

This restores the old method as an explicit option:

- New **Use Valuation Rate** checkbox on BOM Secondary Item. Checked rows hide Cost Allocation % and are costed on every BOM cost calculation as valuation rate x stock qty, using the same bin-average chain as the raw material rows (scoped to the BOM's default target warehouse when set, else all warehouses); that cost is deducted from the raw material cost. The remaining cost is what the other rows' percentages split, so the 100% validation is unchanged. No per-unit rate is stored: the old `rate` field on BOM Secondary Item is removed and its data is folded into `cost`.
- In Manufacture entries these rows are valued at their valuation rate at the target warehouse, exactly as the legacy scrap rows were, and their value is deducted from the consumed cost; percentage rows and the finished good split the remainder, keeping the entry balanced. Subcontracting Receipts value them the same way at the receipt warehouse.
- Replaces the `is_legacy` / `is_legacy_scrap_item` fields: `co_by_product_patch` now writes `use_valuation_rate` and copies the v15 scrap amount into `cost` for v15 upgrades, and a new patch renames the columns and backfills `cost` for sites already on v16 (no-op where the old columns never existed).
- The Valuation Rate method for BOM raw materials is now warehouse-scoped: the row's source warehouse, else the BOM's default source warehouse, else the company-wide average as before.

Also fixes two bugs in the legacy path: job-card-sourced secondary items never carried the legacy flag (the query does not select it), so they fell into the percentage branch with 0% and were valued at zero; and job cards skipped the process loss deduction that the BOM path applies to every secondary item.

https://docs.frappe.io/erpnext/secondary-items