### PR TITLE
fix: hide supplier name in rfq portal

### DIFF
--- a/erpnext/templates/pages/rfq.html
+++ b/erpnext/templates/pages/rfq.html
@@ -22,10 +22,7 @@
 
 {% block page_content %}
 <div class="row">
-    <div class="col-6">
-        <div class="rfq-supplier">{{ doc.supplier }}</div>
-	</div>
-    <div class="col-6 text-muted text-right h6">
+    <div class="col-12 text-muted text-right h6">
         {{ doc.get_formatted("transaction_date") }}
     </div>
 </div>


### PR DESCRIPTION
  ### Issue

  The supplier name is shown when a supplier opens a Request for Quotation. It is unnecessary because the supplier can only see requests intended for them.


  **Fixes:** https://github.com/frappe/erpnext/issues/55251

  ### Steps to reproduce

  1. Create and submit a Request for Quotation.
  2. Send it to a supplier.
  3. Log in to the supplier portal.
  4. Open the Request for Quotation.

  ### Actual behaviour

  The supplier name is displayed on the page.

  ### Expected behaviour

  The supplier name should not be displayed on the page.


**Backport Needed For V15 and v16**