### PR TITLE
fix(selling): check sales order permission before work order creation

### DIFF
--- a/erpnext/selling/doctype/sales_order/mapper.py
+++ b/erpnext/selling/doctype/sales_order/mapper.py
@@ -875,6 +875,8 @@ def set_delivery_date(items: list, sales_order: str) -> None:
 @frappe.whitelist(methods=["POST"])
 def make_work_orders(items: str | dict, sales_order: str, company: str, project: str | None = None):
 	"""Make Work Orders against the given Sales Order for the given `items`"""
+	frappe.has_permission("Sales Order", "read", sales_order, throw=True)
+
 	items = frappe.parse_json(items).get("items")
 	out = []
 


### PR DESCRIPTION
 ### Issue

- A user who cannot access a Sales Order can still create Work Orders for it by calling the endpoint directly. This bypasses the Sales Order’s access permissions.

  **Fixes:**  #57576 

 **Steps to reproduce**

  1. Create a Sales Order.
  2. Log in as a Manufacturing User without access to that Sales Order.
  3. Call `make_work_orders` using the restricted Sales Order.

  ### Actual behaviour

 - Work Orders can be created without checking read permission on the Sales Order.

  ### Expected behaviour

 - The endpoint should reject the request unless the user has read permission on the specified Sales Order.

  ### Backport needed v15 and V16