### PR TITLE
fix(manufacturing): preserve job card qty in mr transfer (backport #58482)

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -206,6 +206,43 @@ class TestJobCard(FrappeTestCase):
 		# transfer was made for 2 fg qty in first transfer Stock Entry
 		self.assertEqual(transfer_entry_2.fg_completed_qty, 0)
 
+	def test_material_request_stock_entry_uses_job_card_coverage(self):
+		from erpnext.stock.doctype.material_request.material_request import make_stock_entry
+
+		self.transfer_material_against = "Job Card"
+		self.source_warehouse = "Stores - _TC"
+		job_card = frappe.get_last_doc("Job Card", {"work_order": self.work_order.name})
+		mr = make_material_request(job_card.name)
+		mr.schedule_date = today()
+		for row in mr.items:
+			row.qty = flt(row.qty) / 2
+			row.stock_qty = flt(row.stock_qty) / 2
+		mr.submit()
+
+		stock_entry = make_stock_entry(mr.name)
+		self.assertEqual(stock_entry.fg_completed_qty, job_card.for_quantity / 2)
+
+		selected_row = mr.items[0]
+		try:
+			frappe.flags.selected_children = {"items": [selected_row.name]}
+			selected_stock_entry = make_stock_entry(mr.name)
+		finally:
+			frappe.flags.selected_children = None
+
+		self.assertEqual(
+			[row.job_card_item for row in selected_stock_entry.items], [selected_row.job_card_item]
+		)
+		self.assertEqual(selected_stock_entry.fg_completed_qty, 0)
+
+		for row in mr.items:
+			transferred_qty = flt(row.stock_qty) / 2
+			frappe.db.set_value("Job Card Item", row.job_card_item, "transferred_qty", transferred_qty)
+			frappe.db.set_value(row.doctype, row.name, "ordered_qty", transferred_qty)
+		mr.reload()
+
+		repeated_stock_entry = make_stock_entry(mr.name)
+		self.assertEqual(repeated_stock_entry.fg_completed_qty, job_card.for_quantity / 4)
+
 	@change_settings("Manufacturing Settings", {"job_card_excess_transfer": 1})
 	def test_job_card_excess_material_transfer(self):
 		"Test transferring more than required RM against Job Card."
@@ -616,6 +653,7 @@ class TestJobCard(FrappeTestCase):
 		self.assertEqual(ste.job_card, job_card_name)
 		self.assertEqual(ste.from_bom, 1.0)
 		self.assertEqual(ste.bom_no, work_order.bom_no)
+		self.assertEqual(ste.fg_completed_qty, frappe.get_value("Job Card", job_card_name, "for_quantity"))
 
 	def test_job_card_proccess_qty_and_completed_qty(self):
 		from erpnext.manufacturing.doctype.routing.test_routing import (

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -791,6 +791,8 @@ def make_stock_entry(source_name, target_doc=None):
 				target.fg_completed_qty = job_card_details[0].for_quantity
 				target.from_bom = 1
 
+			target.cap_completed_qty_to_material_coverage()
+
 	doclist = get_mapped_doc(
 		"Material Request",
 		source_name,

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1205,17 +1205,26 @@ class StockEntry(StockController):
 		if transfer_limit_qty < to_transfer_qty:
 			return
 
-		required_qty, transferred_qty = self._get_work_order_material_qty()
+		self.cap_completed_qty_to_material_coverage()
+
+	def cap_completed_qty_to_material_coverage(self):
+		required_qty, transferred_qty, target_qty, precision = self._get_material_coverage_data()
 		if not required_qty:
 			return
 
-		covered_before = self._get_covered_work_order_qty(required_qty, transferred_qty)
+		covered_before = self._get_covered_qty(required_qty, transferred_qty, target_qty, precision)
 		for row in self.items:
-			item_code = row.original_item or row.item_code
-			if row.s_warehouse and item_code in required_qty:
-				transferred_qty[item_code] += flt(row.qty) * flt(row.conversion_factor or 1)
+			if self.job_card:
+				material_reference = row.job_card_item
+				transferred = flt(row.qty)
+			else:
+				material_reference = row.original_item or row.item_code
+				transferred = flt(row.qty) * flt(row.conversion_factor or 1)
 
-		covered_after = self._get_covered_work_order_qty(required_qty, transferred_qty)
+			if material_reference in required_qty and (self.job_card or row.s_warehouse):
+				transferred_qty[material_reference] += transferred
+
+		covered_after = self._get_covered_qty(required_qty, transferred_qty, target_qty, precision)
 		covered_by_entry = flt(max(covered_after - covered_before, 0), self.precision("fg_completed_qty"))
 		self.fg_completed_qty = min(flt(self.fg_completed_qty), covered_by_entry)
 
@@ -1230,6 +1239,49 @@ class StockEntry(StockController):
 			return False
 		return not (self.pro_doc.operations and self.pro_doc.transfer_material_against == "Job Card")
 
+	def _get_material_coverage_data(self):
+		if self.job_card:
+			return self._get_job_card_material_qty()
+		return self._get_work_order_material_qty()
+
+	def _get_job_card_material_qty(self):
+		job_card = frappe.get_doc("Job Card", self.job_card)
+		required_qty = {}
+		transferred_qty = {}
+		for row in job_card.items:
+			if flt(row.required_qty) <= 0:
+				continue
+			required_qty[row.name] = flt(row.required_qty)
+			transferred_qty[row.name] = flt(row.transferred_qty)
+
+		return (
+			required_qty,
+			transferred_qty,
+			self._get_job_card_target_qty(job_card),
+			job_card.precision("required_qty", "items"),
+		)
+
+	def _get_job_card_target_qty(self, job_card):
+		required_by_item = {}
+		for row in job_card.items:
+			required_by_item[row.item_code] = required_by_item.get(row.item_code, 0.0) + flt(row.required_qty)
+
+		work_order_required_by_item = {}
+		work_order = frappe.get_doc("Work Order", job_card.work_order)
+		for row in work_order.required_items:
+			if job_card.operation != row.operation:
+				continue
+			work_order_required_by_item[row.item_code] = work_order_required_by_item.get(
+				row.item_code, 0.0
+			) + flt(row.required_qty)
+
+		target_qty = [
+			item_required * flt(work_order.qty) / work_order_required_by_item[item_code]
+			for item_code, item_required in required_by_item.items()
+			if work_order_required_by_item.get(item_code)
+		]
+		return min(target_qty) if target_qty else job_card.for_quantity
+
 	def _get_work_order_material_qty(self):
 		required_qty = {}
 		transferred_qty = {}
@@ -1241,15 +1293,20 @@ class StockEntry(StockController):
 			transferred_qty[row.item_code] = max(
 				transferred_qty.get(row.item_code, 0.0), flt(row.transferred_qty)
 			)
-		return required_qty, transferred_qty
+		return (
+			required_qty,
+			transferred_qty,
+			self.pro_doc.qty,
+			self.pro_doc.precision("required_qty", "required_items"),
+		)
 
-	def _get_covered_work_order_qty(self, required_qty, transferred_qty):
+	def _get_covered_qty(self, required_qty, transferred_qty, target_qty, precision):
 		min_fraction = get_minimum_material_coverage_fraction(
 			required_qty,
 			transferred_qty,
-			self.pro_doc.precision("required_qty", "required_items"),
+			precision,
 		)
-		return min_fraction * flt(self.pro_doc.qty)
+		return min_fraction * flt(target_qty)
 
 	def _validate_no_excess_transfer(self):
 		if self.is_return:


### PR DESCRIPTION
Backport of #58482 to version-15-hotfix.

## Problem

Material Request mapping assigns the full Job Card quantity when the request covers only part of the required material.

## Solution

Run the material coverage calculation after mapping the selected rows. Adapt the calculation to the legacy Stock Entry controller.

## Tests

- Ruff lint and formatting passed.
- The Python AST check passed.
- The focused test could not start because the shared PostgreSQL test site has duplicate legacy Employee fixtures.