### PR TITLE
fix(company): throw if linked to demo_company field

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -899,6 +899,13 @@ class Company(NestedSet):
 		"""
 		Trash accounts and cost centers for this company if no gl entry exists
 		"""
+		if frappe.db.get_single_value("Global Defaults", "demo_company") == self.name:
+			frappe.throw(
+				_("{0} is the site's Demo Company and cannot be deleted directly. Use {1} instead.").format(
+					bold(self.name), bold(_("Delete Demo Data"))
+				)
+			)
+
 		NestedSet.validate_if_child_exists(self)
 		frappe.utils.nestedset.update_nsm(self)
 


### PR DESCRIPTION
This is more so a UX fix. Throws an error msg if user is deleting demo company directly. 

Observed in Ticket 76578 wherein a generic link field msg is thrown, but had to look into doctype structure to find the presence of `demo_company` field (hidden), ended up being the culprit that blocks deletion so throw an error early on indicating link w/ `demo_company` field in Global Defaults.