### PR TITLE
fix: fetch accounts by company

### DIFF
--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -114,6 +114,7 @@ def execute(filters=None):
 				filters={
 					"account_type": row["account_type"],
 					"is_group": 0,
+					"company": filters.company,
 				},
 				pluck="name",
 			)


### PR DESCRIPTION
**Discription:**
In a multi-company setup, clicking any section row in the Cash Flow report (e.g. Net Change in Accounts Receivable / Payable / Inventory) drills down to General Ledger (or Accounts Payable / Accounts Receivable) with an account filter containing accounts from every company, not just the company selected in the Cash Flow report.
The target report then filters those accounts by the single selected company,  so most of the passed accounts return nothing and the user sees only a small subset of the expected accounts.

**Backport Needed v15 and v16**
