### PR TITLE
fix(selling): check quotation write permission before marking lost

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -267,6 +267,8 @@ class Quotation(SellingController):
 	def declare_enquiry_lost(
 		self, lost_reasons_list: list, competitors: list, detailed_reason: str | None = None
 	):
+		self.check_permission("write")
+
 		if not (self.is_fully_ordered() or self.is_partially_ordered()):
 			get_lost_reasons = frappe.get_list("Quotation Lost Reason", fields=["name"])
 			lost_reasons_lst = [reason.get("name") for reason in get_lost_reasons]


### PR DESCRIPTION
### Issue

  A user without permission to edit a Quotation can call the endpoint that marks it as Lost. The endpoint starts changing the Quotation and related records before
  verifying write permission.

  Fixes #57575.

  ### Steps to reproduce

  1. Create a Quotation.
  2. Log in as a user who cannot edit that Quotation.
  3. Call `declare_enquiry_lost`.

  ### Actual behaviour

  The endpoint starts updating the Quotation before checking whether the user has write permission.

  ### Expected behaviour

  The endpoint should reject the request before making any changes when the user cannot edit the Quotation.

  ### Backport needed

 version-15 and version-16.