### PR TITLE
fix(projects): exclude cancelled invoices from timesheet portal

### DIFF
--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -411,18 +411,9 @@ class TestTimesheet(ERPNextTestSuite):
 		self.addCleanup(self._delete_if_exists, "Contact", contact.name)
 
 		si = create_sales_invoice(customer=customer)
-		project = frappe.get_doc(
-			{
-				"doctype": "Project",
-				"project_name": "_Test Timesheet Portal Project",
-				"customer": customer,
-				"company": "_Test Company",
-				"expected_start_date": nowdate(),
-			}
-		).insert()
 
 		employee = make_employee("_test_timesheet_portal@example.com", company="_Test Company")
-		timesheet = make_timesheet(employee, is_billable=0, project=project.name)
+		timesheet = make_timesheet(employee, is_billable=0)
 		frappe.db.set_value("Timesheet", timesheet.name, "sales_invoice", si.name)
 
 		rows = get_timesheets_list("Timesheet", None, {}, 0, 500)
@@ -430,12 +421,6 @@ class TestTimesheet(ERPNextTestSuite):
 		row = next((r for r in rows if r.name == timesheet.name), None)
 		self.assertIsNotNone(row, "billed timesheet not returned by portal list")
 		self.assertEqual(row.sales_invoice, si.name)
-
-		frappe.db.set_value("Timesheet", timesheet.name, "sales_invoice", None)
-		si.cancel()
-		frappe.db.set_value("Timesheet", timesheet.name, "sales_invoice", si.name)
-		rows = get_timesheets_list("Timesheet", None, {}, 0, 500)
-		self.assertNotIn(timesheet.name, [row.name for row in rows])
 
 	def test_get_activity_cost_falls_back_to_activity_type(self):
 		from erpnext.projects.doctype.timesheet.timesheet import get_activity_cost

--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -411,9 +411,18 @@ class TestTimesheet(ERPNextTestSuite):
 		self.addCleanup(self._delete_if_exists, "Contact", contact.name)
 
 		si = create_sales_invoice(customer=customer)
+		project = frappe.get_doc(
+			{
+				"doctype": "Project",
+				"project_name": "_Test Timesheet Portal Project",
+				"customer": customer,
+				"company": "_Test Company",
+				"expected_start_date": nowdate(),
+			}
+		).insert()
 
 		employee = make_employee("_test_timesheet_portal@example.com", company="_Test Company")
-		timesheet = make_timesheet(employee, is_billable=0)
+		timesheet = make_timesheet(employee, is_billable=0, project=project.name)
 		frappe.db.set_value("Timesheet", timesheet.name, "sales_invoice", si.name)
 
 		rows = get_timesheets_list("Timesheet", None, {}, 0, 500)
@@ -421,6 +430,12 @@ class TestTimesheet(ERPNextTestSuite):
 		row = next((r for r in rows if r.name == timesheet.name), None)
 		self.assertIsNotNone(row, "billed timesheet not returned by portal list")
 		self.assertEqual(row.sales_invoice, si.name)
