### PR TITLE
fix(stock): guard serial batch editor grid lookup

### DIFF
--- a/erpnext/public/js/utils/serial_batch_inline_editor.js
+++ b/erpnext/public/js/utils/serial_batch_inline_editor.js
@@ -1276,7 +1276,7 @@ erpnext.stock.mount_serial_batch_inline_editor = async function (frm, cdt, cdn) 
 	let config = erpnext.stock.get_sbie_config(frm.doc.doctype, cdt);
 	if (!config || !frm.fields_dict[config.table]) return;
 
-	let grid_row = frm.fields_dict[config.table].grid.grid_rows_by_docname[cdn];
+	let grid_row = frm.fields_dict[config.table].grid?.grid_rows_by_docname?.[cdn];
 	let grid_form = grid_row && grid_row.grid_form;
 	if (!grid_form) return;
 


### PR DESCRIPTION
  ### Issue

-  While opening a Sales Invoice, some background validations or warning dialogs can delay the form from rendering completely.

-  During this delay, the serial and batch inline editor tries to access a row in the Items table before the table has finished initializing. Because the grid-row data is not available yet, the browser throws a JavaScript error.


  **Fixes** #58460

  ### Steps to reproduce

  1. Configure a condition that delays Sales Invoice form rendering, such as an active Accounting Dimension that triggers a “Fieldname Conflict” warning.
  2. Open or create a Sales Invoice.
  3. Open the browser console.
  4. During form setup, `use_serial_batch_fields` runs before the items grid has fully initialized.

  ### Actual behaviour

  The form setup throws an unhandled promise rejection because `grid_rows_by_docname` is not initialized:
  TypeError: frm.fields_dict[config.table].grid.grid_rows_by_docname is undefined

  This prevents the serial/batch inline editor handler from completing cleanly.

  ### Expected behaviour

  Sales Invoice should load without a console error when the child-table grid is still initializing.

  The serial/batch inline editor should safely return when the grid row is unavailable and mount later through the existing form_render event.