### PR TITLE
fix(accounts): validate frozen accounts in period closing voucher

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -54,7 +54,7 @@ class PeriodClosingVoucher(AccountsController):
 		if for_cancellation and is_immutable_ledger_enabled():
 			posting_date = getdate()
 
-		check_freezing_date(posting_date, self.company)
+		check_freezing_date(posting_date)
 
 	def validate_start_and_end_date(self):
 		self.fy_start_date, self.fy_end_date = frappe.db.get_value(


### PR DESCRIPTION
### Issue

 - Period Closing Voucher passes the company to `check_freezing_date` as its second positional argument.

  - In version 15, the second argument is `adv_adj`. Because the company value is truthy, the frozen-accounts validation is skipped.

  Fixes #58446.

  ### Steps to reproduce

  1. Set **Accounts Frozen Till Date** to a future date.
  4. Submit the voucher.

  ### Actual behaviour

  The Period Closing Voucher is accepted because the frozen-accounts validation is skipped.

  ### Expected behaviour

  The Period Closing Voucher should be blocked when its period end date falls within the frozen accounting period.