### PR TITLE
fix: respect zero currency precision

### DIFF
--- a/erpnext/accounts/test/test_utils.py
+++ b/erpnext/accounts/test/test_utils.py
@@ -4,6 +4,7 @@ from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_ent
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 from erpnext.accounts.party import get_party_shipping_address
 from erpnext.accounts.utils import (
+	get_currency_precision,
 	get_future_stock_vouchers,
 	get_voucherwise_gl_entries,
 	get_zero_cutoff,
@@ -154,3 +155,18 @@ class TestUtils(ERPNextTestSuite):
 		self.assertEqual(get_zero_cutoff(None), 0.005)
 		self.assertEqual(get_zero_cutoff("EUR"), 0.005)
 		self.assertEqual(get_zero_cutoff("BHD"), 0.0005)
+
+	def test_get_currency_precision_respects_zero_and_fallback(self):
+		currency_precision = frappe.db.get_default("currency_precision")
+		number_format = frappe.db.get_default("number_format")
+
+		try:
+			frappe.db.set_default("number_format", "#,###.##")
+			frappe.db.set_default("currency_precision", "0")
+			self.assertEqual(get_currency_precision(), 0)
+
+			frappe.db.set_default("currency_precision", "")
+			self.assertEqual(get_currency_precision(), 2)
+		finally:
+			frappe.db.set_default("currency_precision", currency_precision or "")
+			frappe.db.set_default("number_format", number_format or "#,###.##")

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1200,12 +1200,12 @@ def fix_total_debit_credit():
 
 
 def get_currency_precision():
-	precision = cint(frappe.db.get_default("currency_precision"))
-	if not precision:
-		number_format = frappe.db.get_default("number_format") or "#,###.##"
-		precision = get_number_format_info(number_format)[2]
+	currency_precision = frappe.db.get_default("currency_precision")
+	if currency_precision not in (None, ""):
+		return cint(currency_precision)
 
-	return precision
+	number_format = frappe.db.get_default("number_format") or "#,###.##"
+	return get_number_format_info(number_format)[2]
 
 
 def get_fraction_units(currency: str) -> int:


### PR DESCRIPTION
  ### Issue

  When Currency Precision is set to `0` in System Settings, ERPNext ignores it and continues showing amounts with decimal places.

 **Fixes:** https://github.com/frappe/erpnext/issues/58392

  ### Steps to reproduce

  1. Open System Settings.
  2. Set Currency Precision to `0`.
  3. Open a transaction or accounting report containing currency values.

  ### Actual behaviour

  Currency values still appear with decimal places even though Currency Precision is set to `0`.

  ### Expected behaviour

  Currency values should appear without decimal places when Currency Precision is set to `0`.


**Backport Needed For V16 and V15**