### PR TITLE
fix: include payment deductions in sales/purchase register ledger bal…

### DIFF
--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -309,6 +309,9 @@ def get_payment_entries(filters, args):
 			pe.mode_of_payment,
 			pe.project,
 			pe.cost_center,
+			pe.payment_type,
+			pe.source_exchange_rate,
+			pe.target_exchange_rate,
 		)
 		.where(
 			(pe.docstatus == 1)
@@ -319,6 +322,22 @@ def get_payment_entries(filters, args):
 	)
 	query = apply_common_conditions(filters, query, doctype="Payment Entry", payments=True)
 	payment_entries = query.run(as_dict=True)
+
+	if payment_entries:
+		ded = frappe.qb.DocType("Payment Entry Deduction")
+		deduction_totals = frappe._dict(
+			frappe.qb.from_(ded)
+			.select(ded.parent, Sum(ded.amount))
+			.where(ded.parent.isin([d.name for d in payment_entries]) & (ded.is_exchange_gain_loss == 0))
+			.groupby(ded.parent)
+			.run()
+		)
+		for d in payment_entries:
+			exchange_rate = (
+				d.source_exchange_rate if d.payment_type == "Receive" else d.target_exchange_rate
+			) or 1
+			d.base_grand_total = flt(d.base_grand_total) + flt(deduction_totals.get(d.name)) / exchange_rate
+
 	return payment_entries
 
 


### PR DESCRIPTION
**Issue :**
When a Payment Entry includes a discount amount posted to a Sales Discount account, the Sales Register Report – Ledger View incorrectly shows the discounted amount as an outstanding customer balance.
However, the General Ledger calculates the Customer balance correctly.

**Issue Detailed Description:**

When receiving payment from a Customer, the Customer's outstanding amount is settled and the difference is recorded as Sales Discount in the Payment Entry.

For example, when the Customer pays an amount that is less than the invoice amount, the difference is entered as a Sales Discount in the Payment Entry.

The accounting entries are correct, and when we check the same Customer in the General Ledger, the Customer balance is correctly shown as zero.

However, when we open the Sales Register Report, select the same Customer, and use Ledger View, the amount that was deducted as Sales Discount is incorrectly displayed as a remaining balance.

Therefore, the Customer balance shown in the Sales Register Ledger View does not match the actual balance shown in the General Ledger.

**Steps to Replicate the issue:**

1. Create a Sales Invoice for a Customer.
2. Create a Payment Entry against the Sales Invoice.
3. Receive an amount less than the Sales Invoice total.
4. Enter the difference as Sales Discount in the Payment Entry.
