### PR TITLE
fix(manufacturing): preserve job card qty in mr stock entry

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -340,6 +340,43 @@ class TestJobCard(ERPNextTestSuite):
 		job_card.reload()
 		self.assertEqual(job_card.transferred_qty, 2)
 
+	def test_material_request_stock_entry_uses_incremental_job_card_coverage(self):
+		from erpnext.stock.doctype.material_request.mapper import make_stock_entry
+
+		self.transfer_material_against = "Job Card"
+		self.source_warehouse = "Stores - _TC"
+		job_card_name = frappe.db.get_value("Job Card", {"work_order": self.work_order.name})
+		job_card = frappe.get_doc("Job Card", job_card_name)
+		self.assertEqual(len(job_card.items), 2)
+
+		mr = make_material_request(job_card.name)
+		mr.schedule_date = today()
+		mr.submit()
+
+		completed_row, limiting_row = mr.items
+		frappe.db.set_value(
+			"Job Card Item", completed_row.job_card_item, "transferred_qty", completed_row.stock_qty
+		)
+		frappe.db.set_value(
+			"Job Card Item",
+			limiting_row.job_card_item,
+			"transferred_qty",
+			flt(limiting_row.stock_qty) / 2,
+		)
+		frappe.db.set_value(completed_row.doctype, completed_row.name, "ordered_qty", completed_row.stock_qty)
+		frappe.db.set_value(
+			limiting_row.doctype,
+			limiting_row.name,
+			"ordered_qty",
+			flt(limiting_row.stock_qty) / 2,
+		)
+		mr.reload()
+
+		stock_entry = make_stock_entry(mr.name)
+		self.assertEqual(len(stock_entry.items), 1)
+		self.assertEqual(stock_entry.items[0].job_card_item, limiting_row.job_card_item)
+		self.assertEqual(stock_entry.fg_completed_qty, job_card.for_quantity / 2)
+
 	def test_job_card_partial_material_transfer_qty(self):
 		self.transfer_material_against = "Job Card"
 		self.source_warehouse = "Stores - _TC"
@@ -1006,6 +1043,7 @@ class TestJobCard(ERPNextTestSuite):
 		work_order = make_wo_with_transfer_against_jc()
 
 		job_card_name = frappe.db.get_value("Job Card", {"work_order": work_order.name}, "name")
+		for_quantity = frappe.get_value("Job Card", job_card_name, "for_quantity")
 
 		mr = make_material_request(job_card_name)
 		mr.schedule_date = today()
@@ -1017,6 +1055,32 @@ class TestJobCard(ERPNextTestSuite):
 		self.assertEqual(ste.job_card, job_card_name)
 		self.assertEqual(ste.from_bom, 1.0)
 		self.assertEqual(ste.bom_no, work_order.bom_no)
+		self.assertEqual(ste.fg_completed_qty, for_quantity)
+
+		partial_work_order = make_wo_with_transfer_against_jc()
+		partial_job_card_name = frappe.db.get_value(
+			"Job Card", {"work_order": partial_work_order.name}, "name"
+		)
+		partial_for_quantity = frappe.get_value("Job Card", partial_job_card_name, "for_quantity")
+
+		partial_mr = make_material_request(partial_job_card_name)
+		partial_mr.schedule_date = today()
+		partial_mr.set_from_warehouse = partial_work_order.source_warehouse
+		for row in partial_mr.items:
+			row.from_warehouse = partial_work_order.source_warehouse
+			row.qty = flt(row.qty) / 2
+			row.stock_qty = flt(row.stock_qty) / 2
+		partial_mr.submit()
+
+		partial_ste = make_stock_entry(partial_mr.name)
+		self.assertEqual(partial_ste.fg_completed_qty, partial_for_quantity / 2)
+
+		for row in partial_mr.items:
+			frappe.db.set_value(row.doctype, row.name, "ordered_qty", flt(row.stock_qty) / 2)
+		partial_mr.reload()
+
+		repeated_ste = make_stock_entry(partial_mr.name)
+		self.assertEqual(repeated_ste.fg_completed_qty, partial_for_quantity / 4)
 
 	def test_job_card_material_transfer_via_pick_list(self):
 		from erpnext.stock.doctype.material_request.mapper import create_pick_list

--- a/erpnext/stock/doctype/material_request/mapper.py
+++ b/erpnext/stock/doctype/material_request/mapper.py
@@ -9,6 +9,9 @@ from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import cint, comma_and, flt, get_link_to_form, getdate, nowdate
 
