### PR TITLE
fix(manufacturing): scope job card items to operation row

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1572,7 +1572,12 @@ def _add_normal_item_columns(query, t, amount_col, stock_item_condition, track_s
 	if track_semi_finished_goods:
 		group_by = [t.bom_item.item_code, t.bom_item.operation_row_id, t.item_doc.stock_uom]
 	else:
-		group_by = [t.bom_item.item_code, t.item_doc.stock_uom, t.bom_item.operation]
+		group_by = [
+			t.bom_item.item_code,
+			t.bom_item.operation_row_id,
+			t.item_doc.stock_uom,
+			t.bom_item.operation,
+		]
 	group_by += [t.bom_item.bom_no, t.bom_item.is_phantom_item]
 
 	return query, group_by
@@ -1585,8 +1590,7 @@ def _add_bom_item_to_dict(item_dict, item, company, opts):
 
 	if item.operation_row_id:
 		key = (item.item_code, item.operation_row_id)
-
-	if item.operation:
+	elif item.operation:
 		key = (item.item_code, item.operation)
 
 	if item.get("is_phantom_item"):

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1203,8 +1203,12 @@ class BOM(WebsiteGenerator):
 	def add_to_cur_exploded_items(self, args):
 		return BOMExplodedItemsService(self).add_to_cur_exploded_items(args)
 
-	def get_child_exploded_items(self, bom_no, stock_qty, operation=None):
-		return BOMExplodedItemsService(self).get_child_exploded_items(bom_no, stock_qty, operation)
+	def get_child_exploded_items(
+		self, bom_no, stock_qty, operation=None, operation_row_id=None, operation_bom=None
+	):
+		return BOMExplodedItemsService(self).get_child_exploded_items(
+			bom_no, stock_qty, operation, operation_row_id, operation_bom
+		)
 
 	def add_exploded_items(self, save=True):
 		return BOMExplodedItemsService(self).add_exploded_items(save)
@@ -1518,6 +1522,8 @@ def _add_exploded_item_columns(query, t, bom, amount_col, stock_item_condition):
 		Max(t.bom_item.source_warehouse).as_("source_warehouse"),
 		Count(t.bom_item.name).distinct().as_("line_count"),
 		Max(t.bom_item.operation).as_("operation"),
+		Max(t.bom_item.operation_row_id).as_("operation_row_id"),
+		Max(t.bom_item.operation_bom).as_("operation_bom"),
 		Max(t.bom_item.include_item_in_manufacturing).as_("include_item_in_manufacturing"),
 		Max(t.bom_item.rate).as_("rate"),
 		Max(t.bom_item.sourced_by_supplier).as_("sourced_by_supplier"),
@@ -1525,7 +1531,13 @@ def _add_exploded_item_columns(query, t, bom, amount_col, stock_item_condition):
 		idx_subquery.as_("idx"),
 	).where(stock_item_condition)
 
-	return query, [t.bom_item.item_code, t.item_doc.stock_uom, t.bom_item.operation]
+	return query, [
+		t.bom_item.item_code,
+		t.bom_item.operation_bom,
+		t.bom_item.operation_row_id,
+		t.item_doc.stock_uom,
+		t.bom_item.operation,
+	]
 
 
 def _add_secondary_item_columns(query, t, stock_item_condition):
