### PR TITLE
fix: hide rfq status in supplier portal

### DIFF
--- a/erpnext/templates/includes/transaction_row.html
+++ b/erpnext/templates/includes/transaction_row.html
@@ -7,9 +7,11 @@
 				{{ frappe.utils.global_date_format(doc.modified) }}
 			</div>
 		</div>
-		<div class="col-sm-3">
-			<span class="indicator-pill {{ doc.indicator_color or ("blue" if doc.docstatus==1 else "gray") }} list-item-status">{{ _(doc.status) }}</span>
-		</div>
+		{% if doc.doctype != "Request for Quotation" %}
+			<div class="col-sm-3">
+				<span class="indicator-pill {{ doc.indicator_color or ("blue" if doc.docstatus==1 else "gray") }} list-item-status">{{ _(doc.status) }}</span>
+			</div>
+		{% endif %}
 		<div class="col-sm-2">
 			<div class="small text-muted items-preview ellipsis ellipsis-width">
 				{{ doc.items_preview | e }}


### PR DESCRIPTION
### Issue

  The Request for Quotation shows “Submitted” in the supplier portal. This can make suppliers think they have already submitted their quotation.

 **Fixes** : https://github.com/frappe/erpnext/issues/55250

  ### Steps to reproduce

  1. Create and submit a Request for Quotation.
  2. Send it to a supplier.
  3. Log in to the supplier portal.
  4. Open the Request for Quotation list.

  ### Actual behaviour

  The Request for Quotation shows “Submitted.”

  ### Expected behaviour

  The “Submitted” status should not be shown to the supplier.

**Backport Needed For V15 and V16**