### PR TITLE
fix(taxes): skip tax addition for invoice created from opening invoice tool

### DIFF
--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -297,6 +297,9 @@ def start_import(invoices):
 				invoice_number = d.invoice_number
 			doc = frappe.get_doc(d)
 			doc.flags.ignore_mandatory = True
+			# the outstanding amount is entered inclusive of tax, so taxes must not
+			# be added on top of it
+			doc.flags.dont_auto_add_taxes = True
 			doc.insert(set_name=invoice_number)
 			doc.submit()
 			if not frappe.in_test:

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
@@ -4,9 +4,11 @@
 import frappe
 from frappe.utils import add_days, today
 
+from erpnext.accounts.doctype.account.test_account import create_account
 from erpnext.accounts.doctype.opening_invoice_creation_tool.opening_invoice_creation_tool import (
 	get_temporary_opening_account,
 )
+from erpnext.accounts.doctype.tax_rule.test_tax_rule import make_tax_rule
 from erpnext.projects.doctype.project.test_project import make_project
 from erpnext.tests.utils import ERPNextTestSuite
 
@@ -125,6 +127,55 @@ class TestOpeningInvoiceCreationTool(ERPNextTestSuite):
 
 		for invoice in invoices:
 			self.assertEqual(frappe.db.get_value("Sales Invoice", invoice, "department"), "Sales - _TOIC")
+
+	@ERPNextTestSuite.change_settings(
+		"Accounts Settings",
+		{"add_taxes_from_taxes_and_charges_template": 1, "add_taxes_from_item_tax_template": 0},
+	)
+	def test_opening_invoice_creation_without_taxes(self):
+		company = "_Test Opening Invoice Company"
+		template = frappe.get_doc(
+			{
+				"doctype": "Sales Taxes and Charges Template",
+				"company": company,
+				"title": "_Test Opening Invoice Tax",
+				"taxes": [
+					{
+						"charge_type": "On Net Total",
+						"account_head": create_account(
+							account_name="_Test Opening Tax Account",
+							parent_account="Duties and Taxes - _TOIC",
+							account_type="Tax",
+							company=company,
+						),
+						"description": "Test taxes",
+						"rate": 9,
+					}
+				],
+			}
+		).insert()
+
+		# makes the template the default for the party, as it would be on a live site
+		make_tax_rule(tax_type="Sales", company=company, sales_tax_template=template.name, save=1)
+
+		tool = self.make_invoices(company=company, return_doc=True)
+		invoices = tool.make_invoices()
+		self.assertEqual(len(invoices), 2)
+
+		# outstanding amount is entered inclusive of tax, so taxes must not be added on top of it
+		for invoice in invoices:
+			si = frappe.get_doc("Sales Invoice", invoice)
+			self.assertFalse(si.taxes)
+			self.assertEqual(si.grand_total, 200)
+			self.assertEqual(si.outstanding_amount, 200)
+
+		# the same invoice created outside the tool keeps the default taxes,
+		# since adding them there is the user's decision
+		si = frappe.get_doc(tool.get_invoices()[0])
+		si.flags.ignore_mandatory = True
+		si.insert()
+		self.assertTrue(si.taxes)
+		self.assertEqual(si.grand_total, 218)
 
 	def test_opening_entry_project_linking(self):
 		doc = self.make_invoices(

--- a/erpnext/accounts/services/taxes.py
+++ b/erpnext/accounts/services/taxes.py
@@ -53,6 +53,11 @@ class TaxService:
 		if doc.get("taxes") or doc.get("is_pos"):
 			return
 
+		# set by the Opening Invoice Creation Tool, where the outstanding amount
+		# entered against a party is already inclusive of tax
+		if doc.flags.dont_auto_add_taxes:
+			return
+
 		if frappe.get_single_value(
 			"Accounts Settings", "add_taxes_from_taxes_and_charges_template"
 		) and hasattr(doc, "taxes_and_charges"):


### PR DESCRIPTION
Issue: While creating opening invoices, it automatically fetches the taxes part based on taxes and charge if setting is enabled in Account Settings.

- Opening entries are inclusive of taxes and do not require auto tax addition.
- Used a flag so that if someone wants to manually disable this for a specific transaction, they can.
 
<img width="1398" height="835" alt="image" src="https://github.com/user-attachments/assets/53b48f7b-df78-4e13-b3a0-8a7ad11f1340" />


Frappe Support Issue: https://support.frappe.io/desk/hd-ticket/76688