### PR TITLE
fix(accounts): resolve subscription plans for any reference doctype in Payment Request

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -874,7 +874,8 @@ def make_payment_request(**args):
 		if not party_account_currency:
 			party_account = get_party_account(party_type, ref_doc.get(party_type.lower()), ref_doc.company)
 			party_account_currency = get_account_currency(party_account)
-		is_a_subscription = 1 if ref_doc.get("subscription") else 0
+
+		subscription_plans = get_subscription_details(ref_doc.doctype, ref_doc.name)
 		pr.update(
 			{
 				"payment_gateway_account": gateway_account.get("name"),
@@ -906,15 +907,14 @@ def make_payment_request(**args):
 					or gateway_account.get("payment_channel", "Email") != "Email"
 				),
 				"phone_number": args.get("phone_number") if args.get("phone_number") else None,
-				"is_a_subscription": is_a_subscription,
+				"is_a_subscription": 1 if subscription_plans else 0,
 			}
 		)
 
 		if selected_payment_schedules:
 			apply_payment_references(pr, payment_reference)
-		if is_a_subscription:
-			values = get_subscription_details(ref_doc.doctype, ref_doc.name)
 
+		if subscription_plans:
 			pr.set(
 				"subscription_plans",
 				[
@@ -922,7 +922,7 @@ def make_payment_request(**args):
 						"plan": row.plan,
 						"qty": row.qty,
 					}
-					for row in values
+					for row in subscription_plans
 				],
 			)
 		# Dimensions
@@ -1238,16 +1238,18 @@ def get_dummy_message(doc):
 
 
 @frappe.whitelist()
-def get_subscription_details(reference_doctype: str, reference_name: str):
-	if reference_doctype != "Sales Invoice":
+def get_subscription_details(reference_doctype: str, reference_name: str) -> list[dict]:
+	frappe.has_permission(reference_doctype, "read", reference_name, throw=True)
+
+	if not frappe.get_meta(reference_doctype).has_field("subscription"):
 		return []
 
-	subscription = frappe.db.get_value("Sales Invoice", reference_name, "subscription")
+	subscription = frappe.db.get_value(reference_doctype, reference_name, "subscription")
 
 	if not subscription:
 		return []
 
