### PR TITLE
ci: use release token for crowdin translation push

### DIFF
--- a/.github/workflows/crowdin-actions-download-translations.yml
+++ b/.github/workflows/crowdin-actions-download-translations.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download translations and open PR
         uses: crowdin/github-action@8f01d54f70f1713ee3f09d82c2bbb2daeac28689 # v2.17.1


### PR DESCRIPTION
The scheduled translation download runs to completion but fails to push, so no translation PR is ever opened:

```
PUSH TO BRANCH l10n_crowdin_develop
[l10n_crowdin_develop f7284dfc5d] fix: sync translations from crowdin
 36 files changed, 94042 insertions(+), 22133 deletions(-)
remote: Permission to frappe/erpnext.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/frappe/erpnext.git/': The requested URL returned error: 403
```

### Cause

`actions/checkout` defaults to `persist-credentials: true`, which stores the default `GITHUB_TOKEN` in the repo config:

```
git config ... http.https://github.com/.extraheader AUTHORIZATION: basic ***
```

The Crowdin action pushes with the token embedded in the remote URL (`https://actor:$AUTH_TOKEN@github.com/...`), but git still sends the stored `extraheader`, and that takes precedence over credentials in the URL. So the push authenticates as `github-actions[bot]` instead of `RELEASE_TOKEN`, and the job's `GITHUB_TOKEN` is `contents: read`, hence the 403.

### Fix

Set `persist-credentials: false` on the checkout step so no credential is left in `.git/config` and the action's `RELEASE_TOKEN` is the one actually used. Documented upstream in [crowdin/github-action EXAMPLES.md](https://github.com/crowdin/github-action/blob/master/docs/EXAMPLES.md) (written for App tokens, but applies equally to a PAT passed via `GITHUB_TOKEN`).

Checkout still works without credentials since the repo is public.

Failing run: https://github.com/frappe/erpnext/actions/runs/32964650754/job/98164396660