+
+		frappe.db.set_value("Timesheet", timesheet.name, "sales_invoice", None)
+		si.cancel()
+		frappe.db.set_value("Timesheet", timesheet.name, "sales_invoice", si.name)
+		rows = get_timesheets_list("Timesheet", None, {}, 0, 500)
+		self.assertNotIn(timesheet.name, [row.name for row in rows])
 
 	def test_get_activity_cost_falls_back_to_activity_type(self):
 		from erpnext.projects.doctype.timesheet.timesheet import get_activity_cost

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -547,12 +547,17 @@ def get_timesheets_list(doctype, txt, filters, limit_start, limit_page_length=20
 		customer = contact.get_link_for("Customer")
 
 	if customer:
-		sales_invoices = frappe.get_all("Sales Invoice", filters={"customer": customer}, pluck="name")
+		customer_invoices = frappe.get_all(
+			"Sales Invoice", filters={"customer": customer}, fields=["name", "docstatus"]
+		)
+		sales_invoices = [invoice.name for invoice in customer_invoices if invoice.docstatus != 2]
+		cancelled_sales_invoices = [invoice.name for invoice in customer_invoices if invoice.docstatus == 2]
 		projects = frappe.get_all("Project", filters={"customer": customer}, pluck="name")
 
 		# Return timesheet related data to web portal.
 		table = frappe.qb.DocType("Timesheet")
 		child_table = frappe.qb.DocType("Timesheet Detail")
+		sales_invoice = Coalesce(table.sales_invoice, child_table.sales_invoice)
 		query = (
 			frappe.qb.from_(table)
 			.join(child_table)
@@ -562,7 +567,7 @@ def get_timesheets_list(doctype, txt, filters, limit_start, limit_page_length=20
 				child_table.activity_type,
 				table.status,
 				child_table.billing_hours,
-				Coalesce(table.sales_invoice, child_table.sales_invoice).as_("sales_invoice"),
+				sales_invoice.as_("sales_invoice"),
 				child_table.project,
 			)
 			.orderby(table.end_date)
@@ -580,6 +585,8 @@ def get_timesheets_list(doctype, txt, filters, limit_start, limit_page_length=20
 
 		if conditions:
 			query = query.where(frappe.qb.terms.Criterion.any(conditions))
+		if cancelled_sales_invoices:
+			query = query.where(sales_invoice.isnull() | sales_invoice.notin(cancelled_sales_invoices))
 
 		return query.run(as_dict=True)
 	else:

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -10,6 +10,7 @@ from frappe.model.document import Document
 from frappe.query_builder.functions import Coalesce, Concat, Date, Round
 from frappe.utils import flt, get_datetime, getdate
 from frappe.utils.deprecations import deprecated
+from pypika.terms import ExistsCriterion
 
 from erpnext.setup.utils import get_exchange_rate
 
@@ -547,17 +548,32 @@ def get_timesheets_list(doctype, txt, filters, limit_start, limit_page_length=20
 		customer = contact.get_link_for("Customer")
 
 	if customer:
-		customer_invoices = frappe.get_all(
-			"Sales Invoice", filters={"customer": customer}, fields=["name", "docstatus"]
+		sales_invoices = frappe.get_all(
+			"Sales Invoice",
+			filters={"customer": customer, "docstatus": ["!=", 2]},
+			pluck="name",
 		)
-		sales_invoices = [invoice.name for invoice in customer_invoices if invoice.docstatus != 2]
-		cancelled_sales_invoices = [invoice.name for invoice in customer_invoices if invoice.docstatus == 2]
 		projects = frappe.get_all("Project", filters={"customer": customer}, pluck="name")
+		if not (sales_invoices or projects):
+			return []
 
 		# Return timesheet related data to web portal.
 		table = frappe.qb.DocType("Timesheet")
 		child_table = frappe.qb.DocType("Timesheet Detail")
-		sales_invoice = Coalesce(table.sales_invoice, child_table.sales_invoice)
+		sales_invoice = frappe.qb.DocType("Sales Invoice")
+		cancelled_invoice_detail = frappe.qb.DocType("Timesheet Detail").as_("cancelled_invoice_detail")
+		cancelled_header_invoice_exists = ExistsCriterion(
+			frappe.qb.from_(sales_invoice)
+			.select(sales_invoice.name)
+			.where((sales_invoice.docstatus == 2) & (sales_invoice.name == table.sales_invoice))
+		)
+		cancelled_detail_invoice_exists = ExistsCriterion(
+			frappe.qb.from_(cancelled_invoice_detail)
+			.join(sales_invoice)
+			.on(sales_invoice.name == cancelled_invoice_detail.sales_invoice)
+			.select(cancelled_invoice_detail.name)
+			.where((cancelled_invoice_detail.parent == table.name) & (sales_invoice.docstatus == 2))
+		)
 		query = (
 			frappe.qb.from_(table)
 			.join(child_table)
@@ -567,7 +583,7 @@ def get_timesheets_list(doctype, txt, filters, limit_start, limit_page_length=20
 				child_table.activity_type,
 				table.status,
 				child_table.billing_hours,
-				sales_invoice.as_("sales_invoice"),
+				Coalesce(table.sales_invoice, child_table.sales_invoice).as_("sales_invoice"),
 				child_table.project,
 			)
 			.orderby(table.end_date)
@@ -583,12 +599,12 @@ def get_timesheets_list(doctype, txt, filters, limit_start, limit_page_length=20
 		if projects:
 			conditions.append(child_table.project.isin(projects))
 
-		if conditions:
-			query = query.where(frappe.qb.terms.Criterion.any(conditions))
-		if cancelled_sales_invoices:
-			query = query.where(sales_invoice.isnull() | sales_invoice.notin(cancelled_sales_invoices))
-
-		return query.run(as_dict=True)
+		return (
+			query.where(frappe.qb.terms.Criterion.any(conditions))
+			.where(cancelled_header_invoice_exists.negate())
+			.where(cancelled_detail_invoice_exists.negate())
+			.run(as_dict=True)
+		)
 	else:
 		return {}
 


### PR DESCRIPTION
### Issue

  The Timesheet portal query includes cancelled Sales Invoices when resolving invoices belonging to the portal customer. Consequently, Timesheets containing stale
  references to cancelled invoices can remain visible.


  **Fixes** #57577

  ### Steps to reproduce

  1. Create a Sales Invoice for a customer.
  2. Link a submitted Timesheet to the invoice.
  3. Cancel the invoice while retaining a stale Timesheet reference.
  4. Load the customer’s Timesheet portal list.

  ### Actual behaviour

  The Timesheet linked to the cancelled Sales Invoice appears in the portal.

  ### Expected behaviour

  Cancelled Sales Invoices should not be considered when filtering portal Timesheets.

  ### Backport needed v15 and v16.