### PR TITLE
feat: add Customer Group Explorer report

### DIFF
--- a/erpnext/selling/report/customer_group_explorer/customer_group_explorer.js
+++ b/erpnext/selling/report/customer_group_explorer/customer_group_explorer.js
@@ -1,0 +1,11 @@
+frappe.query_reports["Customer Group Explorer"] = {
+	filters: [
+		{
+			fieldname: "customer_group",
+			label: __("Customer Group"),
+			fieldtype: "Link",
+			options: "Customer Group",
+			description: __("Leave blank to explore every Customer Group from the top level down"),
+		},
+	],
+};

--- a/erpnext/selling/report/customer_group_explorer/customer_group_explorer.json
+++ b/erpnext/selling/report/customer_group_explorer/customer_group_explorer.json
@@ -1,0 +1,27 @@
+{
+ "add_total_row": 0,
+ "creation": "2026-08-26 12:00:00.000000",
+ "disable_prepared_report": 0,
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "idx": 0,
+ "is_standard": "Yes",
+ "modified": "2026-08-26 12:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Selling",
+ "name": "Customer Group Explorer",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Customer Group",
+ "report_name": "Customer Group Explorer",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "Sales User"
+  },
+  {
+   "role": "Sales Manager"
+  }
+ ]
+}

--- a/erpnext/selling/report/customer_group_explorer/customer_group_explorer.py
+++ b/erpnext/selling/report/customer_group_explorer/customer_group_explorer.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+
+import frappe
+from frappe import _
+
+
+def execute(filters=None):
+	filters = frappe._dict(filters or {})
+	columns = get_columns()
+	data = get_data(filters)
+	return columns, data
+
+
+def get_columns():
+	return [
+		{
+			"label": _("Customer Group / Customer"),
+			"fieldname": "name",
+			"fieldtype": "Dynamic Link",
+			"options": "entity_type",
+			"width": 300,
+		},
+		{
+			"label": _("Type"),
+			"fieldname": "entity_type",
+			"fieldtype": "Data",
+			"width": 120,
+		},
+		{
+			"label": _("Under Customer Group"),
+			"fieldname": "parent_customer_group",
+			"fieldtype": "Link",
+			"options": "Customer Group",
+			"width": 180,
+		},
+		{
+			"label": _("Territory"),
+			"fieldname": "territory",
+			"fieldtype": "Link",
+			"options": "Territory",
+			"width": 150,
+		},
+		{
+			"label": _("Level"),
+			"fieldname": "level",
+			"fieldtype": "Int",
+			"width": 70,
+		},
+		{
+			"label": _("Disabled"),
+			"fieldname": "disabled",
+			"fieldtype": "Check",
+			"width": 90,
+		},
+	]
+
+
+def get_data(filters):
+	children_map, groups_by_name, customers_by_group = fetch_customer_group_tree()
+
+	if filters.get("customer_group"):
+		root = groups_by_name.get(filters.customer_group)
+		roots = [root] if root else []
+	else:
+		roots = sorted(children_map.get("", []), key=lambda group: group.name)
+
+	data = []
+	for root in roots:
+		build_tree_rows(root, children_map, customers_by_group, data, indent=0)
+
+	return data
+
+
+def fetch_customer_group_tree():
+	"""Group every Customer Group by its parent, and every Customer by its
+	Customer Group, so the tree can be walked without repeated DB round-trips.
+
+	Uses `get_list` (not `get_all`) so that user permissions on Customer are
+	respected -- a Sales User restricted to specific customers must not see
+	customers outside their permitted scope in this report.
+	"""
+	customer_groups = frappe.get_list(
+		"Customer Group",
+		fields=["name", "parent_customer_group"],
+	)
+
+	children_map = {}
+	groups_by_name = {}
+	for group in customer_groups:
+		children_map.setdefault(group.parent_customer_group or "", []).append(group)
+		groups_by_name[group.name] = group
+
+	customers = frappe.get_list(
+		"Customer",
+		fields=["name", "customer_name", "customer_group", "territory", "disabled"],
+	)
+
+	customers_by_group = {}
+	for customer in customers:
+		customers_by_group.setdefault(customer.customer_group or "", []).append(customer)
+
+	return children_map, groups_by_name, customers_by_group
+
+
+def build_tree_rows(group, children_map, customers_by_group, data, indent):
+	data.append(
+		{
+			"name": group.name,
+			"entity_type": "Customer Group",
+			"parent_customer_group": group.parent_customer_group,
+			"territory": None,
+			"level": indent,
+			"indent": indent,
+			"disabled": None,
+		}
+	)
+
+	child_groups = sorted(children_map.get(group.name, []), key=lambda child: child.name)
+	for child_group in child_groups:
+		build_tree_rows(child_group, children_map, customers_by_group, data, indent + 1)
+
+	customers = sorted(
+		customers_by_group.get(group.name, []), key=lambda customer: customer.customer_name or customer.name
+	)
+	for customer in customers:
+		data.append(
+			{
+				"name": customer.name,
+				"entity_type": "Customer",
+				"parent_customer_group": customer.customer_group,
+				"territory": customer.territory,
+				"level": indent + 1,
+				"indent": indent + 1,
+				"disabled": customer.disabled,
+			}
+		)

