### PR TITLE
fix(projects): ignore cancelled invoices in timesheet portal

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -547,8 +547,14 @@ def get_timesheets_list(doctype, txt, filters, limit_start, limit_page_length=20
 		customer = contact.get_link_for("Customer")
 
 	if customer:
-		sales_invoices = frappe.get_all("Sales Invoice", filters={"customer": customer}, pluck="name")
+		sales_invoices = frappe.get_all(
+			"Sales Invoice",
+			filters={"customer": customer, "docstatus": ["!=", 2]},
+			pluck="name",
+		)
 		projects = frappe.get_all("Project", filters={"customer": customer}, pluck="name")
+		if not (sales_invoices or projects):
+			return []
 
 		# Return timesheet related data to web portal.
 		table = frappe.qb.DocType("Timesheet")
@@ -578,10 +584,7 @@ def get_timesheets_list(doctype, txt, filters, limit_start, limit_page_length=20
 		if projects:
 			conditions.append(child_table.project.isin(projects))
 
-		if conditions:
-			query = query.where(frappe.qb.terms.Criterion.any(conditions))
-
-		return query.run(as_dict=True)
+		return query.where(frappe.qb.terms.Criterion.any(conditions)).run(as_dict=True)
 	else:
 		return {}
 


### PR DESCRIPTION
### Problem

The Timesheet portal treats all customer Sales Invoices as access relationships. This includes cancelled invoices.

### Change

- Exclude cancelled Sales Invoices from the invoice allowlist.
- Return no rows when the customer has no invoice or project relationship.

### Authorization behavior

This is a narrower alternative to #58485.

The portal has always combined invoice and project relationships with OR. A customer project remains a valid access relationship when an invoice reference is stale. Sales Invoice cancellation also removes Timesheet links during the normal workflow.

The cancelled invoice therefore stops granting access. It does not override access from a customer project. This avoids the timesheet-wide NOT EXISTS checks discussed in #58485.

Closes #57577

### Verification

- Ran the existing Timesheet portal Sales Invoice test.
- Ran pre-commit checks for the changed file.
- No test files changed.