### PR TITLE
fix(stock): preserve exchange gain loss journals in lcv

### DIFF
--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
@@ -442,7 +442,7 @@ class LandedCostVoucher(Document):
 			# update stock & gl entries for cancelled state of PR
 			doc.docstatus = 2
 			doc.update_stock_ledger(allow_negative_stock=True, via_landed_cost_voucher=True)
-			doc.make_gl_entries_on_cancel()
+			doc.make_gl_entries_on_cancel(from_repost=True)
 
 			# update stock & gl entries for submit state of PR
 			doc.docstatus = 1


### PR DESCRIPTION
  ### Issue

  Submitting a Landed Cost Voucher against a stock-updating Purchase Invoice cancels its linked exchange gain/loss Journal Entry.

  Fixes #57147

  ### Steps to reproduce

  1. Create a foreign-currency Purchase Invoice with Update Stock enabled.
  2. Make a payment using a different exchange rate so an exchange gain/loss Journal Entry is created.
  3. Submit a Landed Cost Voucher against the Purchase Invoice.

  ### Actual behaviour

  The linked exchange gain/loss Journal Entry is cancelled when the Landed Cost Voucher rebuilds the Purchase Invoice’s stock and accounting entries.

  ### Expected behaviour

  The exchange gain/loss Journal Entry should remain submitted because the Purchase Invoice itself was not cancelled.

  ### Backport needed for V15 and V16