### PR TITLE
fix: clarify duplicate internal party messages

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -10,6 +10,7 @@ from frappe.contacts.address_and_contact import (
 	load_address_and_contact,
 )
 from frappe.model.naming import set_name_by_naming_series, set_name_from_naming_options
+from frappe.utils import get_link_to_form
 
 from erpnext.accounts.party import (
 	get_dashboard_info,
@@ -184,10 +185,15 @@ class Supplier(TransactionBase):
 		)
 
 		if internal_supplier:
+			internal_supplier_link = get_link_to_form("Supplier", internal_supplier)
 			frappe.throw(
-				_("Internal Supplier for company {0} already exists").format(
-					frappe.bold(self.represents_company)
-				)
+				_(
+					"Internal Supplier {0} already exists for {1}. Disable it to make this Supplier internal."
+				).format(
+					internal_supplier_link,
+					frappe.bold(self.represents_company),
+				),
+				title=_("Internal Supplier Already Exists"),
 			)
 
 	def create_primary_contact(self):

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -16,7 +16,7 @@ from frappe.model.naming import set_name_by_naming_series, set_name_from_naming_
 from frappe.model.utils.rename_doc import update_linked_doctypes
 from frappe.query_builder import CustomFunction, Field, functions
 from frappe.query_builder.functions import Cast, Coalesce, Max
-from frappe.utils import cint, cstr, flt, fmt_money, get_formatted_email, getdate, today
+from frappe.utils import cint, cstr, flt, fmt_money, get_formatted_email, get_link_to_form, getdate, today
 from frappe.utils.user import get_users_with_role
 
 from erpnext.accounts.party import (
@@ -266,10 +266,15 @@ class Customer(TransactionBase):
 		)
 
 		if internal_customer:
+			internal_customer_link = get_link_to_form("Customer", internal_customer)
 			frappe.throw(
-				_("Internal Customer for company {0} already exists").format(
-					frappe.bold(self.represents_company)
-				)
+				_(
+					"Internal Customer {0} already exists for {1}. Disable it to make this Customer internal."
+				).format(
+					internal_customer_link,
+					frappe.bold(self.represents_company),
+				),
+				title=_("Internal Customer Already Exists"),
 			)
 
 	def on_update(self):


### PR DESCRIPTION
 ### Issue

  When creating an internal Customer or Supplier, the validation message does not show which existing record is already internal for the company.

  ### Steps to reproduce

  1. Create an internal Customer or Supplier for a company.
  2. Create another Customer or Supplier.
  3. Select the same company and mark it as internal.
  4. Save the record.

  ### Actual behaviour

  The error says an internal Customer or Supplier already exists, but does not identify the existing record.

  ### Expected behaviour

  The error should show a clickable link to the existing internal Customer or Supplier and clearly tell the user to disable it.

**Backport Needed For V15 and V16**