### PR TITLE
fix: send auto reorder email to all managers in single company setup

### DIFF
--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -944,6 +944,33 @@ class TestMaterialRequest(ERPNextTestSuite):
 		for perm in permissions:
 			perm.delete()
 
+	def test_auto_email_single_company_without_user_permission(self):
+		from unittest.mock import patch
+
+		from erpnext.stock.reorder_item import get_email_list
+
+		users = ["test_reorder_single_1@example.com", "test_reorder_single_2@example.com"]
+		for user in users:
+			if not frappe.db.exists("User", user):
+				frappe.get_doc(
+					{
+						"doctype": "User",
+						"email": user,
+						"first_name": user,
+						"send_notifications": 0,
+						"enabled": 1,
+						"user_type": "System User",
+						"roles": [{"role": "Purchase Manager"}],
+					}
+				).insert(ignore_permissions=True)
+
+		# single company: managers without any Company User Permission must still be emailed
+		with patch("frappe.db.count", return_value=1):
+			emails = get_email_list("_Test Company")
+
+		for user in users:
+			self.assertIn(user, emails)
+
 	def test_manufacture_type_status_over_wo(self):
 		from erpnext.stock.doctype.material_request.material_request import raise_work_orders
 

--- a/erpnext/stock/reorder_item.py
+++ b/erpnext/stock/reorder_item.py
@@ -350,6 +350,10 @@ def get_email_list(company):
 
 
 def get_comapny_wise_users(company):
+	# single company: no explicit permission needed, everyone has access
+	if frappe.db.count("Company") == 1:
+		return []
+
 	companies = [company]
 
 	if parent_company := frappe.db.get_value("Company", company, "parent_company"):


### PR DESCRIPTION
Auto Material Request notification now reaches all Purchase/Stock Managers in a single-company setup, without requiring an explicit Company User Permission per user.

https://support.frappe.io/helpdesk/tickets/76953?view=VIEW-HD+Ticket-70177
