### PR TITLE
feat(selling): add transaction currency commission

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
@@ -183,6 +183,7 @@
   "amount_eligible_for_commission",
   "commission_rate",
   "total_commission",
+  "total_commission_in_transaction_currency",
   "section_break2",
   "sales_team",
   "subscription_section",
@@ -1441,11 +1442,20 @@
    "depends_on": "eval:doc.sales_partner",
    "fieldname": "total_commission",
    "fieldtype": "Currency",
-   "label": "Total Commission",
+   "label": "Total Commission (Company Currency)",
    "no_copy": 1,
    "oldfieldname": "total_commission",
    "oldfieldtype": "Currency",
    "options": "Company:company:default_currency",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "eval:doc.sales_partner",
+   "fieldname": "total_commission_in_transaction_currency",
+   "fieldtype": "Currency",
+   "label": "Total Commission (Transaction Currency)",
+   "no_copy": 1,
+   "options": "currency",
    "print_hide": 1
   },
   {
@@ -1643,7 +1653,7 @@
  "icon": "fa fa-file-text",
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-21 23:11:45.029925",
+ "modified": "2026-08-25 16:03:21.338942",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice",

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -181,6 +181,7 @@ class POSInvoice(SalesInvoice):
 		total_advance: DF.Currency
 		total_billing_amount: DF.Currency
 		total_commission: DF.Currency
+		total_commission_in_transaction_currency: DF.Currency
 		total_net_weight: DF.Float
 		total_qty: DF.Float
 		total_taxes_and_charges: DF.Currency

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -208,6 +208,7 @@
   "column_break10",
   "commission_rate",
   "total_commission",
+  "total_commission_in_transaction_currency",
   "sales_team_section",
   "sales_team",
   "edit_printing_settings",
@@ -1810,11 +1811,20 @@
    "fieldtype": "Currency",
    "hide_days": 1,
    "hide_seconds": 1,
-   "label": "Total Commission",
+   "label": "Total Commission (Company Currency)",
    "no_copy": 1,
    "oldfieldname": "total_commission",
    "oldfieldtype": "Currency",
    "options": "Company:company:default_currency",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "eval:doc.sales_partner",
+   "fieldname": "total_commission_in_transaction_currency",
+   "fieldtype": "Currency",
+   "label": "Total Commission (Transaction Currency)",
+   "no_copy": 1,
+   "options": "currency",
    "print_hide": 1
   },
   {
@@ -2405,7 +2415,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2026-08-14 12:43:19.480555",
+ "modified": "2026-08-25 16:01:21.338942",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -241,6 +241,7 @@ class SalesInvoice(SellingController):
 		total_billing_amount: DF.Currency
 		total_billing_hours: DF.Float
 		total_commission: DF.Currency
+		total_commission_in_transaction_currency: DF.Currency
 		total_net_weight: DF.Float
 		total_qty: DF.Float
 		total_taxes_and_charges: DF.Currency

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4092,12 +4092,27 @@ class TestSalesInvoice(ERPNextTestSuite):
 			si.save()
 			self.assertEqual(si.amount_eligible_for_commission, 500)
 			self.assertEqual(si.total_commission, total_commission)
+			self.assertEqual(si.total_commission_in_transaction_currency, total_commission)
 
 		# Test invalid values
 		for commission_rate in (101, -1):
 			si.reload()
 			si.commission_rate = commission_rate
 			self.assertRaises(frappe.ValidationError, si.save)
+
+	@ERPNextTestSuite.change_settings(
+		"Accounts Settings", {"allow_multi_currency_invoices_against_single_party_account": 1}
+	)
+	def test_sales_commission_in_transaction_currency(self):
+		frappe.db.set_value("Item", "_Test Item", "grant_commission", 1)
+		foreign_currency_si = create_sales_invoice(
+			currency="USD", conversion_rate=80, rate=100, do_not_save=True
+		)
+		foreign_currency_si.commission_rate = 10
+		foreign_currency_si.save()
+
+		self.assertEqual(foreign_currency_si.total_commission, 800)
+		self.assertEqual(foreign_currency_si.total_commission_in_transaction_currency, 10)
 
 	def test_sales_invoice_submission_post_account_freezing_date(self):
 		frappe.db.set_value("Company", "_Test Company", "accounts_frozen_till_date", add_days(getdate(), 1))

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -221,6 +221,15 @@ class SellingController(StockController):
 			self.precision("total_commission"),
 		)
 
+		if self.meta.get_field("total_commission_in_transaction_currency"):
+			amount_eligible_in_transaction_currency = sum(
+				item.net_amount for item in self.items if item.grant_commission
+			)
+			self.total_commission_in_transaction_currency = flt(
+				amount_eligible_in_transaction_currency * self.commission_rate / 100.0,
+				self.precision("total_commission_in_transaction_currency"),
+			)
+
 	def calculate_contribution(self):
 		if not self.meta.get_field("sales_team"):
 			return

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -149,6 +149,7 @@
   "amount_eligible_for_commission",
   "commission_rate",
   "total_commission",
+  "total_commission_in_transaction_currency",
   "section_break1",
   "sales_team",
   "loyalty_points_redemption",
