### PR TITLE
fix(crm): enforce lead read permission when linking prospect

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -382,6 +382,9 @@ def get_lead_with_phone_number(number):
 
 @frappe.whitelist(methods=["POST"])
 def add_lead_to_prospect(lead: str, prospect: str):
+	if lead:
+		frappe.has_permission("Lead", "read", lead, throw=True)
+
 	prospect = frappe.get_doc("Prospect", prospect)
 	prospect.append("leads", {"lead": lead})
 	prospect.save()

--- a/erpnext/crm/doctype/prospect/test_prospect.py
+++ b/erpnext/crm/doctype/prospect/test_prospect.py
@@ -27,6 +27,30 @@ class TestProspect(ERPNextTestSuite):
 		address_doc.reload()
 		self.assertEqual(address_doc.has_link("Prospect", prospect_doc.name), True)
 
+	def test_add_lead_to_prospect_requires_lead_read_permission(self):
+		lead = make_lead()
+		prospect = make_prospect(company="_Test Company")
+		user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": f"lead-permission-{random_string(5)}@example.com",
+				"first_name": "Lead Permission Test",
+				"send_welcome_email": 0,
+			}
+		).insert()
+		frappe.share.add("Prospect", prospect.name, user.name, read=1, write=1)
+
+		self.assertTrue(frappe.has_permission("Prospect", "write", prospect.name, user=user.name))
+		self.assertFalse(frappe.has_permission("Lead", "read", lead.name, user=user.name))
+
+		self.addCleanup(frappe.set_user, "Administrator")
+		frappe.set_user(user.name)
+		with self.assertRaises(frappe.PermissionError):
+			add_lead_to_prospect(lead.name, prospect.name)
+
+		prospect.reload()
+		self.assertNotIn(lead.name, [row.lead for row in prospect.leads])
+
 	def test_make_customer_from_prospect(self):
 		from erpnext.crm.doctype.prospect.prospect import make_customer as make_customer_from_prospect
 


### PR DESCRIPTION
### Issue

  The `add_lead_to_prospect` endpoint allows callers to link a Lead without checking whether they can read that Lead.

  Credit to @pratheep-bit for reporting the issue and proposing the fix.


  Fixes #57578.

  ### Steps to reproduce

  1. Create a restricted Lead.
  2. Give a user write access to a Prospect but no read access to the Lead.
  3. Call `add_lead_to_prospect` with both records.

  ### Actual behaviour

  The restricted Lead is linked to the Prospect.

  ### Expected behaviour

  The endpoint should raise a permission error when the caller cannot read the Lead.

  ### Backport needed For V15 and V16.