### PR TITLE
fix: Work Order picks wrong Delivery Date when Sales Order has the same item in multiple rows

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -508,7 +508,7 @@ class WorkOrder(Document):
 			PackedItem = frappe.qb.DocType("Packed Item")
 			ProductBundleItem = frappe.qb.DocType("Product Bundle Item")
 
-			so = (
+			so_query = (
 				frappe.qb.from_(SalesOrder)
 				.inner_join(SalesOrderItem)
 				.on(SalesOrderItem.parent == SalesOrder.name)
@@ -524,8 +524,12 @@ class WorkOrder(Document):
 						| (ProductBundleItem.item_code == production_item)
 					)
 				)
-				.run(as_dict=1)
 			)
+
+			if self.sales_order_item:
+				so_query = so_query.where(SalesOrderItem.name == self.sales_order_item)
+
+			so = so_query.run(as_dict=1)
 
 			if not so:
 				so = (


### PR DESCRIPTION
## What was wrong

If a Sales Order has the same item added in two different rows, each with its own Delivery Date (e.g. Row 1 = Sept 1, Row 2 = Sept 5), creating a separate Work Order for each row would set the **same** Expected Delivery Date on both Work Orders (whichever row happened to match first), instead of using the date from the row it was actually created for.
Support ticket reference: https://support.frappe.io/helpdesk/tickets/77043

## What changed

Work Order already knows exactly which Sales Order row it was created from. This fix uses that information to look up the correct row's Delivery Date, instead of only matching by item code (which can't tell two rows of the same item apart).

## Result

Each Work Order now correctly picks up the Delivery Date from its own Sales Order row.