### PR TITLE
fix(accounts): prevent child table doctypes as accounting dimensions

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
@@ -16,6 +16,8 @@ frappe.ui.form.on("Accounting Dimension", {
 			return {
 				filters: {
 					name: ["not in", invalid_doctypes],
+					istable: 0,
+					issingle: 0,
 				},
 			};
 		});

--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -60,6 +60,14 @@ class AccountingDimension(Document):
 			msg = _("Not allowed to create accounting dimension for {0}").format(self.document_type)
 			frappe.throw(msg)
 
+		meta = frappe.get_meta(self.document_type)
+		if meta.istable or meta.issingle:
+			frappe.throw(
+				_(
+					"{0} cannot be used as an accounting dimension as it is not a standalone document type."
+				).format(frappe.bold(self.document_type))
+			)
+
 		exists = frappe.db.get_value("Accounting Dimension", {"document_type": self.document_type}, ["name"])
 
 		if exists and self.is_new():

--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -51,6 +51,10 @@ class TestAccountingDimension(ERPNextTestSuite):
 		self.assertEqual(gle.get("department"), "_Test Department - _TC")
 		self.assertEqual(gle1.get("department"), "_Test Department - _TC")
 
+	def test_child_table_not_allowed_as_dimension(self):
+		dimension = frappe.get_doc({"doctype": "Accounting Dimension", "document_type": "Sales Team"})
+		self.assertRaises(frappe.ValidationError, dimension.insert)
+
 	def test_mandatory(self):
 		location = frappe.get_doc("Accounting Dimension", "Location")
 		location.dimension_defaults[0].mandatory_for_bs = True

--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -55,6 +55,19 @@ class TestAccountingDimension(ERPNextTestSuite):
 		dimension = frappe.get_doc({"doctype": "Accounting Dimension", "document_type": "Sales Team"})
 		self.assertRaises(frappe.ValidationError, dimension.insert)
 
+	def test_single_doctype_not_allowed_as_dimension(self):
+		dimension = frappe.get_doc({"doctype": "Accounting Dimension", "document_type": "Selling Settings"})
+		self.assertRaises(frappe.ValidationError, dimension.insert)
+
+	def test_non_scalar_dimension_value_skipped_in_gl_dict(self):
+		si = create_sales_invoice(do_not_save=1)
+
+		si.department = "_Test Department - _TC"
+		self.assertEqual(si.get_gl_dict({}).get("department"), "_Test Department - _TC")
+
+		si.department = ["_Test Department - _TC"]
+		self.assertNotIn("department", si.get_gl_dict({}))
+
 	def test_mandatory(self):
 		location = frappe.get_doc("Accounting Dimension", "Location")
 		location.dimension_defaults[0].mandatory_for_bs = True

--- a/erpnext/accounts/services/base_gl_composer.py
+++ b/erpnext/accounts/services/base_gl_composer.py
@@ -67,9 +67,12 @@ def get_gl_dict(doc, args: dict, account_currency: str | None = None, item=None)
 	accounting_dimensions = get_accounting_dimensions()
 	dimension_dict = frappe._dict()
 	for dimension in accounting_dimensions:
-		dimension_dict[dimension] = doc.get(dimension)
+		value = doc.get(dimension)
 		if item and item.get(dimension):
-			dimension_dict[dimension] = item.get(dimension)
+			value = item.get(dimension)
+		if isinstance(value, list | dict):
+			continue
+		dimension_dict[dimension] = value
 
 	gl_dict.update(dimension_dict)
 	gl_dict.update(args)


### PR DESCRIPTION
Description:

Selecting a child-table (or single) doctype as an Accounting Dimension breaks submission. Its fieldname can collide with an existing child table on transactions — e.g. "Sales Team" → sales_team — so the whole child table gets pushed into the GL/Payment Ledger Entry, failing with AssertionError: Unexpected value for field sales_team.

Changes

Hide child table / single doctypes from the Reference Document Type picker
Block them server-side in validate_doctype with a clear message
Skip non-scalar dimension values in get_gl_dict so existing bad configs can't crash submission
Add test