--- a/erpnext/selling/report/customer_group_explorer/test_customer_group_explorer.py
+++ b/erpnext/selling/report/customer_group_explorer/test_customer_group_explorer.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+
+from erpnext.selling.report.customer_group_explorer.customer_group_explorer import build_tree_rows, execute
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+def create_customer_group(name, parent_customer_group, is_group):
+	if frappe.db.exists("Customer Group", name):
+		return frappe.get_doc("Customer Group", name)
+
+	doc = frappe.get_doc(
+		{
+			"doctype": "Customer Group",
+			"customer_group_name": name,
+			"parent_customer_group": parent_customer_group,
+			"is_group": is_group,
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc
+
+
+def create_customer(name, customer_group, territory=None):
+	if frappe.db.exists("Customer", name):
+		return frappe.get_doc("Customer", name)
+
+	doc = frappe.get_doc(
+		{
+			"doctype": "Customer",
+			"customer_name": name,
+			"customer_group": customer_group,
+			"territory": territory or "All Territories",
+			"customer_type": "Individual",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc
+
+
+class TestCustomerGroupExplorer(ERPNextTestSuite):
+	def setUp(self):
+		# root
+		#   |- child (org node, no direct customers)
+		#   |    |- grandchild (leaf) -> leaf_customer
+		#   |- root_leaf (leaf) -> root_customer
+		#
+		# Customers can only be linked to a leaf (is_group=0) Customer Group, so only
+		# `grandchild` and `root_leaf` hold customers directly, matching how real data
+		# is organized (organizational groups stay empty; only leaves hold customers).
+		self.root = create_customer_group("_Test Explorer Group Root", "All Customer Groups", is_group=1)
+		self.child = create_customer_group("_Test Explorer Group Child", self.root.name, is_group=1)
+		self.grandchild = create_customer_group("_Test Explorer Group Grandchild", self.child.name, is_group=0)
+		self.root_leaf = create_customer_group("_Test Explorer Group Root Leaf", self.root.name, is_group=0)
+
+		self.root_customer = create_customer("_Test Explorer Customer Root", self.root_leaf.name)
+		self.leaf_customer = create_customer("_Test Explorer Customer Leaf", self.grandchild.name)
+
+	def tearDown(self):
+		frappe.delete_doc("Customer", self.root_customer.name, force=True)
+		frappe.delete_doc("Customer", self.leaf_customer.name, force=True)
+		frappe.delete_doc("Customer Group", self.grandchild.name, force=True)
+		frappe.delete_doc("Customer Group", self.root_leaf.name, force=True)
+		frappe.delete_doc("Customer Group", self.child.name, force=True)
+		frappe.delete_doc("Customer Group", self.root.name, force=True)
+
+	def run_report(self, customer_group=None):
+		filters = frappe._dict({"customer_group": customer_group})
+		return execute(filters)[1]
+
+	def rows_by_name(self, data):
+		return {row["name"]: row for row in data}
+
+	def test_explores_full_hierarchy_from_selected_root(self):
+		data = self.run_report(self.root.name)
+		rows = self.rows_by_name(data)
+
+		self.assertIn(self.root.name, rows)
+		self.assertIn(self.child.name, rows)
+		self.assertIn(self.grandchild.name, rows)
+		self.assertIn(self.root_leaf.name, rows)
+		self.assertIn(self.root_customer.name, rows)
+		self.assertIn(self.leaf_customer.name, rows)
+
+		self.assertEqual(rows[self.root.name]["entity_type"], "Customer Group")
+		self.assertEqual(rows[self.root.name]["indent"], 0)
+
+		self.assertEqual(rows[self.child.name]["indent"], 1)
+		self.assertEqual(rows[self.grandchild.name]["indent"], 2)
+		self.assertEqual(rows[self.root_leaf.name]["indent"], 1)
+
+	def test_customer_sits_one_level_below_its_own_group(self):
+		data = self.run_report(self.root.name)
+		rows = self.rows_by_name(data)
+
+		# A customer linked to the root's direct leaf group is one level below that leaf.
+		self.assertEqual(rows[self.root_customer.name]["entity_type"], "Customer")
+		self.assertEqual(rows[self.root_customer.name]["indent"], 2)
+		self.assertEqual(rows[self.root_customer.name]["parent_customer_group"], self.root_leaf.name)
+
+		# A customer linked to the grandchild group sits one level below it, three deep overall.
+		self.assertEqual(rows[self.leaf_customer.name]["indent"], 3)
+		self.assertEqual(rows[self.leaf_customer.name]["parent_customer_group"], self.grandchild.name)
+
+	def test_blank_filter_starts_from_the_true_top_level_group(self):
+		# self.root is parented under "All Customer Groups" (the actual top-level node),
+		# so a blank filter shows that real root at indent 0 and self.root one level deeper.
+		data = self.run_report()
+		rows = self.rows_by_name(data)
+
+		self.assertIn("All Customer Groups", rows)
+		self.assertEqual(rows["All Customer Groups"]["indent"], 0)
+		self.assertIn(self.root.name, rows)
+		self.assertEqual(rows[self.root.name]["indent"], 1)
+
+	def test_build_tree_rows_walks_groups_and_customers(self):
+		children_map = {
+			"": [frappe._dict(name="root", parent_customer_group=None)],
+			"root": [frappe._dict(name="child", parent_customer_group="root")],
+		}
+		customers_by_group = {
+			"root": [
+				frappe._dict(name="cust-1", customer_name="Cust 1", customer_group="root", territory=None, disabled=0)
+			],
+			"child": [
+				frappe._dict(
+					name="cust-2", customer_name="Cust 2", customer_group="child", territory=None, disabled=0
+				)
+			],
+		}
+
+		data = []
+		build_tree_rows(children_map[""][0], children_map, customers_by_group, data, indent=0)
+
+		rows = self.rows_by_name(data)
+		self.assertEqual(rows["root"]["indent"], 0)
+		self.assertEqual(rows["child"]["indent"], 1)
+		# root's own customer is nested directly below it...
+		self.assertEqual(rows["cust-1"]["indent"], 1)
+		# ...while child's customer is nested below child, one level deeper again.
+		self.assertEqual(rows["cust-2"]["indent"], 2)


### PR DESCRIPTION
## Summary
- Adds a new **Customer Group Explorer** script report under Selling, following the same structure and pattern as the existing [BOM Explorer](erpnext/manufacturing/report/bom_explorer) report.
- Displays the complete hierarchy of Customer Groups, with the Customers linked to each group nested as leaves — e.g. `Reliance Industries → Reliance Jio → Reliance Jio MH → Reliance Jio Mumbai`.
- Like BOM Explorer, rows are flat dicts carrying an `indent` key, which the query report framework auto-detects to render an expandable/collapsible tree (no custom JS tree-rendering code needed).
- Filter: an optional `Customer Group` — leave it blank to explore every Customer Group from the top level down, or set it to scope the tree to one subtree.
- Columns: `Customer Group / Customer` (Dynamic Link, resolves to either doctype via an `entity_type` column), `Type`, `Under Customer Group`, `Territory`, `Level`, `Disabled`.
- Note: a Customer can only be linked to a leaf (non-group) Customer Group in ERPNext, so Customers only ever appear nested under leaf groups, never under purely organizational parent groups — the report and its tests account for this.
- Includes unit tests covering hierarchy traversal, indent/level correctness for both groups and customers, and the blank-filter (full-forest) case.

## Note on this revision
This supersedes #58445, which was closed for carrying unrelated `.github/workflows/*` diffs (it was branched off a newer `upstream/develop` while the fork's `develop` was stale). This branch is based directly on the fork's current `develop`, so it carries no workflow changes. It also fixes a permission gap flagged in review on the prior PR: `fetch_customer_group_tree()` now uses `frappe.get_list` instead of `frappe.get_all` for both Customer Group and Customer, so user permissions on Customer are respected — a Sales User restricted to specific customers will only see those customers in this report.

## Test plan
- [x] Verified report output via `bench console` against a hand-built test hierarchy (function-level correctness).
- [x] Verified visually in the browser: built a Reliance Industries / Reliance Jio / Reliance Retail example hierarchy matching the requested use case and confirmed the report renders the expected expandable tree.
- [x] `bench --site develop.localhost migrate` — registers the new Report doctype record, no errors.
- [x] `bench build --app erpnext` — succeeds.