### PR TITLE
refactor(stock): use db.count for the empty ledger check

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1949,7 +1949,7 @@ class update_entries_after:
 		if not item_code or not warehouse or (item_code, warehouse) in self.prev_sle_dict:
 			return
 
-		if frappe.db.exists(
+		if frappe.db.count(
 			"Stock Ledger Entry", {"item_code": item_code, "warehouse": warehouse, "is_cancelled": 0}
 		):
 			return


### PR DESCRIPTION
Follow-up to #58362. Same check, just using `frappe.db.count` instead of `frappe.db.exists` so this function reads the same on develop and on version-15-hotfix (#58434).