@@ -1398,11 +1399,20 @@
    "fieldtype": "Currency",
    "hide_days": 1,
    "hide_seconds": 1,
-   "label": "Total Commission",
+   "label": "Total Commission (Company Currency)",
    "no_copy": 1,
    "oldfieldname": "total_commission",
    "oldfieldtype": "Currency",
    "options": "Company:company:default_currency",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "eval:doc.sales_partner",
+   "fieldname": "total_commission_in_transaction_currency",
+   "fieldtype": "Currency",
+   "label": "Total Commission (Transaction Currency)",
+   "no_copy": 1,
+   "options": "currency",
    "print_hide": 1
   },
   {
@@ -1826,7 +1836,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-21 23:11:48.053347",
+ "modified": "2026-08-25 15:59:21.338942",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -175,6 +175,7 @@ class SalesOrder(SellingController):
 		to_date: DF.Date | None
 		total: DF.Currency
 		total_commission: DF.Currency
+		total_commission_in_transaction_currency: DF.Currency
 		total_net_weight: DF.Float
 		total_qty: DF.Float
 		total_taxes_and_charges: DF.Currency

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -3358,7 +3358,7 @@ class TestSalesOrder(ERPNextTestSuite):
 			frappe.db.set_value("Sales Person", "_Test Sales Person 2", "enabled", 1)
 
 	def test_sales_partner_commission(self):
-		"""Sales Partner commission: total_commission = amount_eligible_for_commission * rate / 100."""
+		"""Sales Partner commission is available in company and transaction currencies."""
 		frappe.db.set_value("Item", "_Test Item", "grant_commission", 1)
 		try:
 			so = make_sales_order(qty=10, rate=100, do_not_save=True)
@@ -3367,7 +3367,16 @@ class TestSalesOrder(ERPNextTestSuite):
 			so.save()
 
 			self.assertEqual(so.amount_eligible_for_commission, 1000)
-			self.assertEqual(so.total_commission, 70)  # 1000 * 7%
+			self.assertEqual(so.total_commission, 70)
+			self.assertEqual(so.total_commission_in_transaction_currency, 70)
+
+			foreign_currency_so = make_sales_order(qty=10, rate=100, currency="USD", do_not_save=True)
+			foreign_currency_so.conversion_rate = 80
+			foreign_currency_so.sales_partner = "_Test Sales Partner India - 1"
+			foreign_currency_so.commission_rate = 7
+			foreign_currency_so.save()
+			self.assertEqual(foreign_currency_so.total_commission, 5600)
+			self.assertEqual(foreign_currency_so.total_commission_in_transaction_currency, 70)
 
 			with self.subTest("commission rate above 100 is rejected"):
 				so.commission_rate = 101
@@ -3390,6 +3399,7 @@ class TestSalesOrder(ERPNextTestSuite):
 			self.assertEqual(duplicate.sales_partner, "_Test Sales Partner India - 1")
 			self.assertFalse(duplicate.commission_rate)
 			self.assertFalse(duplicate.total_commission)
+			self.assertFalse(duplicate.total_commission_in_transaction_currency)
 			self.assertFalse(duplicate.amount_eligible_for_commission)
 		finally:
 			frappe.db.set_value("Item", "_Test Item", "grant_commission", 1)

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -149,6 +149,7 @@
   "column_break7",
   "commission_rate",
   "total_commission",
+  "total_commission_in_transaction_currency",
   "section_break1",
   "sales_team",
   "auto_repeat_section",
@@ -1208,11 +1209,20 @@
    "depends_on": "eval:doc.sales_partner",
    "fieldname": "total_commission",
    "fieldtype": "Currency",
-   "label": "Total Commission",
+   "label": "Total Commission (Company Currency)",
    "no_copy": 1,
    "oldfieldname": "total_commission",
    "oldfieldtype": "Currency",
    "options": "Company:company:default_currency",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "eval:doc.sales_partner",
+   "fieldname": "total_commission_in_transaction_currency",
+   "fieldtype": "Currency",
+   "label": "Total Commission (Transaction Currency)",
+   "no_copy": 1,
+   "options": "currency",
    "print_hide": 1
   },
   {
@@ -1509,7 +1519,7 @@
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-14 12:43:19.480555",
+ "modified": "2026-08-25 16:05:21.338942",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -145,6 +145,7 @@ class DeliveryNote(SellingController):
 		title: DF.Data | None
 		total: DF.Currency
 		total_commission: DF.Currency
+		total_commission_in_transaction_currency: DF.Currency
 		total_net_weight: DF.Float
 		total_qty: DF.Float
 		total_taxes_and_charges: DF.Currency


### PR DESCRIPTION
### Issue

Sales Partner commission is currently calculated and displayed only in the company’s default currency. For transactions in another currency, users cannot see the corresponding commission amount in the transaction currency.

**Fixes** #7083

### Description

* Retain `total_commission` in the company currency for backward compatibility.
* Add `total_commission_in_transaction_currency` to store the commission in the transaction currency.
* Calculate the transaction-currency commission using the `net_amount` of commission-eligible items.
* Clearly label commission fields to distinguish between company currency and transaction currency.
* Add the transaction-currency commission field to:

  * Sales Order
  * Sales Invoice
  * Delivery Note
  * POS Invoice


No-docs
