### PR TITLE
fix(manufacturing): classify MRP items without a BOM as Purchase

### DIFF
--- a/erpnext/manufacturing/report/material_requirements_planning_report/material_requirements_planning_report.py
+++ b/erpnext/manufacturing/report/material_requirements_planning_report/material_requirements_planning_report.py
@@ -467,6 +467,8 @@ class MaterialRequirementsPlanningReport:
 					row.lead_time = math.ceil(row.required_qty / row.lead_time)
 				elif not row.required_qty:
 					row.lead_time = 0
+			else:
+				row.type_of_material = "Purchase"
 
 			if not row.lead_time and rm_details.raw_materials:
 				row.lead_time = self.get_lead_time_from_raw_materials(rm_details.raw_materials)


### PR DESCRIPTION
## Problem

In the Material Requirements Planning Report, `get_detailed_view_data` only set `type_of_material` when the item had raw materials:

```python
if rm_details.raw_materials:
    row.type_of_material = "Manufacture"
```

An item without a BOM got no `type_of_material` at all. Such a row:

- shows an empty "Type of Material" column in the report,
- is ignored by `make_order`, which dispatches on `"Purchase"` / `"Manufacture"`. Selecting the row and pressing "Make Purchase / Work Order" creates nothing and gives no explanation.

## Change

Add the missing `else` branch so an item without raw materials is classified as `Purchase`, the same rule the bucket view (`get_bucket_view_data`) already applies.

## Stack

Part 1 of 3, kept separate on purpose: this is the minimal fix, so it can be backported on its own. #58510 then replaces the rule with one based on `is_purchase_item`, and #58511 adds the BOM selection dialog. Both are larger than a backport should carry.