+from erpnext.manufacturing.doctype.work_order.services.material_coverage import (
+	get_minimum_material_coverage_fraction,
+)
 from erpnext.setup.doctype.brand.brand import get_brand_defaults
 from erpnext.setup.doctype.item_group.item_group import get_item_group_defaults
 from erpnext.stock.doctype.item.item import get_item_defaults
@@ -33,6 +36,44 @@ def get_source_item_for_qty(item, qty):
 	source_item.stock_qty = flt(qty) * flt(item.conversion_factor)
 
 	return source_item
+
+
+def get_job_card_qty_for_material_request(source, for_quantity):
+	required_qty = {}
+	transferred_qty = {}
+	for row in frappe.get_all(
+		"Job Card Item",
+		filters={"parent": source.job_card},
+		fields=["name", "required_qty", "transferred_qty"],
+	):
+		if flt(row.required_qty) > 0:
+			required_qty[row.name] = flt(row.required_qty)
+			transferred_qty[row.name] = flt(row.transferred_qty)
+
+	if not required_qty:
+		return for_quantity
+
+	has_job_card_item = False
+	entry_transferred_qty = transferred_qty.copy()
+	for row in source.items:
+		if row.job_card_item in required_qty:
+			has_job_card_item = True
+			qty = flt(row.stock_qty) - flt(row.ordered_qty)
+			if qty > 0:
+				entry_transferred_qty[row.job_card_item] += qty
+
+	if not has_job_card_item:
+		return for_quantity
+
+	precision = frappe.get_precision("Job Card Item", "required_qty")
+	covered_before = (
+		get_minimum_material_coverage_fraction(required_qty, transferred_qty, precision) * for_quantity
+	)
+	covered_after = (
+		get_minimum_material_coverage_fraction(required_qty, entry_transferred_qty, precision) * for_quantity
+	)
+
+	return flt(max(covered_after - covered_before, 0))
 
 
 def update_item(obj, target, source_parent):
@@ -373,7 +414,9 @@ def make_stock_entry(source_name: str, target_doc: str | dict | Document | None 
 
 			if job_card_details and job_card_details[0]:
 				target.bom_no = job_card_details[0].bom_no
-				target.fg_completed_qty = job_card_details[0].for_quantity
+				target.fg_completed_qty = get_job_card_qty_for_material_request(
+					source, job_card_details[0].for_quantity
+				)
 				target.from_bom = 1
 
 		if source.work_order:
@@ -385,8 +428,9 @@ def make_stock_entry(source_name: str, target_doc: str | dict | Document | None 
 				target.bom_no = work_order_details.bom_no
 				target.use_multi_level_bom = work_order_details.use_multi_level_bom
 				target.from_bom = 1
-				# not fg-qty-driven, mirrors the Pick List -> Stock Entry transfer for this Work Order
-				target.fg_completed_qty = 0
+				if not source.job_card:
+					# not fg-qty-driven, mirrors the Pick List -> Stock Entry transfer for this Work Order
+					target.fg_completed_qty = 0
 
 	doclist = get_mapped_doc(
 		"Material Request",


### PR DESCRIPTION
### Issue

Job Cards created with `Transfer Material Against = Job Card` can fail submission with:

> Materials need to be transferred to the work in progress warehouse

even when the raw material transfer is completed and the Job Card Item shows the full transferred quantity.

### Root Cause

When creating a Stock Entry from a Material Request linked to a Job Card, the mapper first sets:

```python
target.fg_completed_qty = job_card.for_quantity
```

But if the same Material Request also has `work_order`, the Work Order block overwrites it:

```python
target.fg_completed_qty = 0
```

This leaves submitted Job Card material transfers with `fg_completed_qty = 0`, so `Job Card.transferred_qty` recalculates to zero.

### Fix

Preserve `fg_completed_qty` when the Material Request is linked to a Job Card. The zeroing behavior is kept only for Work Order-only Material Requests.

### Steps To Replicate

Prerequisites:

1. Create a BOM with operations enabled.
2. Set Transfer Material Against = Job Card.
3. Add items to Components table.
4. Submit the BOM.
5. Create and submit a Work Order from that BOM.
6. Open the generated Job Card.

Original issue:

1. From the Job Card, create a Material Request.
2. Submit the Material Request.
3. From the Material Request, create a Stock Entry.
4. Submit the Stock Entry.
5. Open the Job Card again.
6. Try to submit the Job Card.

Support ticket: [#76460](https://support.frappe.io/helpdesk/tickets/76460)