### PR TITLE
fix(manufacturing): scope job card items to operation row

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1510,7 +1510,12 @@ def _add_normal_item_columns(query, t, amount_col, stock_item_condition, track_s
 	if track_semi_finished_goods:
 		group_by = [t.bom_item.item_code, t.bom_item.operation_row_id, t.item_doc.stock_uom]
 	else:
-		group_by = [t.bom_item.item_code, t.item_doc.stock_uom, t.bom_item.operation]
+		group_by = [
+			t.bom_item.item_code,
+			t.bom_item.operation_row_id,
+			t.item_doc.stock_uom,
+			t.bom_item.operation,
+		]
 	group_by += [t.bom_item.bom_no, t.bom_item.is_phantom_item]
 
 	return query, group_by
@@ -1520,8 +1525,7 @@ def _add_bom_item_to_dict(item_dict, item, company, opts):
 	key = item.item_code
 	if item.operation_row_id:
 		key = (item.item_code, item.operation_row_id)
-
-	if item.operation:
+	elif item.operation:
 		key = (item.item_code, item.operation)
 
 	if item.get("is_phantom_item"):

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -39,6 +39,42 @@ class TestBOM(ERPNextTestSuite):
 		self.assertEqual(len(items_dict.values()), 2)
 
 	@timeout
+	def test_get_items_keeps_repeated_operation_rows_separate(self):
+		from erpnext.manufacturing.doctype.bom.bom import get_bom_items_as_dict
+		from erpnext.manufacturing.doctype.operation.test_operation import make_operation
+
+		operation = make_operation(
+			{"operation": "_Test Repeated Operation", "workstation": "_Test Workstation 1"}
+		)
+		finished_good = make_item(properties={"is_stock_item": 1}).name
+		raw_material = make_item(properties={"is_stock_item": 1}).name
+		bom = frappe.new_doc(
+			"BOM",
+			company="_Test Company",
+			item=finished_good,
+			quantity=1,
+			with_operations=1,
+		)
+		for _ in range(2):
+			bom.append(
+				"operations",
+				{
+					"operation": operation.name,
+					"workstation": "_Test Workstation 1",
+					"time_in_mins": 30,
+				},
+			)
+
+		bom.append("items", {"item_code": raw_material, "qty": 1, "operation_row_id": 1})
+		bom.append("items", {"item_code": raw_material, "qty": 2, "operation_row_id": 2})
+		bom.insert()
+
+		items = get_bom_items_as_dict(bom.name, bom.company, qty=1, fetch_exploded=0)
+
+		self.assertEqual(items[(raw_material, 1)].qty, 1)
+		self.assertEqual(items[(raw_material, 2)].qty, 2)
+
+	@timeout
 	def test_get_items_exploded(self):
 		from erpnext.manufacturing.doctype.bom.bom import get_bom_items_as_dict
 

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -817,7 +817,12 @@ class JobCard(Document):
 				)
 			)
 
-		if not (self.get("operation") == d.operation or self.operation_row_id == d.operation_row_id):
+		if self.operation_row_id and d.operation_row_id:
+			is_current_operation = self.operation_row_id == d.operation_row_id
+		else:
+			is_current_operation = self.get("operation") == d.operation
+
+		if not is_current_operation:
 			return
 
 		self.append(

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -20,6 +20,7 @@ from erpnext.manufacturing.doctype.job_card.mapper import (
 from erpnext.manufacturing.doctype.job_card.mapper import (
 	make_stock_entry as make_stock_entry_from_jc,
 )
+from erpnext.manufacturing.doctype.work_order.mapper import create_job_card
 from erpnext.manufacturing.doctype.work_order.test_work_order import make_wo_order_test_record
 from erpnext.manufacturing.doctype.work_order.work_order import WorkOrder, make_work_order
 from erpnext.manufacturing.doctype.workstation.test_workstation import make_workstation
@@ -553,6 +554,38 @@ class TestJobCard(ERPNextTestSuite):
 		self.assertEqual(len(transfer_entry.items), 1)
 		self.assertEqual(transfer_entry.items[0].item_code, "_Test Item")
 		self.assertEqual(transfer_entry.items[0].qty, 2)
+
+	def test_required_items_are_scoped_to_repeated_operation_row(self):
+		work_order = make_wo_order_test_record(
+			item="_Test FG Item 2",
+			qty=1,
+			transfer_material_against="Job Card",
+			do_not_submit=True,
+		)
+		operation = work_order.operations[0]
+		work_order.append(
+			"operations",
+			{
+				"operation": operation.operation,
+				"workstation": operation.workstation,
+				"time_in_mins": operation.time_in_mins,
+				"hour_rate": operation.hour_rate,
+				"sequence_id": operation.sequence_id + 1,
+			},
+		)
+
+		for operation_row_id, item in enumerate(work_order.required_items, start=1):
+			item.operation = operation.operation
+			item.operation_row_id = operation_row_id
+
+		work_order.save()
+		second_operation = work_order.operations[1]
+		second_operation.job_card_qty = work_order.qty
+		job_card = create_job_card(work_order, second_operation)
+
+		self.assertEqual(
+			[item.item_code for item in job_card.items], [work_order.required_items[1].item_code]
+		)
 
 	def test_work_order_transferred_qty_with_multiple_job_cards(self):
 		create_bom_with_multiple_operations()


### PR DESCRIPTION
### Issue

 -  When the same operation appears more than once in a Work Order, a Job Card can receive raw materials belonging to another operation row because items are matched using
  only the operation name.

 **Fixes** : https://github.com/frappe/erpnext/issues/58401

  ### Steps to reproduce

  1. Create a Work Order containing the same operation in two rows.
  2. Assign different required materials to each operation row.
  3. Create a Job Card for the second operation row.
  4. Check its Required Items table.

  ### Actual behaviour

 - The Job Card contains materials belonging to both operation rows.

  ### Expected behaviour

-  The Job Card should contain only materials belonging to its specific operation row.



**Backport Needed For V16**