### PR TITLE
fix(asset): skip missing checkbox columns in asset type patch

### DIFF
--- a/erpnext/patches/v16_0/migrate_asset_type_checkboxes_to_select.py
+++ b/erpnext/patches/v16_0/migrate_asset_type_checkboxes_to_select.py
@@ -3,13 +3,19 @@ from frappe.query_builder import Case
 
 
 def execute():
-	Asset = frappe.qb.DocType("Asset")
+	# v15 sites never had is_composite_component; only migrate columns that exist.
+	column_values = (
+		("is_existing_asset", "Existing Asset"),
+		("is_composite_asset", "Composite Asset"),
+		("is_composite_component", "Composite Component"),
+	)
+	existing = [(col, value) for col, value in column_values if frappe.db.has_column("Asset", col)]
+	if not existing:
+		return
 
-	frappe.qb.update(Asset).set(
-		Asset.asset_type,
-		Case()
-		.when(Asset.is_existing_asset == 1, "Existing Asset")
-		.when(Asset.is_composite_asset == 1, "Composite Asset")
-		.when(Asset.is_composite_component == 1, "Composite Component")
-		.else_(""),
-	).run()
+	Asset = frappe.qb.DocType("Asset")
+	case = Case()
+	for column, value in existing:
+		case = case.when(getattr(Asset, column) == 1, value)
+
+	frappe.qb.update(Asset).set(Asset.asset_type, case.else_("")).run()


### PR DESCRIPTION
`migrate_asset_type_checkboxes_to_select` always reads `is_composite_component`. That column was added on v16, so upgrades from v15 fail with `Unknown column 'is_composite_component'`.
Copy into `asset_type` only the checkbox columns that exist (`is_existing_asset`, `is_composite_asset`, `is_composite_component`).
