### PR TITLE
fix: show cost center for unmatched payments in receivables

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -171,6 +171,7 @@ class ReceivablePayableReport:
 			party_account=ple.account,
 			posting_date=ple.posting_date,
 			account_currency=ple.account_currency,
+			cost_center=ple.cost_center,
 			remarks=ple.remarks,
 			invoiced=0.0,
 			paid=0.0,

--- a/erpnext/accounts/report/accounts_receivable/test_accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/test_accounts_receivable.py
@@ -1339,6 +1339,28 @@ class TestAccountsReceivable(ERPNextTestSuite, AccountsTestMixin):
 		row = report[1][0]
 		self.assertEqual(expected_data_after_payment, [row.voucher_no, row.cost_center, row.outstanding])
 
+	def test_cost_center_on_payment_before_invoice(self):
+		filters = {
+			"company": self.company,
+			"party_type": "Customer",
+			"party": [self.customer],
+			"report_date": today(),
+			"range": "30, 60, 90, 120",
+		}
+
+		si = self.create_sales_invoice(no_payment_schedule=True, do_not_submit=True)
+		si.posting_date = add_days(today(), 1)
+		si.due_date = si.posting_date
+		si.payment_schedule[0].due_date = si.posting_date
+		si.save().submit()
+
+		pe = self.create_payment_entry(si.name, do_not_submit=True)
+		pe.cost_center = self.cost_center
+		pe.save().submit()
+
+		row = next(row for row in execute(filters)[1] if row.voucher_no == pe.name)
+		self.assertEqual(row.cost_center, pe.cost_center)
+
 	def test_payment_terms_template_filters(self):
 		from erpnext.controllers.accounts_controller import get_payment_terms
 


### PR DESCRIPTION
Accounts Receivable omitted the cost center for Payment and Journal Entry rows built directly from Payment Ledger Entries when the linked invoice was outside the report date.

This copies the cost center from the Payment Ledger Entry into the report row.

### Before
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/6e5bd352-f1fb-452b-bf27-65f2e42affc5" />

### After
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/5f357042-1269-4134-be3f-fb57e4718873" />
