### PR TITLE
feat(analytics): filter sales and purchase analytics by entity 

### DIFF
--- a/erpnext/buying/report/purchase_analytics/purchase_analytics.js
+++ b/erpnext/buying/report/purchase_analytics/purchase_analytics.js
@@ -66,6 +66,19 @@ frappe.query_reports["Purchase Analytics"] = {
 			reqd: 1,
 		},
 		{
+			fieldname: "curves",
+			label: __("Curves"),
+			fieldtype: "Select",
+			options: [
+				{ value: "select", label: __("Select") },
+				{ value: "all", label: __("All") },
+				{ value: "non-zeros", label: __("Non-Zeros") },
+				{ value: "total", label: __("Total Only") },
+			],
+			default: "select",
+			reqd: 1,
+		},
+		{
 			fieldname: "show_aggregate_value_from_subsidiary_companies",
 			label: __("Show Aggregate Value from Subsidiary Companies"),
 			fieldtype: "Check",

--- a/erpnext/buying/report/purchase_analytics/purchase_analytics.js
+++ b/erpnext/buying/report/purchase_analytics/purchase_analytics.js
@@ -10,6 +10,26 @@ frappe.query_reports["Purchase Analytics"] = {
 			options: ["Supplier Group", "Supplier", "Item Group", "Item"],
 			default: "Supplier",
 			reqd: 1,
+			on_change: function () {
+				const entity_filter = frappe.query_report.get_filter("entity");
+				if (entity_filter) {
+					entity_filter.df.label = __(frappe.query_report.get_filter_value("tree_type"));
+					entity_filter.set_value([]);
+					entity_filter.refresh();
+				}
+				frappe.query_report.refresh();
+			},
+		},
+		{
+			fieldname: "entity",
+			label: __("Entity"),
+			fieldtype: "MultiSelectList",
+			get_data: function (txt) {
+				const tree_type = frappe.query_report.get_filter_value("tree_type");
+				if (!tree_type || tree_type === "Order Type") return [];
+				return frappe.db.get_link_options(tree_type, txt);
+			},
+			depends_on: "eval:doc.tree_type != 'Order Type'",
 		},
 		{
 			fieldname: "doc_type",

--- a/erpnext/buying/report/purchase_analytics/test_purchase_analytics.py
+++ b/erpnext/buying/report/purchase_analytics/test_purchase_analytics.py
@@ -43,6 +43,44 @@ class TestPurchaseAnalytics(ERPNextTestSuite):
 			company=COMPANY, supplier=SUPPLIER, qty=qty, rate=rate, transaction_date="2019-04-10"
 		)
 
+	def test_supplier_entity_filter(self):
+		filters = self._filters(tree_type="Supplier", entity=[SUPPLIER], curves="all")
+		base_total = flt(self._rows(filters).get(SUPPLIER, {}).get("total", 0.0))
+
+		po = self.make_po()
+		columns, data, _message, chart, *_rest = execute(filters)
+
+		self.assertTrue(columns)
+		self.assertEqual({row["entity"] for row in data}, {SUPPLIER})
+		self.assertAlmostEqual(data[0]["total"] - base_total, flt(po.base_net_total), places=2)
+
+		supplier_name = frappe.db.get_value("Supplier", SUPPLIER, "supplier_name")
+		self.assertEqual({dataset["name"] for dataset in chart["data"]["datasets"]}, {supplier_name})
+
+	def test_parent_supplier_group_filter_preserves_rollup(self):
+		self.make_po()
+		filters = self._filters(tree_type="Supplier Group")
+		unfiltered = self._rows(filters)
+		filtered = self._rows(self._filters(tree_type="Supplier Group", entity=["All Supplier Groups"]))
+
+		self.assertEqual(set(filtered), {"All Supplier Groups"})
+		self.assertAlmostEqual(
+			filtered["All Supplier Groups"]["total"],
+			unfiltered["All Supplier Groups"]["total"],
+			places=2,
+		)
+
+	def test_supplier_group_entity_filter(self):
+		self.make_po()
+		unfiltered = self._rows(self._filters(tree_type="Supplier Group"))
+		filtered = self._rows(self._filters(tree_type="Supplier Group", entity=[SUPPLIER_GROUP]))
+
+		self.assertEqual(set(filtered), {SUPPLIER_GROUP})
+		self.assertEqual(filtered[SUPPLIER_GROUP]["indent"], 0)
+		self.assertAlmostEqual(
+			filtered[SUPPLIER_GROUP]["total"], unfiltered[SUPPLIER_GROUP]["total"], places=2
+		)
+
 	def test_supplier_group_tree_rolls_up_to_root(self):
 		filters = self._filters(tree_type="Supplier Group")
 		base = self._rows(filters)

--- a/erpnext/selling/report/sales_analytics/sales_analytics.js
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.js
@@ -2,6 +2,18 @@
 // For license information, please see license.txt
 
 frappe.query_reports["Sales Analytics"] = {
+	// "All" reports on every doctype at once and forces the tree to Customer
+	entity_tree_type() {
+		const doc_type = frappe.query_report.get_filter_value("doc_type");
+		return doc_type === "All" ? "Customer" : frappe.query_report.get_filter_value("tree_type");
+	},
+	reset_entity_filter() {
+		const entity_filter = frappe.query_report.get_filter("entity");
+		if (!entity_filter) return;
+		entity_filter.df.label = __(this.entity_tree_type());
+		entity_filter.set_value([]);
+		entity_filter.refresh();
+	},
 	filters: [
 		{
 			fieldname: "tree_type",
@@ -18,6 +30,21 @@ frappe.query_reports["Sales Analytics"] = {
 			],
 			default: "Customer",
 			reqd: 1,
+			on_change: function () {
+				frappe.query_reports["Sales Analytics"].reset_entity_filter();
+				frappe.query_report.refresh();
+			},
+		},
+		{
+			fieldname: "entity",
+			label: __("Entity"),
+			fieldtype: "MultiSelectList",
+			get_data: function (txt) {
+				const tree_type = frappe.query_reports["Sales Analytics"].entity_tree_type();
+				if (!tree_type || tree_type === "Order Type") return [];
+				return frappe.db.get_link_options(tree_type, txt);
+			},
+			depends_on: "eval:doc.tree_type != 'Order Type'",
 		},
 		{
 			fieldname: "doc_type",
@@ -34,6 +61,10 @@ frappe.query_reports["Sales Analytics"] = {
 			],
 			default: "Sales Invoice",
 			reqd: 1,
+			on_change: function () {
+				frappe.query_reports["Sales Analytics"].reset_entity_filter();
+				frappe.query_report.refresh();
+			},
 		},
 		{
 			fieldname: "value_quantity",

--- a/erpnext/selling/report/sales_analytics/sales_analytics.py
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.py
@@ -15,6 +15,11 @@ def execute(filters=None):
 	filters = frappe._dict(filters or {})
 	# Special report showing all doctype totals on a single chart; overrides some filters
 	if filters.doc_type == "All":
+		if filters.entity:
+			# the tree is forced to Customer below, so drop anything picked for another tree
+			filters.entity = frappe.get_all(
+				"Customer", filters={"name": ["in", filters.entity]}, pluck="name"
+			)
 		filters.tree_type = "Customer"
 		filters.value_quantity = "Value"
 		filters.curves = "total"
@@ -53,6 +58,7 @@ def append_report(dt, org, new):
 class Analytics:
 	def __init__(self, filters=None):
 		self.filters = frappe._dict(filters or {})
+		self.entities = self.filters.get("entity") or []
 		if self.filters.doc_type == "Payment Entry" and self.filters.value_quantity == "Quantity":
 			frappe.throw(_("Only Value available for Payment Entry"))
 		self.date_field = (
@@ -263,6 +269,9 @@ class Analytics:
 		if self.filters.doc_type in ["Sales Invoice", "Purchase Invoice", "Payment Entry"]:
 			filters.update({"is_opening": "No"})
 
+		if self.entities:
+			filters[entity.split(" as ")[0]] = ["in", self.entities]
+
 		self.entries = frappe.qb.get_query(
 			table=self.filters.doc_type,
 			fields=[entity, entity_name, value_field, self.date_field],
@@ -289,7 +298,7 @@ class Analytics:
 		doctype = DocType(self.filters.doc_type)
 		doctype_item = DocType(f"{self.filters.doc_type} Item")
 
-		self.entries = (
+		query = (
 			frappe.qb.from_(doctype_item)
 			.join(doctype)
 			.on(doctype.name == doctype_item.parent)
@@ -301,7 +310,12 @@ class Analytics:
 				doctype[self.date_field],
 			)
 			.where((doctype_item.docstatus == 1) & (doctype.name.isin(permitted_names)))
-		).run(as_dict=True)
+		)
+
+		if self.entities:
+			query = query.where(doctype_item.item_code.isin(self.entities))
+
+		self.entries = query.run(as_dict=True)
 
 		self.entity_names = {}
 		for d in self.entries:
@@ -330,6 +344,18 @@ class Analytics:
 		if self.filters.doc_type in ["Sales Invoice", "Purchase Invoice", "Payment Entry"]:
 			filters.update({"is_opening": "No"})
 
+		if self.entities:
+			if self.filters.tree_type == "Supplier Group":
+				# the entity column holds the supplier, mapped to its group later
+				filters["supplier"] = [
+					"in",
+					frappe.get_all(
+						"Supplier", filters={"supplier_group": ["in", self.entities]}, pluck="name"
+					),
+				]
+			else:
+				filters[entity_field.split(" as ")[0]] = ["in", self.entities]
+
 		self.entries = frappe.qb.get_query(
 			table=self.filters.doc_type,
 			fields=[entity_field, value_field, self.date_field],
@@ -353,7 +379,7 @@ class Analytics:
 		doctype = DocType(self.filters.doc_type)
 		doctype_item = DocType(f"{self.filters.doc_type} Item")
 
-		self.entries = (
+		query = (
 			frappe.qb.from_(doctype_item)
 			.join(doctype)
 			.on(doctype.name == doctype_item.parent)
@@ -363,7 +389,12 @@ class Analytics:
 				doctype[self.date_field],
 			)
 			.where((doctype_item.docstatus == 1) & (doctype.name.isin(permitted_names)))
-		).run(as_dict=True)
+		)
+
+		if self.entities:
+			query = query.where(doctype_item.item_group.isin(self.entities))
+
+		self.entries = query.run(as_dict=True)
 
 		self.get_groups()
 
@@ -387,6 +418,9 @@ class Analytics:
 
 		if self.filters.doc_type in ["Sales Invoice", "Purchase Invoice", "Payment Entry"]:
 			filters.update({"is_opening": "No"})
+
+		if self.entities:
+			filters["project"] = ["in", self.entities]
 
 		self.entries = frappe.qb.get_query(
 			table=self.filters.doc_type,
@@ -515,6 +549,14 @@ class Analytics:
 			fields=["name", "lft", "rgt", f"{parent} as parent"],
 			order_by="lft",
 		)
+
+		if self.entities:
+			selected = [d for d in self.group_entries if d.name in self.entities]
+			keep = {d.name for d in selected}
+			for d in self.group_entries:
+				if any(d.lft <= s.lft and d.rgt >= s.rgt for s in selected):
+					keep.add(d.name)
+			self.group_entries = [d for d in self.group_entries if d.name in keep]
 
 		for d in self.group_entries:
 			if d.parent:

--- a/erpnext/selling/report/sales_analytics/sales_analytics.py
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.py
@@ -15,11 +15,6 @@ def execute(filters=None):
 	filters = frappe._dict(filters or {})
 	# Special report showing all doctype totals on a single chart; overrides some filters
 	if filters.doc_type == "All":
-		if filters.entity:
-			# the tree is forced to Customer below, so drop anything picked for another tree
-			filters.entity = frappe.get_all(
-				"Customer", filters={"name": ["in", filters.entity]}, pluck="name"
-			)
 		filters.tree_type = "Customer"
 		filters.value_quantity = "Value"
 		filters.curves = "total"
@@ -108,6 +103,7 @@ class Analytics:
 		self.update_company_list_for_parent_company()
 		self.get_columns()
 		self.get_data()
+		self.filter_data_by_entities()
 		self.get_chart_data()
 
 		# Skipping total row for tree-view reports
@@ -269,9 +265,6 @@ class Analytics:
 		if self.filters.doc_type in ["Sales Invoice", "Purchase Invoice", "Payment Entry"]:
 			filters.update({"is_opening": "No"})
 
-		if self.entities:
-			filters[entity.split(" as ")[0]] = ["in", self.entities]
-
 		self.entries = frappe.qb.get_query(
 			table=self.filters.doc_type,
 			fields=[entity, entity_name, value_field, self.date_field],
@@ -298,7 +291,7 @@ class Analytics:
 		doctype = DocType(self.filters.doc_type)
 		doctype_item = DocType(f"{self.filters.doc_type} Item")
 
-		query = (
+		self.entries = (
 			frappe.qb.from_(doctype_item)
 			.join(doctype)
 			.on(doctype.name == doctype_item.parent)
@@ -310,12 +303,7 @@ class Analytics:
 				doctype[self.date_field],
 			)
 			.where((doctype_item.docstatus == 1) & (doctype.name.isin(permitted_names)))
-		)
-
-		if self.entities:
-			query = query.where(doctype_item.item_code.isin(self.entities))
-
-		self.entries = query.run(as_dict=True)
+		).run(as_dict=True)
 
 		self.entity_names = {}
 		for d in self.entries:
@@ -344,18 +332,6 @@ class Analytics:
 		if self.filters.doc_type in ["Sales Invoice", "Purchase Invoice", "Payment Entry"]:
 			filters.update({"is_opening": "No"})
 
-		if self.entities:
-			if self.filters.tree_type == "Supplier Group":
-				# the entity column holds the supplier, mapped to its group later
-				filters["supplier"] = [
-					"in",
-					frappe.get_all(
-						"Supplier", filters={"supplier_group": ["in", self.entities]}, pluck="name"
-					),
-				]
-			else:
-				filters[entity_field.split(" as ")[0]] = ["in", self.entities]
-
 		self.entries = frappe.qb.get_query(
 			table=self.filters.doc_type,
 			fields=[entity_field, value_field, self.date_field],
@@ -379,7 +355,7 @@ class Analytics:
 		doctype = DocType(self.filters.doc_type)
 		doctype_item = DocType(f"{self.filters.doc_type} Item")
 
-		query = (
+		self.entries = (
 			frappe.qb.from_(doctype_item)
 			.join(doctype)
 			.on(doctype.name == doctype_item.parent)
@@ -389,12 +365,7 @@ class Analytics:
 				doctype[self.date_field],
 			)
 			.where((doctype_item.docstatus == 1) & (doctype.name.isin(permitted_names)))
-		)
-
-		if self.entities:
-			query = query.where(doctype_item.item_group.isin(self.entities))
-
-		self.entries = query.run(as_dict=True)
+		).run(as_dict=True)
 
 		self.get_groups()
 
@@ -419,15 +390,29 @@ class Analytics:
 		if self.filters.doc_type in ["Sales Invoice", "Purchase Invoice", "Payment Entry"]:
 			filters.update({"is_opening": "No"})
 
-		if self.entities:
-			filters["project"] = ["in", self.entities]
-
 		self.entries = frappe.qb.get_query(
 			table=self.filters.doc_type,
 			fields=[entity, value_field, self.date_field],
 			filters=filters,
 			ignore_permissions=False,
 		).run(as_dict=True)
+
+	def filter_data_by_entities(self):
+		if not self.entities:
+			return
+
+		entities = set(self.entities)
+		selected_data = []
+		for row in self.data:
+			if row["entity"] not in entities:
+				continue
+
+			row = row.copy()
+			if "indent" in row:
+				row["indent"] = 0
+			selected_data.append(row)
+
+		self.data = selected_data
 
 	def get_rows(self):
 		self.data = []
@@ -549,14 +534,6 @@ class Analytics:
 			fields=["name", "lft", "rgt", f"{parent} as parent"],
 			order_by="lft",
 		)
-
-		if self.entities:
-			selected = [d for d in self.group_entries if d.name in self.entities]
-			keep = {d.name for d in selected}
-			for d in self.group_entries:
-				if any(d.lft <= s.lft and d.rgt >= s.rgt for s in selected):
-					keep.add(d.name)
-			self.group_entries = [d for d in self.group_entries if d.name in keep]
 
 		for d in self.group_entries:
 			if d.parent:

--- a/erpnext/selling/report/sales_analytics/test_sales_analytics.py
+++ b/erpnext/selling/report/sales_analytics/test_sales_analytics.py
@@ -67,6 +67,44 @@ class TestSalesAnalytics(ERPNextTestSuite):
 	def _row_by_entity(self, data):
 		return {row["entity"]: row for row in data}
 
+	def test_customer_entity_filter(self):
+		_columns, data, _message, chart, *_rest = execute(
+			self._base_filters(tree_type="Customer", entity=[CUSTOMER], curves="all")
+		)
+
+		self.assertEqual({row["entity"] for row in data}, {CUSTOMER})
+		self.assertAlmostEqual(data[0]["total"], self._expected_value_total(), places=2)
+		self.assertEqual({dataset["name"] for dataset in chart["data"]["datasets"]}, {CUSTOMER})
+
+	def test_parent_customer_group_filter_preserves_rollup(self):
+		_columns, unfiltered_data, *_rest = execute(self._base_filters(tree_type="Customer Group"))
+		_columns, filtered_data, *_rest = execute(
+			self._base_filters(tree_type="Customer Group", entity=["All Customer Groups"])
+		)
+
+		unfiltered = self._row_by_entity(unfiltered_data)
+		filtered = self._row_by_entity(filtered_data)
+		self.assertEqual(set(filtered), {"All Customer Groups"})
+		self.assertAlmostEqual(
+			filtered["All Customer Groups"]["total"],
+			unfiltered["All Customer Groups"]["total"],
+			places=2,
+		)
+
+	def test_customer_group_entity_filter(self):
+		_columns, unfiltered_data, *_rest = execute(self._base_filters(tree_type="Customer Group"))
+		_columns, filtered_data, *_rest = execute(
+			self._base_filters(tree_type="Customer Group", entity=[CUSTOMER_GROUP])
+		)
+
+		unfiltered = self._row_by_entity(unfiltered_data)
+		filtered = self._row_by_entity(filtered_data)
+		self.assertEqual(set(filtered), {CUSTOMER_GROUP})
+		self.assertEqual(filtered[CUSTOMER_GROUP]["indent"], 0)
+		self.assertAlmostEqual(
+			filtered[CUSTOMER_GROUP]["total"], unfiltered[CUSTOMER_GROUP]["total"], places=2
+		)
+
 	def test_customer_group_tree_rolls_up_to_root(self):
 		"""tree_type='Customer Group' drives get_groups (tree get_all ordered by lft)
 		and get_rows_by_group, rolling child values up to the 'All Customer Groups' root."""


### PR DESCRIPTION
## Problem

Purchase Analytics can plot one curve for every report row. A user cannot limit the report and chart to selected suppliers, items, or groups.

Support ticket 76685 shows this problem with a supplier. The user wants to view only Gorson Enterprises.

## Solution

Add an Entity multi-select filter to Purchase Analytics and Sales Analytics. The filter follows the selected Tree Type and resets when the Tree Type changes.

Build the normal analytics rows before applying the Entity filter. This keeps complete descendant totals for selected groups. Selected tree rows become top-level filtered results.

Keep the Curves filter in Purchase Analytics. It provides the same chart controls as Sales Analytics.

## Tests

- Purchase Analytics supplier entity and chart dataset filtering
- Purchase Analytics supplier-group and root-group rollups
- Sales Analytics customer entity and chart dataset filtering
- Sales Analytics customer-group and root-group rollups
- Existing Purchase and Sales Analytics test modules
- Pre-commit checks for all changed files

Ref: [support ticket 76685](https://support.frappe.io/helpdesk/tickets/76685)

Backport needed for v15 and v16.

no-docs
