### PR TITLE
fix: retain cost center on AR/AP report for advance JE/PE reconciled …

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -193,7 +193,8 @@ class ReceivablePayableReport:
 
 		if (ple.voucher_type == ple.against_voucher_type and ple.voucher_no == ple.against_voucher_no) or (
 			ple.voucher_type in ("Payment Entry", "Journal Entry")
-			and ple.against_voucher_type in self.advance_payment_doctypes
+			and ple.against_voucher_type
+			in (*self.advance_payment_doctypes, "Sales Invoice", "Purchase Invoice")
 		):
 			self.voucher_balance[key].cost_center = ple.cost_center
 			self.voucher_balance[key].project = ple.project


### PR DESCRIPTION
**Issue Statement:**

The Accounts Payable Report does not display the Cost Center for the Advance Journal Entry and the automatically generated Exchange Gain/Loss Journal Entry after Payment Reconciliation.

**Issue Detailed Description:**

On 31/07/2026, an advance payment was made to a THB supplier using a Journal Entry with an exchange rate of 131.406100900 for an amount of 250,313.00.

On 03/08/2026, a Purchase Invoice was created for the same supplier using an exchange rate of 131.578947400.

Before reconciliation, when reviewing the Accounts Payable Report, the advance Journal Entry correctly displayed the assigned Cost Center.

After performing Payment Reconciliation, ERPNext automatically created an Exchange Gain/Loss Journal Entry because of the exchange rate difference between the advance payment and the Purchase Invoice.

However, after the Exchange Gain/Loss Journal Entry was created, when reviewing the Accounts Payable Report as of 31/07/2026, both:the original Advance Journal Entry, andthe automatically generated Exchange Gain/Loss Journal Entry

**Steps to Replicate the issue:**

1. Create an Advance Journal Entry for a foreign currency supplier.
2. Assign a Cost Center to the Journal Entry.
3. Create a Purchase Invoice for the same supplier using a different exchange rate.
4. Perform Payment Reconciliation between the advance payment and the Purchase Invoice.
5. Allow ERPNext to generate the Exchange Gain/Loss Journal Entry automatically.
6. Open the Accounts Payable Report with the report date set to 31/07/2026.
7. Review the Advance Journal Entry and the Exchange Gain/Loss Journal Entry.
