### PR TITLE
fix: Work Order picks wrong Delivery Date when Sales Order has the same item in multiple rows

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -248,7 +248,7 @@ class WorkOrder(Document):
 			PackedItem = frappe.qb.DocType("Packed Item")
 			ProductBundleItem = frappe.qb.DocType("Product Bundle Item")
 
-			so = (
+			so_query = (
 				frappe.qb.from_(SalesOrder)
 				.inner_join(SalesOrderItem)
 				.on(SalesOrderItem.parent == SalesOrder.name)
@@ -264,8 +264,12 @@ class WorkOrder(Document):
 						| (ProductBundleItem.item_code == production_item)
 					)
 				)
-				.run(as_dict=1)
 			)
+
+			if self.sales_order_item:
+				so_query = so_query.where(SalesOrderItem.name == self.sales_order_item)
+
+			so = so_query.run(as_dict=1)
 
 			if not so:
 				so = (


### PR DESCRIPTION
Backport of #58448 to `version-15-hotfix`.

### The problem
If a Sales Order lists the **same item more than once** — each row with its own delivery date — a Work Order made from one of those rows could pick up the delivery date from the **wrong row**.

Example: a Sales Order has "Item A" twice, one row due 10th Jan and another due 25th Jan. A Work Order created for the 25th Jan row could still show 10th Jan, so production gets planned against the wrong date.

### The fix
When the Work Order already knows exactly which Sales Order row it came from, it now looks up the delivery date from **that specific row** instead of just matching on the item code.

Behaviour is unchanged for Work Orders not tied to a specific Sales Order row.