-	subscription_plan = frappe.get_all(
+	return frappe.get_all(
 		"Subscription Plan Detail",
 		filters={"parent": subscription, "parenttype": "Subscription", "parentfield": "plans"},
 		fields=[
@@ -1255,8 +1257,6 @@ def get_subscription_details(reference_doctype: str, reference_name: str):
 			"qty",
 		],
 	)
-
-	return subscription_plan
 
 
 @frappe.whitelist()

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -11,7 +11,10 @@ from frappe.utils import add_days, nowdate
 
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_terms_template
-from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
+from erpnext.accounts.doctype.payment_request.payment_request import (
+	get_subscription_details,
+	make_payment_request,
+)
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.doctype.subscription.test_subscription import (
@@ -2066,3 +2069,89 @@ class TestPaymentRequestV2Gateway(ERPNextTestSuite):
 		self.assertEqual(len(payment_request.subscription_plans), 0)
 		self.assertEqual(payment_request.reference_doctype, "Sales Invoice")
 		self.assertEqual(payment_request.reference_name, si.name)
+
+	def test_payment_request_with_subscription_for_purchase_invoice(self):
+		make_plans()
+
+		subscription_plan = frappe.get_doc("Subscription Plan", "_Test Plan Name")
+		subscription_plan.payment_gateway = "_Test Gateway - INR - _TC"
+		subscription_plan.save()
+
+		subscription = create_subscription(
+			party_type="Supplier",
+			party="_Test Supplier",
+			plans=[{"plan": "_Test Plan Name", "qty": 1}],
+			start_date=nowdate(),
+			generate_invoice_at="Prepaid (bill at period start)",
+			submit_invoice=1,
+		)
+		invoice_name = frappe.get_value(
+			"Purchase Invoice",
+			{
+				"subscription": subscription.name,
+				"docstatus": 1,
+				"is_return": 0,
+			},
+			"name",
+			order_by="from_date asc",
+		)
+
+		payment_request = make_payment_request(
+			dt="Purchase Invoice",
+			dn=invoice_name,
+			party_type="Supplier",
+			party="_Test Supplier",
+			recipient_id="test@example.com",
+		)
+
+		self.assertEqual(payment_request.is_a_subscription, 1)
+		self.assertEqual(len(payment_request.subscription_plans), 1)
+
+		subscription_plan = payment_request.subscription_plans[0]
+		self.assertEqual(subscription_plan.plan, "_Test Plan Name")
+		self.assertEqual(subscription_plan.qty, 1)
+		self.assertEqual(payment_request.reference_doctype, "Purchase Invoice")
+		self.assertEqual(payment_request.reference_name, invoice_name)
+
+	def test_payment_request_without_subscription_for_purchase_invoice(self):
+		pi = make_purchase_invoice()
+		payment_request = make_payment_request(
+			dt="Purchase Invoice",
+			dn=pi.name,
+			party_type="Supplier",
+			party=pi.supplier,
+			recipient_id="test@example.com",
+		)
+		self.assertEqual(payment_request.is_a_subscription, 0)
+		self.assertEqual(len(payment_request.subscription_plans), 0)
+		self.assertEqual(payment_request.reference_doctype, "Purchase Invoice")
+		self.assertEqual(payment_request.reference_name, pi.name)
+
+	def test_get_subscription_details_returns_empty_for_doctype_without_subscription_field(self):
+		so = make_sales_order()
+		self.assertEqual(get_subscription_details("Sales Order", so.name), [])
+
+	def test_get_subscription_details_requires_read_permission_on_reference(self):
+		si = create_sales_invoice()
+
+		restricted_user = "no-roles@example.com"
+		if not frappe.db.exists("User", restricted_user):
+			user = frappe.new_doc("User")
+			user.email = restricted_user
+			user.first_name = "No Roles"
+			user.send_welcome_email = 0
+			user.insert()
+
+		accounts_user = "accounts-user@example.com"
+		if not frappe.db.exists("User", accounts_user):
+			user = frappe.new_doc("User")
+			user.email = accounts_user
+			user.first_name = "Accounts"
+			user.send_welcome_email = 0
+			user.add_roles("Accounts User")
+
+		with self.set_user(restricted_user):
+			self.assertRaises(frappe.PermissionError, get_subscription_details, "Sales Invoice", si.name)
+
+		with self.set_user(accounts_user):
+			self.assertEqual(get_subscription_details("Sales Invoice", si.name), [])


### PR DESCRIPTION
## Issue

#57494 added logic to auto-populate `is_a_subscription` and `subscription_plans` when creating a Payment Request against a subscription-linked document, but `get_subscription_details()` is hardcoded to only resolve plans for `reference_doctype == "Sales Invoice"`.

`Purchase Invoice` also has a `subscription` field (set by `Subscription._finalize_invoice` for supplier-side subscriptions, a first-class path in `subscription.py`). Since `is_a_subscription` in `make_payment_request()` is computed from `ref_doc.get("subscription")` for *any* reference doctype, creating a Payment Request against a subscription-linked Purchase Invoice results in `is_a_subscription=1` with an empty `subscription_plans` table — an inconsistent Payment Request that only surfaces as a confusing amount-mismatch `msgprint` at validate time.

Separately, `get_subscription_details()` is `@frappe.whitelist()` with no permission check. Any logged-in user can call it with an arbitrary `reference_name` and learn which Subscription (and its plan/qty) is linked to any Sales Invoice or Purchase Invoice, regardless of read access to that document.

## Fix

- Make `get_subscription_details()` resolve plans generically for any reference doctype, guarded by `frappe.get_meta(doctype).has_field("subscription")` so doctypes without the field (Sales Order, Purchase Order, POS Invoice, ...) never hit a nonexistent DB column.
- Derive `is_a_subscription` in `make_payment_request()` from the resolved plans instead of a separate `ref_doc.get("subscription")` check, so the flag and the table can no longer disagree.
- Add `frappe.has_permission(reference_doctype, "read", reference_name, throw=True)` as the first step of `get_subscription_details()`.

## Note for reviewers

Now that Purchase Invoice subscription plans get populated, `PaymentRequest.validate_subscription_details()` actually runs its gateway-match check for Purchase Invoice-based Payment Requests. If a plan's `payment_gateway` doesn't match the PR's `payment_gateway_account`, PR creation now throws where it previously silently produced an empty table. This mirrors the behavior Sales Invoice subscriptions already have since #57494 — it's a consistency fix, not a new failure mode.

## Test plan

- [ ] `bench --site test.site run-tests --module erpnext.accounts.doctype.payment_request.test_payment_request`
- New tests: Purchase Invoice with/without subscription, a doctype with no `subscription` field (Sales Order), and a permission-denied vs. permitted case for `get_subscription_details`.
- Existing Sales Invoice subscription tests are unmodified and should still pass (same resolution path, same output shape).