@@ -1585,10 +1597,12 @@ def _add_normal_item_columns(query, t, amount_col, stock_item_condition, track_s
 
 def _add_bom_item_to_dict(item_dict, item, company, opts):
 	key = item.item_code
+	# Secondary items are grouped by type; manufacturing items are grouped by operation identity.
 	if opts.fetch_secondary_items:
 		key = (item.item_code, item.secondary_item_type or "")
-
-	if item.operation_row_id:
+	elif item.operation_bom and item.operation_row_id:
+		key = (item.item_code, item.operation_bom, item.operation_row_id)
+	elif item.operation_row_id:
 		key = (item.item_code, item.operation_row_id)
 	elif item.operation:
 		key = (item.item_code, item.operation)

--- a/erpnext/manufacturing/doctype/bom/services/exploded_items.py
+++ b/erpnext/manufacturing/doctype/bom/services/exploded_items.py
@@ -24,17 +24,24 @@ class BOMExplodedItemsService:
 		self.doc.cur_exploded_items = {}
 		for d in self.doc.get("items"):
 			if d.bom_no:
-				self.get_child_exploded_items(d.bom_no, d.stock_qty, d.operation)
+				self.get_child_exploded_items(
+					d.bom_no,
+					d.stock_qty,
+					d.operation,
+					d.operation_row_id,
+					self.doc.name if d.operation_row_id else None,
+				)
 			elif d.item_code:
 				self.add_to_cur_exploded_items(self._exploded_item_row(d))
 
-	@staticmethod
-	def _exploded_item_row(d):
+	def _exploded_item_row(self, d):
 		return frappe._dict(
 			{
 				"item_code": d.item_code,
 				"item_name": d.item_name,
 				"operation": d.operation,
+				"operation_row_id": d.operation_row_id,
+				"operation_bom": self.doc.name if d.operation_row_id else None,
 				"is_sub_assembly_item": d.is_sub_assembly_item,
 				"source_warehouse": d.source_warehouse,
 				"description": d.description,
@@ -49,7 +56,9 @@ class BOMExplodedItemsService:
 
 	def add_to_cur_exploded_items(self, args):
 		key = args.item_code
-		if args.operation:
+		if args.operation_row_id:
+			key = (args.item_code, args.operation_bom, args.operation_row_id)
+		elif args.operation:
 			key = (args.item_code, args.operation)
 
 		if self.doc.cur_exploded_items.get(key):
@@ -57,10 +66,14 @@ class BOMExplodedItemsService:
 		else:
 			self.doc.cur_exploded_items[key] = args
 
-	def get_child_exploded_items(self, bom_no, stock_qty, operation=None):
+	def get_child_exploded_items(
+		self, bom_no, stock_qty, operation=None, operation_row_id=None, operation_bom=None
+	):
 		"""Add all items from Flat BOM of child BOM"""
 		for d in self._fetch_child_flat_bom_items(bom_no):
-			self.add_to_cur_exploded_items(self._child_exploded_row(d, stock_qty, operation))
+			self.add_to_cur_exploded_items(
+				self._child_exploded_row(d, stock_qty, operation, operation_row_id, operation_bom)
+			)
 
 	@staticmethod
 	def _fetch_child_flat_bom_items(bom_no):
@@ -78,6 +91,8 @@ class BOMExplodedItemsService:
 				bom_item.description,
 				bom_item.source_warehouse,
 				bom_item.operation,
+				bom_item.operation_row_id,
+				bom_item.operation_bom,
 				bom_item.is_sub_assembly_item,
 				bom_item.stock_uom,
 				bom_item.stock_qty,
@@ -90,13 +105,15 @@ class BOMExplodedItemsService:
 		).run(as_dict=1)
 
 	@staticmethod
-	def _child_exploded_row(d, stock_qty, operation):
+	def _child_exploded_row(d, stock_qty, operation, operation_row_id, operation_bom):
 		return frappe._dict(
 			{
 				"item_code": d["item_code"],
 				"item_name": d["item_name"],
 				"source_warehouse": d["source_warehouse"],
 				"operation": d["operation"] or operation,
+				"operation_row_id": d["operation_row_id"] or operation_row_id,
+				"operation_bom": d["operation_bom"] or operation_bom,
 				"description": d["description"],
 				"stock_uom": d["stock_uom"],
 				"stock_qty": d["qty_consumed_per_unit"] * stock_qty,

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -68,11 +68,43 @@ class TestBOM(ERPNextTestSuite):
 		bom.append("items", {"item_code": raw_material, "qty": 1, "operation_row_id": 1})
 		bom.append("items", {"item_code": raw_material, "qty": 2, "operation_row_id": 2})
 		bom.insert()
+		bom.submit()
 
-		items = get_bom_items_as_dict(bom.name, bom.company, qty=1, fetch_exploded=0)
+		for fetch_exploded in (0, 1):
+			items = get_bom_items_as_dict(bom.name, bom.company, qty=1, fetch_exploded=fetch_exploded)
+			operation_keys = (
+				[(raw_material, bom.name, row_id) for row_id in (1, 2)]
+				if fetch_exploded
+				else [(raw_material, row_id) for row_id in (1, 2)]
+			)
 
-		self.assertEqual(items[(raw_material, 1)].qty, 1)
-		self.assertEqual(items[(raw_material, 2)].qty, 2)
+			self.assertEqual(items[operation_keys[0]].qty, 1)
+			self.assertEqual(items[operation_keys[1]].qty, 2)
+
+		frappe.db.set_value(
+			"BOM Explosion Item",
+			{"parent": bom.name},
+			{"operation_bom": None, "operation_row_id": 0},
+			update_modified=False,
+		)
+
+		from erpnext.patches.v16_0.rebuild_bom_explosion_operation_identity import execute
+
+		execute()
+		execute()
+		operation_identity = frappe.get_all(
+			"BOM Explosion Item",
+			filters={"parent": bom.name},
+			fields=["operation_bom", "operation_row_id"],
+			order_by="operation_row_id",
+		)
+		self.assertEqual(
+			[(row.operation_bom, row.operation_row_id) for row in operation_identity],
+			[(bom.name, 1), (bom.name, 2)],
+		)
+
+		bom.cancel()
+		bom.delete()
 
 	@timeout
 	def test_get_items_exploded(self):

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -39,6 +39,42 @@ class TestBOM(ERPNextTestSuite):
 		self.assertEqual(len(items_dict.values()), 2)
 
 	@timeout
+	def test_get_items_keeps_repeated_operation_rows_separate(self):
+		from erpnext.manufacturing.doctype.bom.bom import get_bom_items_as_dict
+		from erpnext.manufacturing.doctype.operation.test_operation import make_operation
+
+		operation = make_operation(
+			{"operation": "_Test Repeated Operation", "workstation": "_Test Workstation 1"}
+		)
+		finished_good = make_item(properties={"is_stock_item": 1}).name
+		raw_material = make_item(properties={"is_stock_item": 1}).name
+		bom = frappe.new_doc(
+			"BOM",
+			company="_Test Company",
+			item=finished_good,
+			quantity=1,
+			with_operations=1,
+		)
+		for _ in range(2):
+			bom.append(
+				"operations",
+				{
+					"operation": operation.name,
+					"workstation": "_Test Workstation 1",
+					"time_in_mins": 30,
+				},
+			)
+
+		bom.append("items", {"item_code": raw_material, "qty": 1, "operation_row_id": 1})
+		bom.append("items", {"item_code": raw_material, "qty": 2, "operation_row_id": 2})
+		bom.insert()
+
+		items = get_bom_items_as_dict(bom.name, bom.company, qty=1, fetch_exploded=0)
+
+		self.assertEqual(items[(raw_material, 1)].qty, 1)
+		self.assertEqual(items[(raw_material, 2)].qty, 2)
+
+	@timeout
 	def test_get_items_exploded(self):
 		from erpnext.manufacturing.doctype.bom.bom import get_bom_items_as_dict
 

--- a/erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
+++ b/erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
@@ -12,6 +12,8 @@
   "cb",
   "source_warehouse",
   "operation",
+  "operation_bom",
+  "operation_row_id",
   "section_break_3",
   "description",
   "column_break_2",
@@ -65,6 +67,20 @@
    "fieldtype": "Link",
    "label": "Operation",
    "options": "Operation",
+   "read_only": 1
+  },
+  {
+   "fieldname": "operation_bom",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Operation BOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "operation_row_id",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "label": "Operation ID",
    "read_only": 1
   },
   {
@@ -180,7 +196,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-12 20:02:32.694836",
+ "modified": "2026-08-26 16:00:00.000000",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Explosion Item",

--- a/erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.py
+++ b/erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.py
@@ -22,6 +22,8 @@ class BOMExplosionItem(Document):
 		item_code: DF.Link | None
 		item_name: DF.Data | None
 		operation: DF.Link | None
+		operation_bom: DF.Data | None
+		operation_row_id: DF.Int
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -61,6 +61,12 @@ class JobCardOverTransferError(frappe.ValidationError):
 	pass
 
 
+def is_same_operation(first, second):
+	if first.operation_row_id and second.operation_row_id:
+		return cint(first.operation_row_id) == cint(second.operation_row_id)
+	return first.operation == second.operation
+
+
 class JobCard(Document):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
@@ -820,12 +826,7 @@ class JobCard(Document):
 				)
 			)
 
-		if self.operation_row_id and d.operation_row_id:
-			is_current_operation = self.operation_row_id == d.operation_row_id
-		else:
-			is_current_operation = self.get("operation") == d.operation
-
-		if not is_current_operation:
+		if not is_same_operation(self, d):
 			return
 
 		self.append(

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -820,7 +820,12 @@ class JobCard(Document):
 				)
 			)
 
-		if not (self.get("operation") == d.operation or self.operation_row_id == d.operation_row_id):
+		if self.operation_row_id and d.operation_row_id:
+			is_current_operation = self.operation_row_id == d.operation_row_id
+		else:
+			is_current_operation = self.get("operation") == d.operation
+
+		if not is_current_operation:
 			return
 
 		self.append(

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -20,7 +20,6 @@ from erpnext.manufacturing.doctype.job_card.mapper import (
 from erpnext.manufacturing.doctype.job_card.mapper import (
 	make_stock_entry as make_stock_entry_from_jc,
 )
-from erpnext.manufacturing.doctype.work_order.mapper import create_job_card
 from erpnext.manufacturing.doctype.work_order.test_work_order import make_wo_order_test_record
 from erpnext.manufacturing.doctype.work_order.work_order import WorkOrder, make_job_card, make_work_order
 from erpnext.manufacturing.doctype.workstation.test_workstation import make_workstation
@@ -593,36 +592,273 @@ class TestJobCard(ERPNextTestSuite):
 		self.assertEqual(transfer_entry.items[0].qty, 2)
 
 	def test_required_items_are_scoped_to_repeated_operation_row(self):
-		work_order = make_wo_order_test_record(
-			item="_Test FG Item 2",
-			qty=1,
-			transfer_material_against="Job Card",
-			do_not_submit=True,
+		from erpnext.manufacturing.doctype.operation.test_operation import make_operation
+
+		suffix = random_string(6)
+		operation = make_operation(
+			{
+				"operation": f"Repeated Operation {suffix}",
+				"workstation": "_Test Workstation 1",
+			}
 		)
-		operation = work_order.operations[0]
-		work_order.append(
+		finished_good = create_item(f"Repeated Operation FG {suffix}")
+		raw_material = create_item(f"Repeated Operation RM {suffix}")
+		source_warehouses = ("_Test Warehouse - _TC", "Stores - _TC")
+
+		bom = frappe.new_doc(
+			"BOM",
+			company="_Test Company",
+			item=finished_good.name,
+			quantity=1,
+			with_operations=1,
+			transfer_material_against="Job Card",
+		)
+		for sequence_id in (1, 2):
+			bom.append(
+				"operations",
+				{
+					"operation": operation.name,
+					"workstation": "_Test Workstation 1",
+					"time_in_mins": 30,
+					"sequence_id": sequence_id,
+				},
+			)
+		for operation_row_id, (required_qty, source_warehouse) in enumerate(
+			zip((1, 2), source_warehouses, strict=True), start=1
+		):
+			bom.append(
+				"items",
+				{
+					"item_code": raw_material.name,
+					"qty": required_qty,
+					"operation_row_id": operation_row_id,
+					"source_warehouse": source_warehouse,
+				},
+			)
+		bom.insert()
+		bom.submit()
+
+		work_order = make_work_order(
+			bom.name,
+			finished_good.name,
+			1,
+			company="_Test Company",
+			variant_items=[],
+			use_multi_level_bom=1,
+		)
+		work_order.wip_warehouse = "Work In Progress - _TC"
+		work_order.fg_warehouse = "Finished Goods - _TC"
+		work_order.planned_start_date = now()
+		work_order.submit()
+
+		self.assertEqual(work_order.use_multi_level_bom, 1)
+		self.assertEqual(
+			[(row.operation_row_id, row.required_qty) for row in work_order.required_items],
+			[(1, 1), (2, 2)],
+		)
+
+		frappe.db.set_value(
+			"Work Order Operation",
+			{"parent": work_order.name},
+			"bom_operation_row_id",
+			0,
+			update_modified=False,
+		)
+		from erpnext.patches.v16_0.rebuild_bom_explosion_operation_identity import execute
+
+		execute()
+		execute()
+		self.assertEqual(
+			frappe.get_all(
+				"Work Order Operation",
+				filters={"parent": work_order.name},
+				pluck="bom_operation_row_id",
+				order_by="idx",
+			),
+			[1, 2],
+		)
+
+		job_card = frappe.get_last_doc("Job Card", {"work_order": work_order.name, "operation_row_id": 2})
+		self.assertEqual(
+			[(row.item_code, row.required_qty) for row in job_card.items], [(raw_material.name, 2)]
+		)
+
+		make_stock_entry(
+			item_code=raw_material.name,
+			target=source_warehouses[1],
+			qty=2,
+			basic_rate=100,
+		)
+		transfer_entry = make_stock_entry_from_jc(job_card.name)
+		transfer_entry.get_items()
+
+		self.assertEqual(len(transfer_entry.items), 1)
+		self.assertEqual(transfer_entry.items[0].qty, 2)
+		self.assertEqual(transfer_entry.items[0].s_warehouse, source_warehouses[1])
+
+		transfer_entry.submit()
+		job_card.reload()
+		self.assertEqual(transfer_entry.fg_completed_qty, 1)
+		self.assertEqual(job_card.transferred_qty, 1)
+
+	def test_required_items_are_scoped_across_child_bom_operations(self):
+		from erpnext.manufacturing.doctype.operation.test_operation import make_operation
+
+		suffix = random_string(6)
+		child_boms = []
+		raw_materials = []
+		source_warehouses = ("_Test Warehouse - _TC", "Stores - _TC")
+		for child_number, source_warehouse in enumerate(source_warehouses, start=1):
+			operation = make_operation(
+				{
+					"operation": f"Nested Operation {child_number} {suffix}",
+					"workstation": "_Test Workstation 1",
+				}
+			)
+			child_item = create_item(f"Nested SFG {child_number} {suffix}")
+			raw_material = create_item(f"Nested RM {child_number} {suffix}")
+			child_bom = frappe.new_doc(
+				"BOM",
+				company="_Test Company",
+				item=child_item.name,
+				quantity=1,
+				with_operations=1,
+				transfer_material_against="Job Card",
+			)
+			child_bom.append(
+				"operations",
+				{
+					"operation": operation.name,
+					"workstation": "_Test Workstation 1",
+					"time_in_mins": 30,
+				},
+			)
+			child_bom.append(
+				"items",
+				{
+					"item_code": raw_material.name,
+					"qty": child_number,
+					"operation_row_id": 1,
+					"source_warehouse": source_warehouse,
+				},
+			)
+			child_bom.insert()
+			child_bom.submit()
+			child_boms.append(child_bom)
+			raw_materials.append(raw_material)
+
+		finished_good = create_item(f"Nested FG {suffix}")
+		final_operation = make_operation(
+			{
+				"operation": f"Nested Final Operation {suffix}",
+				"workstation": "_Test Workstation 1",
+			}
+		)
+		parent_bom = frappe.new_doc(
+			"BOM",
+			company="_Test Company",
+			item=finished_good.name,
+			quantity=1,
+			with_operations=1,
+			transfer_material_against="Job Card",
+		)
+		parent_bom.append(
 			"operations",
 			{
-				"operation": operation.operation,
-				"workstation": operation.workstation,
-				"time_in_mins": operation.time_in_mins,
-				"hour_rate": operation.hour_rate,
-				"sequence_id": operation.sequence_id + 1,
+				"operation": final_operation.name,
+				"workstation": "_Test Workstation 1",
+				"time_in_mins": 30,
+			},
+		)
+		for child_bom in (*child_boms, child_boms[0]):
+			parent_bom.append(
+				"items",
+				{"item_code": child_bom.item, "qty": 1, "bom_no": child_bom.name},
+			)
+		parent_bom.insert()
+		parent_bom.submit()
+
+		work_order = make_work_order(
+			parent_bom.name,
+			finished_good.name,
+			1,
+			company="_Test Company",
+			variant_items=[],
+			use_multi_level_bom=1,
+		)
+		work_order.wip_warehouse = "Work In Progress - _TC"
+		work_order.fg_warehouse = "Finished Goods - _TC"
+		work_order.planned_start_date = now()
+		work_order.qty = 2
+		work_order.submit()
+
+		operation_row_by_bom = {row.bom: row.idx for row in work_order.operations}
+		self.assertEqual(
+			[row.bom for row in work_order.operations].count(child_boms[0].name),
+			1,
+		)
+		self.assertEqual(
+			next(row.time_in_mins for row in work_order.operations if row.bom == child_boms[0].name),
+			60,
+		)
+		self.assertNotEqual(
+			operation_row_by_bom[child_boms[0].name], operation_row_by_bom[child_boms[1].name]
+		)
+		self.assertEqual(
+			{
+				row.item_code: (row.operation_row_id, row.required_qty, row.source_warehouse)
+				for row in work_order.required_items
+			},
+			{
+				raw_materials[0].name: (
+					operation_row_by_bom[child_boms[0].name],
+					4,
+					source_warehouses[0],
+				),
+				raw_materials[1].name: (
+					operation_row_by_bom[child_boms[1].name],
+					4,
+					source_warehouses[1],
+				),
 			},
 		)
 
-		for operation_row_id, item in enumerate(work_order.required_items, start=1):
-			item.operation = operation.operation
-			item.operation_row_id = operation_row_id
-
-		work_order.save()
-		second_operation = work_order.operations[1]
-		second_operation.job_card_qty = work_order.qty
-		job_card = create_job_card(work_order, second_operation)
-
+		copied_work_order = frappe.copy_doc(work_order, ignore_no_copy=False)
+		copied_work_order.docstatus = 0
+		copied_work_order.set_required_items()
+		self.assertTrue(all(row.bom and row.bom_operation_row_id for row in copied_work_order.operations))
 		self.assertEqual(
-			[item.item_code for item in job_card.items], [work_order.required_items[1].item_code]
+			{
+				row.item_code: (row.operation_row_id, row.required_qty)
+				for row in copied_work_order.required_items
+			},
+			{
+				raw_materials[0].name: (operation_row_by_bom[child_boms[0].name], 4),
+				raw_materials[1].name: (operation_row_by_bom[child_boms[1].name], 4),
+			},
 		)
+
+		for child_qty, (child_bom, raw_material, source_warehouse) in enumerate(
+			zip(child_boms, raw_materials, source_warehouses, strict=True), start=1
+		):
+			required_qty = child_qty * work_order.qty * (2 if child_bom == child_boms[0] else 1)
+			job_card = frappe.get_last_doc(
+				"Job Card",
+				{
+					"work_order": work_order.name,
+					"operation_row_id": operation_row_by_bom[child_bom.name],
+				},
+			)
+			self.assertEqual(
+				[(row.item_code, row.required_qty) for row in job_card.items],
+				[(raw_material.name, required_qty)],
+			)
+			transfer_entry = make_stock_entry_from_jc(job_card.name)
+			transfer_entry.get_items()
+			self.assertEqual(
+				[(row.item_code, row.qty, row.s_warehouse) for row in transfer_entry.items],
+				[(raw_material.name, required_qty, source_warehouse)],
+			)
 
 	def test_work_order_transferred_qty_with_multiple_job_cards(self):
 		create_bom_with_multiple_operations()

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -20,6 +20,7 @@ from erpnext.manufacturing.doctype.job_card.mapper import (
 from erpnext.manufacturing.doctype.job_card.mapper import (
 	make_stock_entry as make_stock_entry_from_jc,
 )
+from erpnext.manufacturing.doctype.work_order.mapper import create_job_card
 from erpnext.manufacturing.doctype.work_order.test_work_order import make_wo_order_test_record
 from erpnext.manufacturing.doctype.work_order.work_order import WorkOrder, make_job_card, make_work_order
 from erpnext.manufacturing.doctype.workstation.test_workstation import make_workstation
@@ -590,6 +591,38 @@ class TestJobCard(ERPNextTestSuite):
 		self.assertEqual(len(transfer_entry.items), 1)
 		self.assertEqual(transfer_entry.items[0].item_code, "_Test Item")
 		self.assertEqual(transfer_entry.items[0].qty, 2)
+
+	def test_required_items_are_scoped_to_repeated_operation_row(self):
+		work_order = make_wo_order_test_record(
+			item="_Test FG Item 2",
+			qty=1,
+			transfer_material_against="Job Card",
+			do_not_submit=True,
+		)
+		operation = work_order.operations[0]
+		work_order.append(
+			"operations",
+			{
+				"operation": operation.operation,
+				"workstation": operation.workstation,
+				"time_in_mins": operation.time_in_mins,
+				"hour_rate": operation.hour_rate,
+				"sequence_id": operation.sequence_id + 1,
+			},
+		)
+
+		for operation_row_id, item in enumerate(work_order.required_items, start=1):
+			item.operation = operation.operation
+			item.operation_row_id = operation_row_id
+
+		work_order.save()
+		second_operation = work_order.operations[1]
+		second_operation.job_card_qty = work_order.qty
+		job_card = create_job_card(work_order, second_operation)
+
+		self.assertEqual(
+			[item.item_code for item in job_card.items], [work_order.required_items[1].item_code]
+		)
 
 	def test_work_order_transferred_qty_with_multiple_job_cards(self):
 		create_bom_with_multiple_operations()

--- a/erpnext/manufacturing/doctype/work_order/services/operations.py
+++ b/erpnext/manufacturing/doctype/work_order/services/operations.py
@@ -44,6 +44,7 @@ _BOM_OPERATION_FIELDS = [
 	"base_hour_rate as hour_rate",
 	"time_in_mins",
 	"parent as bom",
+	"idx as bom_operation_row_id",
 	"bom_no",
 	"batch_size",
 	"sequence_id",
@@ -232,10 +233,16 @@ class OperationsService:
 		groups = []
 		if self.doc.use_multi_level_bom:
 			bom_tree = frappe.get_doc("BOM", self.doc.bom_no).get_tree_representation()
+			exploded_qty_by_bom = {}
 			for node in reversed(bom_tree.level_order_traversal()):
 				if node.is_bom:
-					qty = node.exploded_qty / node.bom_qty
-					groups.append((self._bom_operations(node.name), qty, True))
+					exploded_qty_by_bom[node.name] = (
+						exploded_qty_by_bom.get(node.name, 0.0) + node.exploded_qty
+					)
+
+			for bom_no, exploded_qty in exploded_qty_by_bom.items():
+				bom_qty = frappe.get_cached_value("BOM", bom_no, "quantity")
+				groups.append((self._bom_operations(bom_no), exploded_qty / bom_qty, True))
 
 		bom_qty = frappe.get_cached_value("BOM", self.doc.bom_no, "quantity")
 		groups.append((self._bom_operations(self.doc.bom_no), bom_qty, False))

--- a/erpnext/manufacturing/doctype/work_order/services/required_items.py
+++ b/erpnext/manufacturing/doctype/work_order/services/required_items.py
@@ -10,7 +10,7 @@ callers and the whitelisted entry point keep working unchanged.
 
 import frappe
 from frappe import _
-from frappe.utils import flt
+from frappe.utils import cint, flt
 from pypika import functions as fn
 
 from erpnext.manufacturing.doctype.bom.bom import get_bom_items_as_dict
@@ -61,8 +61,12 @@ class RequiredItemsService:
 				stock_bin.update_reserved_qty_for_production()
 
 	def get_items_and_operations_from_bom(self):
-		self.set_required_items()
-		self.doc.set_work_order_operations()
+		if self.doc.use_multi_level_bom:
+			self.doc.set_work_order_operations()
+			self.set_required_items()
+		else:
+			self.set_required_items()
+			self.doc.set_work_order_operations()
 
 		return check_if_scrap_warehouse_mandatory(self.doc.bom_no)
 
@@ -81,6 +85,8 @@ class RequiredItemsService:
 
 		if not (self.doc.bom_no and self.doc.qty):
 			return
+		if self.doc.is_new() and self.doc.use_multi_level_bom and not self._has_operation_identities():
+			self.doc.set_work_order_operations()
 
 		operations = self.doc.get("operations") or []
 		operation = operations[0].operation if len(operations) == 1 else None
@@ -95,9 +101,14 @@ class RequiredItemsService:
 		self.set_available_qty()
 
 	def _reset_required_qty(self, item_dict, operation):
+		items_by_operation = {
+			self._required_item_identity(item, self._work_order_operation_row_id(item)): item
+			for item in item_dict.values()
+		}
 		for d in self.doc.get("required_items"):
-			if item_dict.get(d.item_code):
-				d.required_qty = item_dict.get(d.item_code).get("qty")
+			item = items_by_operation.get(self._required_item_identity(d, d.operation_row_id))
+			if item:
+				d.required_qty = item.qty
 
 			if not d.operation:
 				d.operation = operation
@@ -147,8 +158,34 @@ class RequiredItemsService:
 			"required_qty": item.qty,
 			"source_warehouse": source_warehouse,
 			"include_item_in_manufacturing": item.include_item_in_manufacturing,
-			"operation_row_id": item.operation_row_id,
+			"operation_row_id": self._work_order_operation_row_id(item),
 		}
+
+	def _work_order_operation_row_id(self, item):
+		if not item.operation_bom:
+			return item.operation_row_id
+
+		for operation in self.doc.operations:
+			if operation.bom == item.operation_bom and cint(operation.bom_operation_row_id) == cint(
+				item.operation_row_id
+			):
+				return operation.idx
+
+		frappe.throw(
+			_("Could not map operation row {0} from BOM {1} to the Work Order.").format(
+				item.operation_row_id, item.operation_bom
+			)
+		)
+
+	def _has_operation_identities(self):
+		return self.doc.operations and all(
+			operation.bom and operation.bom_operation_row_id for operation in self.doc.operations
+		)
+
+	@staticmethod
+	def _required_item_identity(item, operation_row_id):
+		operation_row_id = cint(operation_row_id)
+		return (item.item_code, operation_row_id, None if operation_row_id else item.operation)
 
 	def update_transferred_qty_for_required_items(self):
 		if self.doc.skip_transfer:

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -41,6 +41,39 @@ from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestWorkOrder(ERPNextTestSuite):
+	def test_reset_required_qty_for_legacy_operation_rows(self):
+		from erpnext.manufacturing.doctype.work_order.services.required_items import RequiredItemsService
+
+		work_order = frappe.new_doc("Work Order")
+		work_order.append(
+			"required_items",
+			{"item_code": "Legacy RM", "operation": "Legacy Operation 1", "required_qty": 1},
+		)
+		work_order.append(
+			"required_items",
+			{"item_code": "Legacy RM", "operation": "Legacy Operation 2", "required_qty": 1},
+		)
+		item_dict = {
+			("Legacy RM", "Legacy Operation 1"): frappe._dict(
+				item_code="Legacy RM",
+				operation="Legacy Operation 1",
+				operation_bom=None,
+				operation_row_id=0,
+				qty=2,
+			),
+			("Legacy RM", "Legacy Operation 2"): frappe._dict(
+				item_code="Legacy RM",
+				operation="Legacy Operation 2",
+				operation_bom=None,
+				operation_row_id=0,
+				qty=3,
+			),
+		}
+
+		RequiredItemsService(work_order)._reset_required_qty(item_dict, operation=None)
+
+		self.assertEqual([row.required_qty for row in work_order.required_items], [2, 3])
+
 	def setUp(self):
 		self.warehouse = "_Test Warehouse 2 - _TC"
 		self.item = "_Test Item"

--- a/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
+++ b/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
@@ -14,6 +14,7 @@
   "pending_qty",
   "column_break_4",
   "bom",
+  "bom_operation_row_id",
   "workstation_type",
   "workstation",
   "sequence_id",
@@ -71,6 +72,14 @@
    "no_copy": 1,
    "options": "BOM",
    "print_hide": 1
+  },
+  {
+   "fieldname": "bom_operation_row_id",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "label": "BOM Operation Row ID",
+   "no_copy": 1,
+   "read_only": 1
   },
   {
    "fieldname": "description",

--- a/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.py
+++ b/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.py
@@ -22,6 +22,7 @@ class WorkOrderOperation(Document):
 		batch_size: DF.Float
 		batch_split: DF.Check
 		bom: DF.Link | None
+		bom_operation_row_id: DF.Int
 		bom_no: DF.Link | None
 		completed_qty: DF.Float
 		description: DF.TextEditor | None

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -520,3 +520,4 @@ erpnext.patches.v16_0.add_batch_split_stock_entry_type
 erpnext.patches.v16_0.add_transaction_roles_to_sms_settings
 erpnext.patches.v16_0.set_secondary_item_valuation_type
 erpnext.patches.v16_0.append_fieldname_to_pos_search_fields
+erpnext.patches.v16_0.rebuild_bom_explosion_operation_identity

--- a/erpnext/patches/v16_0/rebuild_bom_explosion_operation_identity.py
+++ b/erpnext/patches/v16_0/rebuild_bom_explosion_operation_identity.py
@@ -1,0 +1,98 @@
+import frappe
+from frappe.utils import cint
+
+
+def execute():
+	bom_names, children_by_bom = _get_boms_with_operation_items_and_ancestors()
+	_rebuild_bom_explosions(bom_names, children_by_bom)
+	_backfill_work_order_operation_rows()
+
+
+def _rebuild_bom_explosions(bom_names, children_by_bom):
+	rebuilt = set()
+	rebuilding = set()
+
+	def rebuild(bom_no):
+		if bom_no in rebuilt or bom_no in rebuilding:
+			return
+
+		rebuilding.add(bom_no)
+		for child_bom in children_by_bom.get(bom_no, ()):
+			if child_bom in bom_names:
+				rebuild(child_bom)
+
+		frappe.get_doc("BOM", bom_no).update_exploded_items()
+		rebuilding.remove(bom_no)
+		rebuilt.add(bom_no)
+
+	for bom_no in bom_names:
+		rebuild(bom_no)
+
+
+def _get_boms_with_operation_items_and_ancestors():
+	bom_names = set(
+		frappe.get_all(
+			"BOM Item",
+			filters={"docstatus": 1, "operation_row_id": [">", 0]},
+			pluck="parent",
+			order_by=None,
+			limit=0,
+		)
+	)
+	children_by_bom = {}
+	for row in frappe.get_all(
+		"BOM Item",
+		filters={"docstatus": 1, "bom_no": ["is", "set"]},
+		fields=["parent", "bom_no"],
+		limit=0,
+	):
+		children_by_bom.setdefault(row.parent, set()).add(row.bom_no)
+
+	while True:
+		parents = {
+			parent for parent, child_boms in children_by_bom.items() if child_boms.intersection(bom_names)
+		}
+		new_parents = parents - bom_names
+		if not new_parents:
+			break
+		bom_names.update(new_parents)
+
+	return bom_names, children_by_bom
+
+
+def _backfill_work_order_operation_rows():
+	rows = frappe.get_all(
+		"Work Order Operation",
+		filters={"bom": ["is", "set"], "bom_operation_row_id": 0},
+		fields=["name", "parent", "bom"],
+		order_by="parent, idx",
+		limit=0,
+	)
+	if not rows:
+		return
+
+	bom_operations = frappe.get_all(
+		"BOM Operation",
+		filters={"parent": ["in", list({row.bom for row in rows})]},
+		fields=["parent", "idx"],
+		order_by="parent, idx",
+		limit=0,
+	)
+	row_ids_by_bom = {}
+	for row in bom_operations:
+		row_ids_by_bom.setdefault(row.parent, []).append(cint(row.idx))
+
+	operation_occurrences = {}
+	updates = {}
+	for row in rows:
+		key = (row.parent, row.bom)
+		row_ids = row_ids_by_bom.get(row.bom, ())
+		if not row_ids:
+			continue
+
+		occurrence = operation_occurrences.get(key, 0)
+		updates[row.name] = {"bom_operation_row_id": row_ids[occurrence % len(row_ids)]}
+		operation_occurrences[key] = occurrence + 1
+
+	if updates:
+		frappe.db.bulk_update("Work Order Operation", updates, update_modified=False)

--- a/erpnext/stock/doctype/stock_entry/services/material_transfer.py
+++ b/erpnext/stock/doctype/stock_entry/services/material_transfer.py
@@ -3,6 +3,7 @@ from frappe import _
 from frappe.query_builder.functions import Sum
 from frappe.utils import cstr, flt
 
+from erpnext.manufacturing.doctype.job_card.job_card import is_same_operation
 from erpnext.manufacturing.doctype.work_order.services.material_coverage import (
 	get_minimum_material_coverage_fraction,
 )
@@ -256,7 +257,7 @@ class MaterialTransferForManufactureStockEntry(BaseMaterialTransferStockEntry):
 
 		work_order_required_by_item = {}
 		for row in self.wo_doc.required_items:
-			if not (job_card.operation == row.operation or job_card.operation_row_id == row.operation_row_id):
+			if not is_same_operation(job_card, row):
 				continue
 			work_order_required_by_item[row.item_code] = work_order_required_by_item.get(
 				row.item_code, 0.0
@@ -426,7 +427,8 @@ class MaterialTransferForManufactureStockEntry(BaseMaterialTransferStockEntry):
 		"""Gets Work Order Required Items for Material Transfer for Manufacture."""
 		work_order = self.wo_doc
 		consider_job_card = work_order.transfer_material_against == "Job Card" and self.doc.get("job_card")
-		job_card_items = self.get_job_card_item_codes() if consider_job_card else []
+		job_card = frappe.get_doc("Job Card", self.doc.job_card) if consider_job_card else None
+		job_card_items = self.get_job_card_item_codes() if job_card else []
 		wip_warehouse = self._resolve_wip_warehouse(work_order)
 		extra_pct = flt(
 			frappe.db.get_single_value("Manufacturing Settings", "transfer_extra_materials_percentage")
@@ -434,7 +436,7 @@ class MaterialTransferForManufactureStockEntry(BaseMaterialTransferStockEntry):
 		item_dict = frappe._dict()
 		for d in work_order.get("required_items"):
 			self._add_required_item(
-				item_dict, d, consider_job_card, job_card_items, wip_warehouse, extra_pct, work_order
+				item_dict, d, job_card, job_card_items, wip_warehouse, extra_pct, work_order
 			)
 		return item_dict
 
@@ -444,9 +446,9 @@ class MaterialTransferForManufactureStockEntry(BaseMaterialTransferStockEntry):
 		return None
 
 	def _add_required_item(
-		self, item_dict, d, consider_job_card, job_card_items, wip_warehouse, extra_pct, work_order
+		self, item_dict, d, job_card, job_card_items, wip_warehouse, extra_pct, work_order
 	):
-		if consider_job_card and d.item_code not in job_card_items:
+		if job_card and (d.item_code not in job_card_items or not is_same_operation(job_card, d)):
 			return
 		additional_qty = extra_pct * flt(d.required_qty) / 100 if extra_pct else 0.0
 		transfer_pending = (
@@ -457,7 +459,7 @@ class MaterialTransferForManufactureStockEntry(BaseMaterialTransferStockEntry):
 		can_transfer = transfer_pending or self.backflush_based_on == "Material Transferred for Manufacture"
 		if not can_transfer or not d.include_item_in_manufacturing:
 			return
-		self._build_required_item_row(item_dict, d, consider_job_card, wip_warehouse, work_order)
+		self._build_required_item_row(item_dict, d, bool(job_card), wip_warehouse, work_order)
 
 	def _build_required_item_row(self, item_dict, d, consider_job_card, wip_warehouse, work_order):
 		item_row = d.as_dict()

--- a/erpnext/stock/doctype/stock_entry/services/material_transfer.py
+++ b/erpnext/stock/doctype/stock_entry/services/material_transfer.py
@@ -318,11 +318,18 @@ class MaterialTransferForManufactureStockEntry(BaseMaterialTransferStockEntry):
 		if not wo:
 			return
 
-		pending_by_item = {}
+		required_by_item = {}
+		transferred_by_item = {}
 		for r in wo.required_items:
-			pending_by_item[r.item_code] = (
-				pending_by_item.get(r.item_code, 0.0) + flt(r.required_qty) - flt(r.transferred_qty)
+			required_by_item[r.item_code] = required_by_item.get(r.item_code, 0.0) + flt(r.required_qty)
+			transferred_by_item[r.item_code] = max(
+				transferred_by_item.get(r.item_code, 0.0), flt(r.transferred_qty)
 			)
+
+		pending_by_item = {
+			item_code: required_qty - transferred_by_item[item_code]
+			for item_code, required_qty in required_by_item.items()
+		}
 
 		transfer_by_item = {}
 		first_row_by_item = {}

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1096,7 +1096,9 @@ class TestStockEntry(ERPNextTestSuite):
 		)
 
 		bom_no, bom_operation_cost = frappe.db.get_value(
-			"BOM", {"item": "_Test FG Item 2", "is_default": 1, "docstatus": 1}, ["name", "operating_cost"]
+			"BOM",
+			{"item": "_Test FG Item 2", "is_default": 1, "docstatus": 1},
+			["name", "base_operating_cost"],
 		)
 
 		work_order = frappe.new_doc("Work Order")
@@ -1161,6 +1163,43 @@ class TestStockEntry(ERPNextTestSuite):
 		service._validate_no_excess_transfer()
 
 		stock_entry.items[0].qty = 0.002
+		with self.assertRaises(frappe.ValidationError):
+			service._validate_no_excess_transfer()
+
+	@ERPNextTestSuite.change_settings("Manufacturing Settings", {"backflush_raw_materials_based_on": "BOM"})
+	def test_material_transfer_for_repeated_required_item_rows(self):
+		from erpnext.stock.doctype.stock_entry.services.material_transfer import (
+			MaterialTransferForManufactureStockEntry,
+		)
+
+		work_order = frappe.new_doc("Work Order")
+		for required_qty in (1, 2):
+			work_order.append(
+				"required_items",
+				{
+					"item_code": "_Test Item",
+					"required_qty": required_qty,
+					"transferred_qty": 1,
+				},
+			)
+
+		stock_entry = frappe.new_doc("Stock Entry")
+		stock_entry.work_order = "Test Work Order"
+		stock_entry.append(
+			"items",
+			{
+				"item_code": "_Test Item",
+				"s_warehouse": "_Test Warehouse - _TC",
+				"qty": 2,
+				"uom": "Nos",
+			},
+		)
+
+		service = MaterialTransferForManufactureStockEntry(stock_entry)
+		service._wo_doc = work_order
+		service._validate_no_excess_transfer()
+
+		stock_entry.items[0].qty = 2.1
 		with self.assertRaises(frappe.ValidationError):
 			service._validate_no_excess_transfer()
 
@@ -1282,6 +1321,8 @@ class TestStockEntry(ERPNextTestSuite):
 		)
 		work_order.insert()
 		work_order.submit()
+		for operation in work_order.operations:
+			operation.db_set("completed_qty", work_order.qty)
 
 		from erpnext.manufacturing.doctype.work_order.mapper import make_stock_entry
 


### PR DESCRIPTION
 ### Issue

-  When a Work Order contains the same Operation in multiple rows, a Job Card can include raw materials belonging to another operation row.

 - Required items were matched using the Operation name even when both records had an `operation_row_id`. BOM item aggregation could also group repeated operation rows
  together by Operation name.

**Fixes:** https://github.com/frappe/erpnext/issues/58401

  ### Steps to reproduce

  1. Create a BOM with the same Operation in two different operation rows.
  2. Assign different raw materials to each operation row.
  3. Create a Work Order with material transfer against Job Card.
  4. Create a Job Card for the second occurrence of the Operation.
  5. Check the Job Card's Required Items table.

  ### Actual behaviour

-  The Job Card includes raw materials assigned to the other row having the same Operation name.

  ### Expected behaviour

 - The Job Card should include only raw materials assigned to its specific operation row.

Backport Needed For V16