### PR TITLE
feat: batch split operation to produce child batches per piece

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -1116,13 +1116,6 @@ frappe.ui.form.on("BOM", {
 							doc.qty = 1.0;
 							this.grid.set_value("qty", 1.0, doc);
 						},
-						get_query() {
-							return {
-								filters: {
-									name: ["!=", row.finished_good],
-								},
-							};
-						},
 					},
 					{
 						label: __("Qty"),

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -339,6 +339,7 @@ class BOM(WebsiteGenerator):
 		self.validate_uoms()
 		self.set_default_uom()
 		self.validate_semi_finished_goods()
+		self.validate_batch_split_operations()
 		self.validate_secondary_items()
 		self.set_fg_cost_allocation()
 		self.validate_total_cost_allocation()
@@ -394,6 +395,32 @@ class BOM(WebsiteGenerator):
 					"Only one operation can have 'Is Final Finished Good' checked when 'Track Semi Finished Goods' is enabled."
 				),
 			)
+
+	def validate_batch_split_operations(self):
+		for row in self.operations:
+			if not row.get("batch_split"):
+				continue
+
+			if not self.track_semi_finished_goods:
+				frappe.throw(
+					_(
+						"Row #{0}: Batch Split is only supported when 'Track Semi Finished Goods' is enabled."
+					).format(row.idx)
+				)
+
+			if flt(row.weight_per_piece) <= 0:
+				frappe.throw(
+					_("Row #{0}: Weight Per Piece is required for the Batch Split operation {1}.").format(
+						row.idx, bold(row.operation)
+					)
+				)
+
+			if row.finished_good and not frappe.get_cached_value("Item", row.finished_good, "has_batch_no"):
+				frappe.throw(
+					_(
+						"Row #{0}: The item {1} must have 'Has Batch No' enabled as the operation {2} is marked as Batch Split."
+					).format(row.idx, bold(row.finished_good), bold(row.operation))
+				)
 
 	def validate_secondary_items(self):
 		for item in self.secondary_items:

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -415,12 +415,16 @@ class BOM(WebsiteGenerator):
 					)
 				)
 
-			if row.finished_good and not frappe.get_cached_value("Item", row.finished_good, "has_batch_no"):
-				frappe.throw(
-					_(
-						"Row #{0}: The item {1} must have 'Has Batch No' enabled as the operation {2} is marked as Batch Split."
-					).format(row.idx, bold(row.finished_good), bold(row.operation))
+			if row.finished_good:
+				item_details = frappe.get_cached_value(
+					"Item", row.finished_good, ["has_batch_no", "create_new_batch"], as_dict=1
 				)
+				if not item_details.has_batch_no or not item_details.create_new_batch:
+					frappe.throw(
+						_(
+							"Row #{0}: The item {1} must have 'Has Batch No' and 'Automatically Create New Batch' enabled as the operation {2} is marked as Batch Split."
+						).format(row.idx, bold(row.finished_good), bold(row.operation))
+					)
 
 	def validate_secondary_items(self):
 		for item in self.secondary_items:

--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -315,7 +315,7 @@
   },
   {
    "depends_on": "eval:doc.batch_split",
-   "description": "Weight of one output piece, in the stock UOM of the consumed batch item",
+   "description": "Produced quantity is split into one batch per this many units of the finished good",
    "fieldname": "weight_per_piece",
    "fieldtype": "Float",
    "label": "Weight Per Piece",
@@ -327,7 +327,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-08-28 12:00:00.000000",
+ "modified": "2026-08-28 18:00:00.000000",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Operation",

--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -22,6 +22,8 @@
   "is_final_finished_good",
   "set_cost_based_on_bom_qty",
   "quality_inspection_required",
+  "batch_split",
+  "weight_per_piece",
   "warehouse_section",
   "skip_material_transfer",
   "backflush_from_wip_warehouse",
@@ -302,13 +304,30 @@
    "fieldname": "quality_inspection_required",
    "fieldtype": "Check",
    "label": "Quality Inspection Required"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:parent.track_semi_finished_goods === 1",
+   "description": "On completion of the Job Card, split the consumed batch into one child batch per finished piece",
+   "fieldname": "batch_split",
+   "fieldtype": "Check",
+   "label": "Batch Split"
+  },
+  {
+   "depends_on": "eval:doc.batch_split",
+   "description": "Weight of one output piece, in the stock UOM of the consumed batch item",
+   "fieldname": "weight_per_piece",
+   "fieldtype": "Float",
+   "label": "Weight Per Piece",
+   "mandatory_depends_on": "eval:doc.batch_split",
+   "non_negative": 1
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-08-08 12:00:00.000000",
+ "modified": "2026-08-28 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Operation",

--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.py
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.py
@@ -19,6 +19,7 @@ class BOMOperation(Document):
 		base_hour_rate: DF.Currency
 		base_operating_cost: DF.Currency
 		batch_size: DF.Float
+		batch_split: DF.Check
 		bom_no: DF.Link | None
 		cost_per_unit: DF.Float
 		description: DF.TextEditor | None
@@ -41,6 +42,7 @@ class BOMOperation(Document):
 		skip_material_transfer: DF.Check
 		source_warehouse: DF.Link | None
 		time_in_mins: DF.Float
+		weight_per_piece: DF.Float
 		wip_warehouse: DF.Link | None
 		workstation: DF.Link | None
 		workstation_type: DF.Link | None

--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -27,6 +27,8 @@
   "finished_good",
   "column_break_mcnb",
   "semi_fg_bom",
+  "batch_split",
+  "weight_per_piece",
   "section_break_folk",
   "pending_qty",
   "column_break_cyjw",
@@ -553,6 +555,20 @@
   },
   {
    "default": "0",
+   "fieldname": "batch_split",
+   "fieldtype": "Check",
+   "label": "Batch Split",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.batch_split",
+   "fieldname": "weight_per_piece",
+   "fieldtype": "Float",
+   "label": "Weight Per Piece",
+   "read_only": 1
+  },
+  {
+   "default": "0",
    "depends_on": "eval:!doc.is_corrective_job_card",
    "fieldname": "is_subcontracted",
    "fieldtype": "Check",
@@ -700,7 +716,7 @@
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-12 15:28:19.126628",
+ "modified": "2026-08-28 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card",

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -85,6 +85,7 @@ class JobCard(Document):
 		amended_from: DF.Link | None
 		backflush_from_wip_warehouse: DF.Check
 		barcode: DF.Barcode | None
+		batch_split: DF.Check
 		batch_no: DF.Link | None
 		bom_no: DF.Link | None
 		company: DF.Link
@@ -141,6 +142,7 @@ class JobCard(Document):
 		time_required: DF.Float
 		total_completed_qty: DF.Float
 		total_time_in_mins: DF.Float
+		weight_per_piece: DF.Float
 		track_semi_finished_goods: DF.Check
 		transferred_qty: DF.Float
 		wip_warehouse: DF.Link | None
@@ -1866,6 +1868,8 @@ class JobCard(Document):
 				"wip_warehouse": self.wip_warehouse,
 				"fg_warehouse": self.target_warehouse,
 				"bom_no": self.semi_fg_bom,
+				"batch_split": self.batch_split,
+				"weight_per_piece": self.weight_per_piece,
 				"project": frappe.db.get_value("Work Order", self.work_order, "project"),
 			}
 		)

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -1868,8 +1868,6 @@ class JobCard(Document):
 				"wip_warehouse": self.wip_warehouse,
 				"fg_warehouse": self.target_warehouse,
 				"bom_no": self.semi_fg_bom,
-				"batch_split": self.batch_split,
-				"weight_per_piece": self.weight_per_piece,
 				"project": frappe.db.get_value("Work Order", self.work_order, "project"),
 			}
 		)

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -1842,7 +1842,7 @@ class TestJobCard(ERPNextTestSuite):
 			with_operations=1,
 			track_semi_finished_goods=1,
 		)
-		fg_bom.append("items", {"item_code": rm, "qty": 10, "operation_row_id": 1})
+		fg_bom.append("items", {"item_code": rm, "qty": 1, "operation_row_id": 1})
 
 		operation = {
 			"operation": "Batch Split Op A",
@@ -1866,7 +1866,7 @@ class TestJobCard(ERPNextTestSuite):
 
 		work_order = make_wo_order_test_record(
 			item=fg,
-			qty=5,
+			qty=50,
 			source_warehouse=warehouse,
 			fg_warehouse=warehouse,
 			bom_no=fg_bom.name,
@@ -1889,7 +1889,7 @@ class TestJobCard(ERPNextTestSuite):
 
 		job_card.append(
 			"time_logs",
-			{"from_time": "2024-03-01 08:00:00", "to_time": "2024-03-01 09:00:00", "completed_qty": 5},
+			{"from_time": "2024-03-01 08:00:00", "to_time": "2024-03-01 09:00:00", "completed_qty": 50},
 		)
 		job_card.save()
 		job_card.submit()
@@ -1901,6 +1901,8 @@ class TestJobCard(ERPNextTestSuite):
 		self.assertEqual(flt(rm_row.transfer_qty), 50.0)
 
 		fg_row = next(row for row in manufacture_entry.items if row.item_code == fg)
+		self.assertEqual(flt(fg_row.transfer_qty), 50.0)
+
 		entries = frappe.get_all(
 			"Serial and Batch Entry",
 			filters={"parent": fg_row.serial_and_batch_bundle},
@@ -1909,7 +1911,7 @@ class TestJobCard(ERPNextTestSuite):
 
 		self.assertEqual(len(entries), 5)
 		for entry in entries:
-			self.assertEqual(flt(entry.qty), 1.0)
+			self.assertEqual(flt(entry.qty), 10.0)
 			self.assertTrue(entry.batch_no.startswith("BS-ROD-PC-"))
 			self.assertEqual(frappe.db.get_value("Batch", entry.batch_no, "parent_batch"), parent_batch)
 

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -1913,6 +1913,14 @@ class TestJobCard(ERPNextTestSuite):
 			self.assertTrue(entry.batch_no.startswith(parent_batch))
 			self.assertEqual(frappe.db.get_value("Batch", entry.batch_no, "parent_batch"), parent_batch)
 
+		manufacture_entry.reload()
+		manufacture_entry.cancel()
+
+		for entry in entries:
+			self.assertFalse(frappe.db.exists("Batch", entry.batch_no))
+
+		self.assertTrue(frappe.db.exists("Batch", parent_batch))
+
 	def test_semi_fg_pending_qty_is_left_to_another_job_card(self):
 		from erpnext.manufacturing.doctype.operation.test_operation import make_operation
 		from erpnext.stock.doctype.item.test_item import make_item

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -1910,23 +1910,15 @@ class TestJobCard(ERPNextTestSuite):
 		self.assertEqual(len(entries), 5)
 		for entry in entries:
 			self.assertEqual(flt(entry.qty), 1.0)
-			self.assertTrue(entry.batch_no.startswith(parent_batch))
+			self.assertTrue(entry.batch_no.startswith("BS-ROD-PC-"))
 			self.assertEqual(frappe.db.get_value("Batch", entry.batch_no, "parent_batch"), parent_batch)
 
-		fg_bundle = fg_row.serial_and_batch_bundle
 		manufacture_entry.reload()
 		manufacture_entry.cancel()
 
 		for entry in entries:
-			self.assertFalse(frappe.db.exists("Batch", entry.batch_no))
+			self.assertTrue(frappe.db.exists("Batch", entry.batch_no))
 
-		self.assertFalse(frappe.db.exists("Serial and Batch Bundle", fg_bundle))
-		self.assertFalse(
-			frappe.db.exists(
-				"Stock Ledger Entry",
-				{"voucher_no": manufacture_entry.name, "serial_and_batch_bundle": fg_bundle},
-			)
-		)
 		self.assertTrue(frappe.db.exists("Batch", parent_batch))
 
 	def test_semi_fg_pending_qty_is_left_to_another_job_card(self):

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -1796,6 +1796,123 @@ class TestJobCard(ERPNextTestSuite):
 			8,
 		)
 
+	def test_batch_split_operation_creates_child_batches(self):
+		from erpnext.manufacturing.doctype.operation.test_operation import make_operation
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle import (
+			get_batch_from_bundle,
+		)
+
+		original_value = frappe.db.get_single_value(
+			"Stock Settings", "auto_create_serial_and_batch_bundle_for_outward"
+		)
+		frappe.db.set_single_value("Stock Settings", "auto_create_serial_and_batch_bundle_for_outward", 1)
+		self.addCleanup(
+			frappe.db.set_single_value,
+			"Stock Settings",
+			"auto_create_serial_and_batch_bundle_for_outward",
+			original_value,
+		)
+
+		warehouse = "Stores - _TC"
+		rm = make_item(
+			"Batch Split Rod KG",
+			{
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "BS-ROD-KG-.####",
+			},
+		).name
+		fg = make_item(
+			"Batch Split Rod PC",
+			{
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "BS-ROD-PC-.####",
+			},
+		).name
+
+		fg_bom = frappe.new_doc(
+			"BOM",
+			company="_Test Company",
+			item=fg,
+			quantity=1,
+			with_operations=1,
+			track_semi_finished_goods=1,
+		)
+		fg_bom.append("items", {"item_code": rm, "qty": 10, "operation_row_id": 1})
+
+		operation = {
+			"operation": "Batch Split Op A",
+			"workstation": "_Test Workstation A",
+			"finished_good": fg,
+			"finished_good_qty": 1,
+			"is_final_finished_good": 1,
+			"sequence_id": 1,
+			"time_in_mins": 60,
+			"source_warehouse": warehouse,
+			"fg_warehouse": warehouse,
+			"skip_material_transfer": 1,
+			"batch_split": 1,
+			"weight_per_piece": 10,
+		}
+		make_workstation(operation)
+		make_operation(operation)
+		fg_bom.append("operations", operation)
+		fg_bom.insert()
+		fg_bom.submit()
+
+		work_order = make_wo_order_test_record(
+			item=fg,
+			qty=5,
+			source_warehouse=warehouse,
+			fg_warehouse=warehouse,
+			bom_no=fg_bom.name,
+			skip_transfer=1,
+			do_not_save=True,
+		)
+		work_order.save()
+		work_order.submit()
+
+		self.assertEqual(work_order.operations[0].batch_split, 1)
+		self.assertEqual(flt(work_order.operations[0].weight_per_piece), 10.0)
+
+		source_entry = make_stock_entry(item_code=rm, target=warehouse, qty=100, basic_rate=100)
+		parent_batch = get_batch_from_bundle(source_entry.items[0].serial_and_batch_bundle)
+
+		job_card = frappe.get_doc(
+			"Job Card", frappe.db.get_value("Job Card", {"work_order": work_order.name}, "name")
+		)
+		self.assertEqual(job_card.batch_split, 1)
+
+		job_card.append(
+			"time_logs",
+			{"from_time": "2024-03-01 08:00:00", "to_time": "2024-03-01 09:00:00", "completed_qty": 5},
+		)
+		job_card.save()
+		job_card.submit()
+
+		manufacture_entry = frappe.get_doc(job_card.make_stock_entry_for_semi_fg_item())
+		manufacture_entry.submit()
+
+		rm_row = next(row for row in manufacture_entry.items if row.item_code == rm)
+		self.assertEqual(flt(rm_row.transfer_qty), 50.0)
+
+		fg_row = next(row for row in manufacture_entry.items if row.item_code == fg)
+		entries = frappe.get_all(
+			"Serial and Batch Entry",
+			filters={"parent": fg_row.serial_and_batch_bundle},
+			fields=["batch_no", "qty"],
+		)
+
+		self.assertEqual(len(entries), 5)
+		for entry in entries:
+			self.assertEqual(flt(entry.qty), 1.0)
+			self.assertTrue(entry.batch_no.startswith(parent_batch))
+			self.assertEqual(frappe.db.get_value("Batch", entry.batch_no, "parent_batch"), parent_batch)
+
 	def test_semi_fg_pending_qty_is_left_to_another_job_card(self):
 		from erpnext.manufacturing.doctype.operation.test_operation import make_operation
 		from erpnext.stock.doctype.item.test_item import make_item

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -1913,12 +1913,20 @@ class TestJobCard(ERPNextTestSuite):
 			self.assertTrue(entry.batch_no.startswith(parent_batch))
 			self.assertEqual(frappe.db.get_value("Batch", entry.batch_no, "parent_batch"), parent_batch)
 
+		fg_bundle = fg_row.serial_and_batch_bundle
 		manufacture_entry.reload()
 		manufacture_entry.cancel()
 
 		for entry in entries:
 			self.assertFalse(frappe.db.exists("Batch", entry.batch_no))
 
+		self.assertFalse(frappe.db.exists("Serial and Batch Bundle", fg_bundle))
+		self.assertFalse(
+			frappe.db.exists(
+				"Stock Ledger Entry",
+				{"voucher_no": manufacture_entry.name, "serial_and_batch_bundle": fg_bundle},
+			)
+		)
 		self.assertTrue(frappe.db.exists("Batch", parent_batch))
 
 	def test_semi_fg_pending_qty_is_left_to_another_job_card(self):

--- a/erpnext/manufacturing/doctype/work_order/mapper.py
+++ b/erpnext/manufacturing/doctype/work_order/mapper.py
@@ -525,6 +525,8 @@ def _job_card_warehouse_values(work_order, row, qty):
 		"finished_good": row.get("finished_good"),
 		"semi_fg_bom": row.get("bom_no"),
 		"is_subcontracted": row.get("is_subcontracted"),
+		"batch_split": row.get("batch_split"),
+		"weight_per_piece": row.get("weight_per_piece"),
 	}
 
 

--- a/erpnext/manufacturing/doctype/work_order/services/operations.py
+++ b/erpnext/manufacturing/doctype/work_order/services/operations.py
@@ -52,6 +52,8 @@ _BOM_OPERATION_FIELDS = [
 	"backflush_from_wip_warehouse",
 	"set_cost_based_on_bom_qty",
 	"quality_inspection_required",
+	"batch_split",
+	"weight_per_piece",
 ]
 
 

--- a/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
+++ b/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
@@ -24,6 +24,8 @@
   "is_subcontracted",
   "skip_material_transfer",
   "backflush_from_wip_warehouse",
+  "batch_split",
+  "weight_per_piece",
   "column_break_vjih",
   "source_warehouse",
   "wip_warehouse",
@@ -301,6 +303,20 @@
   },
   {
    "default": "0",
+   "fieldname": "batch_split",
+   "fieldtype": "Check",
+   "label": "Batch Split",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.batch_split",
+   "fieldname": "weight_per_piece",
+   "fieldtype": "Float",
+   "label": "Weight Per Piece",
+   "read_only": 1
+  },
+  {
+   "default": "0",
    "fieldname": "quality_inspection_required",
    "fieldtype": "Check",
    "label": "Quality Inspection Required"
@@ -317,7 +333,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-05-25 17:15:12.038470",
+ "modified": "2026-08-28 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order Operation",

--- a/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.py
+++ b/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.py
@@ -20,6 +20,7 @@ class WorkOrderOperation(Document):
 		actual_start_time: DF.Datetime | None
 		backflush_from_wip_warehouse: DF.Check
 		batch_size: DF.Float
+		batch_split: DF.Check
 		bom: DF.Link | None
 		bom_no: DF.Link | None
 		completed_qty: DF.Float
@@ -43,6 +44,7 @@ class WorkOrderOperation(Document):
 		source_warehouse: DF.Link | None
 		status: DF.Literal["Pending", "Work in Progress", "Completed"]
 		time_in_mins: DF.Float
+		weight_per_piece: DF.Float
 		wip_warehouse: DF.Link | None
 		workstation: DF.Link | None
 		workstation_type: DF.Link | None

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -515,3 +515,4 @@ erpnext.patches.v16_0.recalculate_purchase_receipt_billing_status
 erpnext.patches.v16_0.recalculate_mixed_purchase_receipt_billing_status
 erpnext.patches.v16_0.repair_work_order_material_transfer
 erpnext.patches.v16_0.remove_frappe_crm_custom_fields
+erpnext.patches.v16_0.add_batch_split_stock_entry_type

--- a/erpnext/patches/v16_0/add_batch_split_stock_entry_type.py
+++ b/erpnext/patches/v16_0/add_batch_split_stock_entry_type.py
@@ -1,0 +1,8 @@
+import frappe
+
+
+def execute():
+	if not frappe.db.exists("Stock Entry Type", "Batch Split"):
+		frappe.new_doc("Stock Entry Type", purpose="Repack", batch_split=1).insert(
+			set_name="Batch Split", ignore_permissions=True
+		)

--- a/erpnext/setup/setup_wizard/operations/install_fixtures.py
+++ b/erpnext/setup/setup_wizard/operations/install_fixtures.py
@@ -99,6 +99,12 @@ def get_preset_records(country=None):
 			"purpose": "Repack",
 			"is_standard": 1,
 		},
+		{
+			"doctype": "Stock Entry Type",
+			"name": _("Batch Split"),
+			"purpose": "Repack",
+			"batch_split": 1,
+		},
 		{"doctype": "Stock Entry Type", "name": "Disassemble", "purpose": "Disassemble", "is_standard": 1},
 		{
 			"doctype": "Stock Entry Type",

--- a/erpnext/stock/doctype/batch/batch.js
+++ b/erpnext/stock/doctype/batch/batch.js
@@ -42,11 +42,16 @@ frappe.ui.form.on("Batch", {
 			return;
 		}
 
-		frappe.db.get_value("Batch", { parent_batch: frm.doc.name }, "name", (r) => {
-			if (r && r.name) {
-				frm.trigger("show_batch_split_tree_button");
+		frappe.db.get_value(
+			"Batch",
+			{ parent_batch: frm.doc.name, reference_name: ["is", "set"] },
+			"name",
+			(r) => {
+				if (r && r.name) {
+					frm.trigger("show_batch_split_tree_button");
+				}
 			}
-		});
+		);
 	},
 	show_batch_split_tree_button: (frm) => {
 		frm.add_custom_button(__("Batch Split Tree"), () => {

--- a/erpnext/stock/doctype/batch/batch.js
+++ b/erpnext/stock/doctype/batch/batch.js
@@ -21,6 +21,7 @@ frappe.ui.form.on("Batch", {
 				};
 				frappe.set_route("query-report", "Stock Ledger");
 			});
+			frm.trigger("add_batch_split_tree_button");
 			frm.trigger("make_dashboard");
 
 			frm.add_custom_button(__("Recalculate Batch Qty"), () => {
@@ -34,6 +35,26 @@ frappe.ui.form.on("Batch", {
 				});
 			});
 		}
+	},
+	add_batch_split_tree_button: (frm) => {
+		if (frm.doc.parent_batch) {
+			frm.trigger("show_batch_split_tree_button");
+			return;
+		}
+
+		frappe.db.get_value("Batch", { parent_batch: frm.doc.name }, "name", (r) => {
+			if (r && r.name) {
+				frm.trigger("show_batch_split_tree_button");
+			}
+		});
+	},
+	show_batch_split_tree_button: (frm) => {
+		frm.add_custom_button(__("Batch Split Tree"), () => {
+			frappe.route_options = {
+				batch: frm.doc.parent_batch || frm.doc.name,
+			};
+			frappe.set_route("query-report", "Batch Split Tree");
+		});
 	},
 	item: (frm) => {
 		// frappe.db.get_value('Item', {name: frm.doc.item}, 'has_expiry_date', (r) => {

--- a/erpnext/stock/doctype/stock_entry/services/batch_split.py
+++ b/erpnext/stock/doctype/stock_entry/services/batch_split.py
@@ -64,10 +64,13 @@ class BatchSplitFinishedGood:
 				).format(row.idx, row.item_code)
 			)
 
-		if not frappe.get_cached_value("Item", row.item_code, "has_batch_no"):
+		item_details = frappe.get_cached_value(
+			"Item", row.item_code, ["has_batch_no", "create_new_batch"], as_dict=1
+		)
+		if not item_details.has_batch_no or not item_details.create_new_batch:
 			frappe.throw(
 				_(
-					"Row #{0}: The item {1} must have 'Has Batch No' enabled for the Batch Split operation."
+					"Row #{0}: The item {1} must have 'Has Batch No' and 'Automatically Create New Batch' enabled for the Batch Split operation."
 				).format(row.idx, row.item_code)
 			)
 
@@ -202,44 +205,21 @@ class BatchSplitFinishedGood:
 
 	def make_child_batches(self, fg_row, parent_batches):
 		batches = frappe._dict()
-		next_index = {}
 		for parent_batch in parent_batches:
-			batch_no = self.insert_child_batch(fg_row, parent_batch, next_index)
+			batch_no = make_batch(
+				frappe._dict(
+					{
+						"item": fg_row.item_code,
+						"parent_batch": parent_batch,
+						"reference_doctype": self.doc.doctype,
+						"reference_name": self.doc.name,
+					}
+				)
+			)
+
 			batches[batch_no] = 1
 
 		return batches
-
-	def insert_child_batch(self, fg_row, parent_batch, next_index):
-		index = next_index.get(parent_batch) or cint(frappe.db.count("Batch", {"parent_batch": parent_batch}))
-
-		while True:
-			index += 1
-			batch_id = f"{parent_batch}-{index}"
-			if frappe.db.exists("Batch", batch_id):
-				continue
-
-			frappe.db.savepoint("insert_child_batch")
-			try:
-				batch_no = self.make_child_batch(fg_row, parent_batch, batch_id)
-			except frappe.DuplicateEntryError:
-				frappe.db.rollback(save_point="insert_child_batch")
-				continue
-
-			next_index[parent_batch] = index
-			return batch_no
-
-	def make_child_batch(self, fg_row, parent_batch, batch_id):
-		return make_batch(
-			frappe._dict(
-				{
-					"item": fg_row.item_code,
-					"parent_batch": parent_batch,
-					"batch_id": batch_id,
-					"reference_doctype": self.doc.doctype,
-					"reference_name": self.doc.name,
-				}
-			)
-		)
 
 	def attach_bundle(self, fg_row, batches):
 		bundle = SerialBatchCreation(
@@ -260,99 +240,3 @@ class BatchSplitFinishedGood:
 		fg_row.serial_and_batch_bundle = bundle.name
 		fg_row.use_serial_batch_fields = 0
 		fg_row.batch_no = None
-
-
-def get_minted_child_batches(doc):
-	return frappe.get_all(
-		"Batch",
-		filters={
-			"reference_doctype": doc.doctype,
-			"reference_name": doc.name,
-			"parent_batch": ("is", "set"),
-		},
-		pluck="name",
-	)
-
-
-def delete_unused_child_batches(doc):
-	minted_batches = set(doc.flags.get("batch_split_child_batches") or [])
-	if not minted_batches:
-		return
-
-	own_bundles = set(
-		frappe.get_all(
-			"Serial and Batch Bundle",
-			filters={"voucher_type": doc.doctype, "voucher_no": doc.name},
-			pluck="name",
-		)
-	)
-
-	for bundle_name, batch_nos in get_bundle_wise_child_batches(doc).items():
-		if not set(batch_nos).issubset(minted_batches):
-			continue
-
-		if any(is_batch_used_outside(batch_no, own_bundles) for batch_no in batch_nos):
-			continue
-
-		delete_child_bundle(doc, bundle_name)
-		for batch_no in batch_nos:
-			frappe.delete_doc("Batch", batch_no, force=True, ignore_permissions=True)
-
-
-def delete_child_bundle(doc, bundle_name):
-	sle = frappe.qb.DocType("Stock Ledger Entry")
-	(
-		frappe.qb.update(sle)
-		.set(sle.serial_and_batch_bundle, None)
-		.where(
-			(sle.voucher_type == doc.doctype)
-			& (sle.voucher_no == doc.name)
-			& (sle.serial_and_batch_bundle == bundle_name)
-		)
-	).run()
-
-	frappe.delete_doc("Serial and Batch Bundle", bundle_name, force=True, ignore_permissions=True)
-
-
-def is_batch_used_outside(batch_no, own_bundles):
-	from frappe.model.delete_doc import get_dynamic_linked_docs, get_linked_docs
-
-	batch_doc = frappe.get_doc("Batch", batch_no)
-	for link in get_linked_docs(batch_doc) + get_dynamic_linked_docs(batch_doc):
-		if (
-			link["reference_doctype"] == "Serial and Batch Bundle"
-			and link["reference_docname"] in own_bundles
-		):
-			continue
-
-		return True
-
-	return False
-
-
-def get_bundle_wise_child_batches(doc):
-	bundle = frappe.qb.DocType("Serial and Batch Bundle")
-	entry = frappe.qb.DocType("Serial and Batch Entry")
-	batch = frappe.qb.DocType("Batch")
-
-	data = (
-		frappe.qb.from_(bundle)
-		.inner_join(entry)
-		.on(entry.parent == bundle.name)
-		.inner_join(batch)
-		.on(batch.name == entry.batch_no)
-		.select(bundle.name.as_("bundle_name"), batch.name.as_("batch_no"))
-		.distinct()
-		.where(
-			(bundle.voucher_type == doc.doctype)
-			& (bundle.voucher_no == doc.name)
-			& (bundle.type_of_transaction == "Inward")
-			& (batch.parent_batch.isnotnull())
-		)
-	).run(as_dict=True)
-
-	bundle_wise_batches = {}
-	for row in data:
-		bundle_wise_batches.setdefault(row.bundle_name, []).append(row.batch_no)
-
-	return bundle_wise_batches

--- a/erpnext/stock/doctype/stock_entry/services/batch_split.py
+++ b/erpnext/stock/doctype/stock_entry/services/batch_split.py
@@ -262,7 +262,23 @@ class BatchSplitFinishedGood:
 		fg_row.batch_no = None
 
 
+def get_minted_child_batches(doc):
+	return frappe.get_all(
+		"Batch",
+		filters={
+			"reference_doctype": doc.doctype,
+			"reference_name": doc.name,
+			"parent_batch": ("is", "set"),
+		},
+		pluck="name",
+	)
+
+
 def delete_unused_child_batches(doc):
+	minted_batches = set(doc.flags.get("batch_split_child_batches") or [])
+	if not minted_batches:
+		return
+
 	own_bundles = set(
 		frappe.get_all(
 			"Serial and Batch Bundle",
@@ -272,6 +288,9 @@ def delete_unused_child_batches(doc):
 	)
 
 	for bundle_name, batch_nos in get_bundle_wise_child_batches(doc).items():
+		if not set(batch_nos).issubset(minted_batches):
+			continue
+
 		if any(is_batch_used_outside(batch_no, own_bundles) for batch_no in batch_nos):
 			continue
 

--- a/erpnext/stock/doctype/stock_entry/services/batch_split.py
+++ b/erpnext/stock/doctype/stock_entry/services/batch_split.py
@@ -1,0 +1,212 @@
+import frappe
+from frappe import _
+from frappe.utils import cint, flt
+
+from erpnext.stock.doctype.batch.batch import get_available_batches, make_batch
+from erpnext.stock.serial_batch_bundle import SerialBatchCreation
+from erpnext.stock.utils import get_combine_datetime
+
+
+class BatchSplitFinishedGood:
+	def __init__(self, doc):
+		self.doc = doc
+
+	def process(self):
+		if not self.is_applicable():
+			return
+
+		fg_row = self.get_finished_good_row()
+		pieces = self.get_pieces(fg_row)
+		input_batches = self.get_input_batches()
+		self.set_weight_per_piece(input_batches, pieces)
+		parent_batches = self.get_parent_batches(input_batches, pieces)
+		child_batches = self.make_child_batches(fg_row, parent_batches)
+		self.attach_bundle(fg_row, child_batches)
+
+	def is_applicable(self):
+		self.weight_per_piece = 0.0
+		if self.doc.purpose == "Repack":
+			return self.doc.stock_entry_type and cint(
+				frappe.get_cached_value("Stock Entry Type", self.doc.stock_entry_type, "batch_split")
+			)
+
+		if self.doc.purpose != "Manufacture" or not self.doc.job_card:
+			return False
+
+		details = frappe.db.get_value(
+			"Job Card", self.doc.job_card, ["batch_split", "weight_per_piece"], as_dict=1
+		)
+
+		self.weight_per_piece = flt(details.weight_per_piece)
+		return cint(details.batch_split) and self.weight_per_piece > 0
+
+	def set_weight_per_piece(self, input_batches, pieces):
+		if not self.weight_per_piece:
+			self.weight_per_piece = sum(flt(qty) for _batch_no, qty in input_batches) / pieces
+
+	def get_finished_good_row(self):
+		fg_rows = [
+			row
+			for row in self.doc.items
+			if row.is_finished_item and not row.secondary_item_type and not row.is_legacy_scrap_item
+		]
+
+		if len(fg_rows) != 1:
+			frappe.throw(
+				_("The Batch Split entry {0} must have exactly one finished good row.").format(self.doc.name)
+			)
+
+		row = fg_rows[0]
+		if row.serial_and_batch_bundle:
+			frappe.throw(
+				_(
+					"Row #{0}: Remove the Serial and Batch Bundle as the batches for the Batch Split item {1} are created automatically."
+				).format(row.idx, row.item_code)
+			)
+
+		if not frappe.get_cached_value("Item", row.item_code, "has_batch_no"):
+			frappe.throw(
+				_(
+					"Row #{0}: The item {1} must have 'Has Batch No' enabled for the Batch Split operation."
+				).format(row.idx, row.item_code)
+			)
+
+		return row
+
+	def get_pieces(self, fg_row):
+		pieces = flt(fg_row.transfer_qty)
+		if pieces <= 0 or pieces != cint(pieces):
+			frappe.throw(
+				_(
+					"Row #{0}: The quantity {1} of the Batch Split item {2} must be a whole number of pieces."
+				).format(fg_row.idx, pieces, fg_row.item_code)
+			)
+
+		return cint(pieces)
+
+	def get_input_batches(self):
+		batches = []
+		for row in self.doc.items:
+			if row.is_finished_item or not row.s_warehouse:
+				continue
+
+			if row.secondary_item_type or row.is_legacy_scrap_item:
+				continue
+
+			if not frappe.get_cached_value("Item", row.item_code, "has_batch_no"):
+				continue
+
+			batches.extend(self.get_row_batches(row))
+
+		if not batches:
+			frappe.throw(
+				_(
+					"The Batch Split operation requires a batch tracked raw material to be consumed in the Stock Entry {0}."
+				).format(self.doc.name)
+			)
+
+		return batches
+
+	def get_row_batches(self, row):
+		if row.serial_and_batch_bundle:
+			entries = frappe.get_all(
+				"Serial and Batch Entry",
+				filters={"parent": row.serial_and_batch_bundle, "batch_no": ("is", "set")},
+				fields=["batch_no", "qty"],
+				order_by="idx",
+			)
+
+			return [(d.batch_no, abs(flt(d.qty))) for d in entries]
+
+		if row.batch_no:
+			return [(row.batch_no, flt(row.transfer_qty))]
+
+		return self.get_available_row_batches(row)
+
+	def get_available_row_batches(self, row):
+		available = get_available_batches(
+			frappe._dict(
+				{
+					"item_code": row.item_code,
+					"warehouse": row.s_warehouse,
+					"posting_datetime": get_combine_datetime(self.doc.posting_date, self.doc.posting_time),
+					"based_on": frappe.get_single_value("Stock Settings", "pick_serial_and_batch_based_on"),
+				}
+			)
+		)
+
+		batches = []
+		remaining = flt(row.transfer_qty)
+		for batch_no, qty in available.items():
+			if remaining <= 0:
+				break
+
+			if flt(qty) <= 0:
+				continue
+
+			taken = min(flt(qty), remaining)
+			batches.append((batch_no, taken))
+			remaining -= taken
+
+		return batches
+
+	def get_parent_batches(self, input_batches, pieces):
+		parents = []
+		pool = [[batch_no, flt(qty)] for batch_no, qty in input_batches]
+		index = 0
+
+		for _piece in range(pieces):
+			while index < len(pool) - 1 and pool[index][1] < self.weight_per_piece / 2:
+				index += 1
+
+			parents.append(pool[index][0])
+			pool[index][1] -= self.weight_per_piece
+
+		return parents
+
+	def make_child_batches(self, fg_row, parent_batches):
+		batches = frappe._dict()
+		for parent_batch in parent_batches:
+			batch_no = make_batch(
+				frappe._dict(
+					{
+						"item": fg_row.item_code,
+						"parent_batch": parent_batch,
+						"batch_id": self.get_child_batch_id(parent_batch),
+						"reference_doctype": self.doc.doctype,
+						"reference_name": self.doc.name,
+					}
+				)
+			)
+
+			batches[batch_no] = 1
+
+		return batches
+
+	def get_child_batch_id(self, parent_batch):
+		index = cint(frappe.db.count("Batch", {"parent_batch": parent_batch}))
+		while True:
+			index += 1
+			batch_id = f"{parent_batch}-{index}"
+			if not frappe.db.exists("Batch", batch_id):
+				return batch_id
+
+	def attach_bundle(self, fg_row, batches):
+		bundle = SerialBatchCreation(
+			{
+				"item_code": fg_row.item_code,
+				"warehouse": fg_row.t_warehouse,
+				"posting_datetime": get_combine_datetime(self.doc.posting_date, self.doc.posting_time),
+				"voucher_type": self.doc.doctype,
+				"voucher_detail_no": fg_row.name,
+				"qty": sum(batches.values()),
+				"batches": batches,
+				"type_of_transaction": "Inward",
+				"company": self.doc.company,
+				"do_not_submit": True,
+			}
+		).make_serial_and_batch_bundle()
+
+		fg_row.serial_and_batch_bundle = bundle.name
+		fg_row.use_serial_batch_fields = 0
+		fg_row.batch_no = None

--- a/erpnext/stock/doctype/stock_entry/services/batch_split.py
+++ b/erpnext/stock/doctype/stock_entry/services/batch_split.py
@@ -177,22 +177,21 @@ class BatchSplitFinishedGood:
 		return batches
 
 	def get_parent_batches(self, input_batches, pieces):
-		pool = [[batch_no, flt(qty)] for batch_no, qty in input_batches if flt(qty) > 0]
+		pool = [(batch_no, flt(qty)) for batch_no, qty in input_batches if flt(qty) > 0]
 		if not pool:
-			pool = [[input_batches[0][0], 0.0]]
+			return [input_batches[0][0]] * pieces
 
-		precision = frappe.get_precision("Serial and Batch Entry", "qty")
+		total_qty = sum(qty for _, qty in pool)
+		shares = [pieces * qty / total_qty for _, qty in pool]
+		counts = [int(share) for share in shares]
+
+		remainders = sorted(range(len(pool)), key=lambda i: (counts[i] - shares[i], i))
+		for index in remainders[: pieces - sum(counts)]:
+			counts[index] += 1
+
 		parents = []
-		index = 0
-
-		for _piece in range(pieces):
-			while index < len(pool) - 1 and flt(pool[index][1], precision) < flt(
-				self.weight_per_piece, precision
-			):
-				index += 1
-
-			parents.append(pool[index][0])
-			pool[index][1] -= self.weight_per_piece
+		for (batch_no, _qty), count in zip(pool, counts, strict=False):
+			parents.extend([batch_no] * count)
 
 		return parents
 

--- a/erpnext/stock/doctype/stock_entry/services/batch_split.py
+++ b/erpnext/stock/doctype/stock_entry/services/batch_split.py
@@ -271,9 +271,29 @@ def delete_unused_child_batches(doc):
 		)
 	)
 
-	for batch_no in get_child_batches(doc):
-		if not is_batch_used_outside(batch_no, own_bundles):
+	for bundle_name, batch_nos in get_bundle_wise_child_batches(doc).items():
+		deletable = [batch_no for batch_no in batch_nos if not is_batch_used_outside(batch_no, own_bundles)]
+
+		if len(deletable) == len(batch_nos):
+			delete_child_bundle(doc, bundle_name)
+
+		for batch_no in deletable:
 			frappe.delete_doc("Batch", batch_no, force=True, ignore_permissions=True)
+
+
+def delete_child_bundle(doc, bundle_name):
+	sle = frappe.qb.DocType("Stock Ledger Entry")
+	(
+		frappe.qb.update(sle)
+		.set(sle.serial_and_batch_bundle, None)
+		.where(
+			(sle.voucher_type == doc.doctype)
+			& (sle.voucher_no == doc.name)
+			& (sle.serial_and_batch_bundle == bundle_name)
+		)
+	).run()
+
+	frappe.delete_doc("Serial and Batch Bundle", bundle_name, force=True, ignore_permissions=True)
 
 
 def is_batch_used_outside(batch_no, own_bundles):
@@ -292,18 +312,18 @@ def is_batch_used_outside(batch_no, own_bundles):
 	return False
 
 
-def get_child_batches(doc):
+def get_bundle_wise_child_batches(doc):
 	bundle = frappe.qb.DocType("Serial and Batch Bundle")
 	entry = frappe.qb.DocType("Serial and Batch Entry")
 	batch = frappe.qb.DocType("Batch")
 
-	return (
+	data = (
 		frappe.qb.from_(bundle)
 		.inner_join(entry)
 		.on(entry.parent == bundle.name)
 		.inner_join(batch)
 		.on(batch.name == entry.batch_no)
-		.select(batch.name)
+		.select(bundle.name.as_("bundle_name"), batch.name.as_("batch_no"))
 		.distinct()
 		.where(
 			(bundle.voucher_type == doc.doctype)
@@ -311,4 +331,10 @@ def get_child_batches(doc):
 			& (bundle.type_of_transaction == "Inward")
 			& (batch.parent_batch.isnotnull())
 		)
-	).run(pluck=True)
+	).run(as_dict=True)
+
+	bundle_wise_batches = {}
+	for row in data:
+		bundle_wise_batches.setdefault(row.bundle_name, []).append(row.batch_no)
+
+	return bundle_wise_batches

--- a/erpnext/stock/doctype/stock_entry/services/batch_split.py
+++ b/erpnext/stock/doctype/stock_entry/services/batch_split.py
@@ -172,36 +172,23 @@ class BatchSplitFinishedGood:
 
 	def get_parent_batches(self, input_batches, pieces):
 		pool = [[batch_no, flt(qty)] for batch_no, qty in input_batches if flt(qty) > 0]
+		if not pool:
+			pool = [[input_batches[0][0], 0.0]]
+
 		precision = frappe.get_precision("Serial and Batch Entry", "qty")
 		parents = []
 		index = 0
 
 		for _piece in range(pieces):
-			shares = {}
-			remaining = self.weight_per_piece
-			while remaining > 0 and index < len(pool):
-				taken = min(pool[index][1], remaining)
-				if taken > 0:
-					shares[pool[index][0]] = flt(shares.get(pool[index][0], 0.0) + taken, precision)
+			while index < len(pool) - 1 and flt(pool[index][1], precision) < flt(
+				self.weight_per_piece, precision
+			):
+				index += 1
 
-				pool[index][1] = flt(pool[index][1] - taken, precision)
-				remaining = flt(remaining - taken, precision)
-				if pool[index][1] <= 0:
-					index += 1
-
-			parents.append(self.get_majority_batch(shares) or pool[-1][0])
+			parents.append(pool[index][0])
+			pool[index][1] -= self.weight_per_piece
 
 		return parents
-
-	@staticmethod
-	def get_majority_batch(shares):
-		majority_batch = None
-		majority_share = 0.0
-		for batch_no, share in shares.items():
-			if share >= majority_share:
-				majority_batch, majority_share = batch_no, share
-
-		return majority_batch
 
 	def make_child_batches(self, fg_row, parent_batches):
 		batches = frappe._dict()

--- a/erpnext/stock/doctype/stock_entry/services/batch_split.py
+++ b/erpnext/stock/doctype/stock_entry/services/batch_split.py
@@ -18,7 +18,6 @@ class BatchSplitFinishedGood:
 		fg_row = self.get_finished_good_row()
 		pieces = self.get_pieces(fg_row)
 		input_batches = self.get_input_batches()
-		self.set_weight_per_piece(input_batches, pieces)
 		parent_batches = self.get_parent_batches(input_batches, pieces)
 		child_batches = self.make_child_batches(fg_row, parent_batches)
 		self.attach_bundle(fg_row, child_batches)
@@ -26,9 +25,13 @@ class BatchSplitFinishedGood:
 	def is_applicable(self):
 		self.weight_per_piece = 0.0
 		if self.doc.purpose == "Repack":
-			return self.doc.stock_entry_type and cint(
+			if not self.doc.stock_entry_type or not cint(
 				frappe.get_cached_value("Stock Entry Type", self.doc.stock_entry_type, "batch_split")
-			)
+			):
+				return False
+
+			self.weight_per_piece = flt(self.doc.weight_per_piece)
+			return True
 
 		if self.doc.purpose != "Manufacture" or not self.doc.job_card:
 			return False
@@ -39,10 +42,6 @@ class BatchSplitFinishedGood:
 
 		self.weight_per_piece = flt(details.weight_per_piece)
 		return cint(details.batch_split) and self.weight_per_piece > 0
-
-	def set_weight_per_piece(self, input_batches, pieces):
-		if not self.weight_per_piece:
-			self.weight_per_piece = sum(flt(qty) for _batch_no, qty in input_batches) / pieces
 
 	def get_finished_good_row(self):
 		fg_rows = [
@@ -77,12 +76,19 @@ class BatchSplitFinishedGood:
 		return row
 
 	def get_pieces(self, fg_row):
-		pieces = flt(fg_row.transfer_qty)
-		if pieces <= 0 or pieces != cint(pieces):
+		if self.weight_per_piece <= 0:
 			frappe.throw(
 				_(
-					"Row #{0}: The quantity {1} of the Batch Split item {2} must be a whole number of pieces."
-				).format(fg_row.idx, pieces, fg_row.item_code)
+					"Please set the Weight Per Piece to split the produced quantity into batches in the Stock Entry {0}."
+				).format(self.doc.name)
+			)
+
+		pieces = flt(fg_row.transfer_qty) / self.weight_per_piece
+		if pieces < 1 or pieces != cint(pieces):
+			frappe.throw(
+				_(
+					"Row #{0}: The quantity {1} of the Batch Split item {2} must be a multiple of the Weight Per Piece {3}."
+				).format(fg_row.idx, fg_row.transfer_qty, fg_row.item_code, self.weight_per_piece)
 			)
 
 		return cint(pieces)
@@ -204,7 +210,7 @@ class BatchSplitFinishedGood:
 				)
 			)
 
-			batches[batch_no] = 1
+			batches[batch_no] = self.weight_per_piece
 
 		return batches
 

--- a/erpnext/stock/doctype/stock_entry/services/batch_split.py
+++ b/erpnext/stock/doctype/stock_entry/services/batch_split.py
@@ -272,12 +272,11 @@ def delete_unused_child_batches(doc):
 	)
 
 	for bundle_name, batch_nos in get_bundle_wise_child_batches(doc).items():
-		deletable = [batch_no for batch_no in batch_nos if not is_batch_used_outside(batch_no, own_bundles)]
+		if any(is_batch_used_outside(batch_no, own_bundles) for batch_no in batch_nos):
+			continue
 
-		if len(deletable) == len(batch_nos):
-			delete_child_bundle(doc, bundle_name)
-
-		for batch_no in deletable:
+		delete_child_bundle(doc, bundle_name)
+		for batch_no in batch_nos:
 			frappe.delete_doc("Batch", batch_no, force=True, ignore_permissions=True)
 
 

--- a/erpnext/stock/doctype/stock_entry/services/batch_split.py
+++ b/erpnext/stock/doctype/stock_entry/services/batch_split.py
@@ -178,15 +178,22 @@ class BatchSplitFinishedGood:
 
 	def get_parent_batches(self, input_batches, pieces):
 		pool = [(batch_no, flt(qty)) for batch_no, qty in input_batches if flt(qty) > 0]
-		if not pool:
-			return [input_batches[0][0]] * pieces
+		capacities = [int(flt(qty / self.weight_per_piece, 6)) for _batch_no, qty in pool]
 
-		total_qty = sum(qty for _, qty in pool)
-		shares = [pieces * qty / total_qty for _, qty in pool]
-		counts = [int(share) for share in shares]
+		if sum(capacities) < pieces:
+			frappe.throw(
+				_(
+					"The batches consumed in the Stock Entry {0} can supply only {1} whole pieces of {2} units each, but {3} pieces are required. Reduce the finished quantity or consume larger batches."
+				).format(self.doc.name, sum(capacities), self.weight_per_piece, pieces)
+			)
 
-		remainders = sorted(range(len(pool)), key=lambda i: (counts[i] - shares[i], i))
-		for index in remainders[: pieces - sum(counts)]:
+		total_qty = sum(qty for _batch_no, qty in pool)
+		shares = [pieces * qty / total_qty for _batch_no, qty in pool]
+		counts = [min(int(share), capacity) for share, capacity in zip(shares, capacities, strict=False)]
+
+		while sum(counts) < pieces:
+			eligible = [i for i in range(len(pool)) if counts[i] < capacities[i]]
+			index = min(eligible, key=lambda i: (counts[i] - shares[i], i))
 			counts[index] += 1
 
 		parents = []

--- a/erpnext/stock/doctype/stock_entry/services/batch_split.py
+++ b/erpnext/stock/doctype/stock_entry/services/batch_split.py
@@ -85,17 +85,25 @@ class BatchSplitFinishedGood:
 		return cint(pieces)
 
 	def get_input_batches(self):
+		input_rows = [row for row in self.doc.items if self.is_batch_input_row(row)]
+
+		if not input_rows:
+			frappe.throw(
+				_(
+					"The Batch Split operation requires a batch tracked raw material to be consumed in the Stock Entry {0}."
+				).format(self.doc.name)
+			)
+
+		item_codes = {row.item_code for row in input_rows}
+		if len(item_codes) > 1:
+			frappe.throw(
+				_(
+					"The Batch Split entry {0} must consume exactly one batch tracked raw material, found {1} ({2})."
+				).format(self.doc.name, len(item_codes), ", ".join(sorted(item_codes)))
+			)
+
 		batches = []
-		for row in self.doc.items:
-			if row.is_finished_item or not row.s_warehouse:
-				continue
-
-			if row.secondary_item_type or row.is_legacy_scrap_item:
-				continue
-
-			if not frappe.get_cached_value("Item", row.item_code, "has_batch_no"):
-				continue
-
+		for row in input_rows:
 			batches.extend(self.get_row_batches(row))
 
 		if not batches:
@@ -106,6 +114,15 @@ class BatchSplitFinishedGood:
 			)
 
 		return batches
+
+	def is_batch_input_row(self, row):
+		if row.is_finished_item or not row.s_warehouse:
+			return False
+
+		if row.secondary_item_type or row.is_legacy_scrap_item:
+			return False
+
+		return bool(frappe.get_cached_value("Item", row.item_code, "has_batch_no"))
 
 	def get_row_batches(self, row):
 		if row.serial_and_batch_bundle:
@@ -151,45 +168,78 @@ class BatchSplitFinishedGood:
 		return batches
 
 	def get_parent_batches(self, input_batches, pieces):
+		pool = [[batch_no, flt(qty)] for batch_no, qty in input_batches if flt(qty) > 0]
+		precision = frappe.get_precision("Serial and Batch Entry", "qty")
 		parents = []
-		pool = [[batch_no, flt(qty)] for batch_no, qty in input_batches]
 		index = 0
 
 		for _piece in range(pieces):
-			while index < len(pool) - 1 and pool[index][1] < self.weight_per_piece / 2:
-				index += 1
+			shares = {}
+			remaining = self.weight_per_piece
+			while remaining > 0 and index < len(pool):
+				taken = min(pool[index][1], remaining)
+				if taken > 0:
+					shares[pool[index][0]] = flt(shares.get(pool[index][0], 0.0) + taken, precision)
 
-			parents.append(pool[index][0])
-			pool[index][1] -= self.weight_per_piece
+				pool[index][1] = flt(pool[index][1] - taken, precision)
+				remaining = flt(remaining - taken, precision)
+				if pool[index][1] <= 0:
+					index += 1
+
+			parents.append(self.get_majority_batch(shares) or pool[-1][0])
 
 		return parents
 
+	@staticmethod
+	def get_majority_batch(shares):
+		majority_batch = None
+		majority_share = 0.0
+		for batch_no, share in shares.items():
+			if share >= majority_share:
+				majority_batch, majority_share = batch_no, share
+
+		return majority_batch
+
 	def make_child_batches(self, fg_row, parent_batches):
 		batches = frappe._dict()
+		next_index = {}
 		for parent_batch in parent_batches:
-			batch_no = make_batch(
-				frappe._dict(
-					{
-						"item": fg_row.item_code,
-						"parent_batch": parent_batch,
-						"batch_id": self.get_child_batch_id(parent_batch),
-						"reference_doctype": self.doc.doctype,
-						"reference_name": self.doc.name,
-					}
-				)
-			)
-
+			batch_no = self.insert_child_batch(fg_row, parent_batch, next_index)
 			batches[batch_no] = 1
 
 		return batches
 
-	def get_child_batch_id(self, parent_batch):
-		index = cint(frappe.db.count("Batch", {"parent_batch": parent_batch}))
+	def insert_child_batch(self, fg_row, parent_batch, next_index):
+		index = next_index.get(parent_batch) or cint(frappe.db.count("Batch", {"parent_batch": parent_batch}))
+
 		while True:
 			index += 1
 			batch_id = f"{parent_batch}-{index}"
-			if not frappe.db.exists("Batch", batch_id):
-				return batch_id
+			if frappe.db.exists("Batch", batch_id):
+				continue
+
+			frappe.db.savepoint("insert_child_batch")
+			try:
+				batch_no = self.make_child_batch(fg_row, parent_batch, batch_id)
+			except frappe.DuplicateEntryError:
+				frappe.db.rollback(save_point="insert_child_batch")
+				continue
+
+			next_index[parent_batch] = index
+			return batch_no
+
+	def make_child_batch(self, fg_row, parent_batch, batch_id):
+		return make_batch(
+			frappe._dict(
+				{
+					"item": fg_row.item_code,
+					"parent_batch": parent_batch,
+					"batch_id": batch_id,
+					"reference_doctype": self.doc.doctype,
+					"reference_name": self.doc.name,
+				}
+			)
+		)
 
 	def attach_bundle(self, fg_row, batches):
 		bundle = SerialBatchCreation(
@@ -210,3 +260,55 @@ class BatchSplitFinishedGood:
 		fg_row.serial_and_batch_bundle = bundle.name
 		fg_row.use_serial_batch_fields = 0
 		fg_row.batch_no = None
+
+
+def delete_unused_child_batches(doc):
+	own_bundles = set(
+		frappe.get_all(
+			"Serial and Batch Bundle",
+			filters={"voucher_type": doc.doctype, "voucher_no": doc.name},
+			pluck="name",
+		)
+	)
+
+	for batch_no in get_child_batches(doc):
+		if not is_batch_used_outside(batch_no, own_bundles):
+			frappe.delete_doc("Batch", batch_no, force=True, ignore_permissions=True)
+
+
+def is_batch_used_outside(batch_no, own_bundles):
+	from frappe.model.delete_doc import get_dynamic_linked_docs, get_linked_docs
+
+	batch_doc = frappe.get_doc("Batch", batch_no)
+	for link in get_linked_docs(batch_doc) + get_dynamic_linked_docs(batch_doc):
+		if (
+			link["reference_doctype"] == "Serial and Batch Bundle"
+			and link["reference_docname"] in own_bundles
+		):
+			continue
+
+		return True
+
+	return False
+
+
+def get_child_batches(doc):
+	bundle = frappe.qb.DocType("Serial and Batch Bundle")
+	entry = frappe.qb.DocType("Serial and Batch Entry")
+	batch = frappe.qb.DocType("Batch")
+
+	return (
+		frappe.qb.from_(bundle)
+		.inner_join(entry)
+		.on(entry.parent == bundle.name)
+		.inner_join(batch)
+		.on(batch.name == entry.batch_no)
+		.select(batch.name)
+		.distinct()
+		.where(
+			(bundle.voucher_type == doc.doctype)
+			& (bundle.voucher_no == doc.name)
+			& (bundle.type_of_transaction == "Inward")
+			& (batch.parent_batch.isnotnull())
+		)
+	).run(pluck=True)

--- a/erpnext/stock/doctype/stock_entry/services/manufacturing.py
+++ b/erpnext/stock/doctype/stock_entry/services/manufacturing.py
@@ -283,6 +283,11 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 		self.set_default_warehouse()
 		self.set_job_card_data()
 
+	def before_submit(self):
+		from .batch_split import BatchSplitFinishedGood
+
+		BatchSplitFinishedGood(self.doc).process()
+
 	def validate(self):
 		self.validate_warehouse()
 		self.validate_raw_materials_exists()
@@ -977,6 +982,11 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 class RepackStockEntry(BaseManufactureStockEntry):
 	def before_validate(self):
 		self.set_default_warehouse()
+
+	def before_submit(self):
+		from .batch_split import BatchSplitFinishedGood
+
+		BatchSplitFinishedGood(self.doc).process()
 
 	def validate(self):
 		self.validate_raw_materials_exists()

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -288,6 +288,7 @@ frappe.ui.form.on("Stock Entry", {
 	refresh: function (frm) {
 		frm.trigger("get_items_from_transit_entry");
 		frm.trigger("toggle_warehouse_fields");
+		frm.trigger("toggle_weight_per_piece");
 		erpnext.toggle_serial_batch_fields(frm);
 
 		if (!frm.doc.docstatus && !frm.doc.subcontracting_inward_order) {
@@ -608,12 +609,25 @@ frappe.ui.form.on("Stock Entry", {
 		frm.events.show_bom_custom_button(frm);
 		frm.trigger("add_to_transit");
 		frm.trigger("toggle_warehouse_fields");
+		frm.trigger("toggle_weight_per_piece");
 
 		frm.fields_dict.items.grid.update_docfield_property(
 			"basic_rate",
 			"read_only",
 			frm.doc.purpose == "Material Receipt" ? 0 : 1
 		);
+	},
+
+	toggle_weight_per_piece(frm) {
+		if (!frm.doc.stock_entry_type || frm.doc.purpose !== "Repack") {
+			frm.toggle_display("weight_per_piece", false);
+			return;
+		}
+
+		frappe.db.get_value("Stock Entry Type", frm.doc.stock_entry_type, "batch_split", (r) => {
+			frm.toggle_display("weight_per_piece", cint(r.batch_split));
+			frm.toggle_reqd("weight_per_piece", cint(r.batch_split));
+		});
 	},
 
 	toggle_warehouse_fields(frm) {

--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -11,6 +11,7 @@
   "company",
   "naming_series",
   "stock_entry_type",
+  "weight_per_piece",
   "purpose",
   "col2",
   "set_posting_time",
@@ -119,6 +120,16 @@
    "options": "Stock Entry Type",
    "reqd": 1,
    "search_index": 1
+  },
+  {
+   "depends_on": "eval:doc.purpose == 'Repack'",
+   "description": "Splits the produced quantity into one batch per this many units",
+   "fieldname": "weight_per_piece",
+   "fieldtype": "Float",
+   "hidden": 1,
+   "label": "Weight Per Piece",
+   "no_copy": 1,
+   "non_negative": 1
   },
   {
    "depends_on": "eval:doc.purpose == 'Material Transfer'",
@@ -784,7 +795,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-27 10:00:00.000000",
+ "modified": "2026-08-28 18:00:00.000000",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry",

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -170,6 +170,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 		total_outgoing_value: DF.Currency
 		use_multi_level_bom: DF.Check
 		value_difference: DF.Currency
+		weight_per_piece: DF.Float
 		work_order: DF.Link | None
 	# end: auto-generated types
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -387,6 +387,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 		if self.purpose_cls and hasattr(self.purpose_cls, "on_cancel"):
 			self.purpose_cls(self).on_cancel()
 
+		self.set_batch_split_child_batches()
 		self.delink_asset_repair_sabb()
 		self.validate_closed_subcontracting_order()
 		self.update_subcontracting_order_status()
@@ -423,13 +424,20 @@ class StockEntry(StockController, SubcontractingInwardController):
 		super().on_update()
 		self.set_serial_and_batch_bundle()
 
-	def delete_batch_split_child_batches(self):
+	def set_batch_split_child_batches(self):
 		from erpnext.stock.doctype.stock_entry.services.batch_split import (
 			BatchSplitFinishedGood,
-			delete_unused_child_batches,
+			get_minted_child_batches,
 		)
 
+		self.flags.batch_split_child_batches = []
 		if BatchSplitFinishedGood(self).is_applicable():
+			self.flags.batch_split_child_batches = get_minted_child_batches(self)
+
+	def delete_batch_split_child_batches(self):
+		from erpnext.stock.doctype.stock_entry.services.batch_split import delete_unused_child_batches
+
+		if self.flags.get("batch_split_child_batches"):
 			delete_unused_child_batches(self)
 
 	def validate_job_card_fg_item(self):

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -387,7 +387,6 @@ class StockEntry(StockController, SubcontractingInwardController):
 		if self.purpose_cls and hasattr(self.purpose_cls, "on_cancel"):
 			self.purpose_cls(self).on_cancel()
 
-		self.set_batch_split_child_batches()
 		self.delink_asset_repair_sabb()
 		self.validate_closed_subcontracting_order()
 		self.update_subcontracting_order_status()
@@ -416,29 +415,12 @@ class StockEntry(StockController, SubcontractingInwardController):
 		# Recompute (now excludes this cancelled entry) so the freed reservation is restored.
 		self.update_wo_reservation_for_subcontracting()
 		self.delete_auto_created_batches()
-		self.delete_batch_split_child_batches()
 		self.delete_linked_stock_entry()
 		super().on_cancel_subcontracting_inward()
 
 	def on_update(self):
 		super().on_update()
 		self.set_serial_and_batch_bundle()
-
-	def set_batch_split_child_batches(self):
-		from erpnext.stock.doctype.stock_entry.services.batch_split import (
-			BatchSplitFinishedGood,
-			get_minted_child_batches,
-		)
-
-		self.flags.batch_split_child_batches = []
-		if BatchSplitFinishedGood(self).is_applicable():
-			self.flags.batch_split_child_batches = get_minted_child_batches(self)
-
-	def delete_batch_split_child_batches(self):
-		from erpnext.stock.doctype.stock_entry.services.batch_split import delete_unused_child_batches
-
-		if self.flags.get("batch_split_child_batches"):
-			delete_unused_child_batches(self)
 
 	def validate_job_card_fg_item(self):
 		if not self.job_card:

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -357,6 +357,9 @@ class StockEntry(StockController, SubcontractingInwardController):
 	def before_submit(self):
 		StockEntrySABB(self).make_serial_and_batch_bundle_for_outward()
 
+		if self.purpose_cls and hasattr(self.purpose_cls, "before_submit"):
+			self.purpose_cls(self).before_submit()
+
 	def on_submit(self):
 		if self.purpose_cls and hasattr(self.purpose_cls, "on_submit"):
 			self.purpose_cls(self).on_submit()

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -415,12 +415,19 @@ class StockEntry(StockController, SubcontractingInwardController):
 		# Recompute (now excludes this cancelled entry) so the freed reservation is restored.
 		self.update_wo_reservation_for_subcontracting()
 		self.delete_auto_created_batches()
+		self.delete_batch_split_child_batches()
 		self.delete_linked_stock_entry()
 		super().on_cancel_subcontracting_inward()
 
 	def on_update(self):
 		super().on_update()
 		self.set_serial_and_batch_bundle()
+
+	def delete_batch_split_child_batches(self):
+		from erpnext.stock.doctype.stock_entry.services.batch_split import delete_unused_child_batches
+
+		if self.purpose in ("Manufacture", "Repack"):
+			delete_unused_child_batches(self)
 
 	def validate_job_card_fg_item(self):
 		if not self.job_card:

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -424,9 +424,12 @@ class StockEntry(StockController, SubcontractingInwardController):
 		self.set_serial_and_batch_bundle()
 
 	def delete_batch_split_child_batches(self):
-		from erpnext.stock.doctype.stock_entry.services.batch_split import delete_unused_child_batches
+		from erpnext.stock.doctype.stock_entry.services.batch_split import (
+			BatchSplitFinishedGood,
+			delete_unused_child_batches,
+		)
 
-		if self.purpose in ("Manufacture", "Repack"):
+		if BatchSplitFinishedGood(self).is_applicable():
 			delete_unused_child_batches(self)
 
 	def validate_job_card_fg_item(self):

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -581,6 +581,29 @@ class TestStockEntry(ERPNextTestSuite):
 
 		self.assertEqual(parent_wise_pieces, {first_parent: 2, second_parent: 3})
 
+		fg_bundle = fg_row.serial_and_batch_bundle
+		draft_issue = frappe.new_doc("Stock Entry")
+		draft_issue.stock_entry_type = "Material Issue"
+		draft_issue.company = "_Test Company"
+		draft_issue.append(
+			"items",
+			{
+				"item_code": fg,
+				"qty": 1,
+				"s_warehouse": warehouse,
+				"batch_no": entries[0].batch_no,
+				"use_serial_batch_fields": 1,
+			},
+		)
+		draft_issue.insert()
+
+		repack.reload()
+		repack.cancel()
+
+		self.assertTrue(frappe.db.exists("Serial and Batch Bundle", fg_bundle))
+		for entry in entries:
+			self.assertTrue(frappe.db.exists("Batch", entry.batch_no))
+
 	def test_batch_split_requires_single_batch_input(self):
 		if not frappe.db.exists("Stock Entry Type", "Batch Split"):
 			frappe.new_doc("Stock Entry Type", purpose="Repack", batch_split=1).insert(

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -559,8 +559,9 @@ class TestStockEntry(ERPNextTestSuite):
 		repack = frappe.new_doc("Stock Entry")
 		repack.stock_entry_type = "Batch Split"
 		repack.company = "_Test Company"
+		repack.weight_per_piece = 10
 		repack.append("items", {"item_code": rm, "qty": 50, "s_warehouse": warehouse})
-		repack.append("items", {"item_code": fg, "qty": 5, "t_warehouse": warehouse, "is_finished_item": 1})
+		repack.append("items", {"item_code": fg, "qty": 50, "t_warehouse": warehouse, "is_finished_item": 1})
 		repack.insert()
 		repack.submit()
 
@@ -574,7 +575,7 @@ class TestStockEntry(ERPNextTestSuite):
 		self.assertEqual(len(entries), 5)
 		parent_wise_pieces = {}
 		for entry in entries:
-			self.assertEqual(flt(entry.qty), 1.0)
+			self.assertEqual(flt(entry.qty), 10.0)
 			parent = frappe.db.get_value("Batch", entry.batch_no, "parent_batch")
 			parent_wise_pieces[parent] = parent_wise_pieces.get(parent, 0) + 1
 
@@ -611,10 +612,11 @@ class TestStockEntry(ERPNextTestSuite):
 		repack = frappe.new_doc("Stock Entry")
 		repack.stock_entry_type = "Batch Split"
 		repack.company = "_Test Company"
+		repack.weight_per_piece = 10
 		repack.append("items", {"item_code": items["RM A"], "qty": 10, "s_warehouse": warehouse})
 		repack.append("items", {"item_code": items["RM B"], "qty": 10, "s_warehouse": warehouse})
 		repack.append(
-			"items", {"item_code": items["FG C"], "qty": 2, "t_warehouse": warehouse, "is_finished_item": 1}
+			"items", {"item_code": items["FG C"], "qty": 20, "t_warehouse": warehouse, "is_finished_item": 1}
 		)
 		repack.insert()
 

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -551,9 +551,9 @@ class TestStockEntry(ERPNextTestSuite):
 			},
 		).name
 
-		first_receipt = make_stock_entry(item_code=rm, target=warehouse, qty=25, basic_rate=200)
+		first_receipt = make_stock_entry(item_code=rm, target=warehouse, qty=30, basic_rate=200)
 		first_parent = get_batch_from_bundle(first_receipt.items[0].serial_and_batch_bundle)
-		second_receipt = make_stock_entry(item_code=rm, target=warehouse, qty=25, basic_rate=200)
+		second_receipt = make_stock_entry(item_code=rm, target=warehouse, qty=20, basic_rate=200)
 		second_parent = get_batch_from_bundle(second_receipt.items[0].serial_and_batch_bundle)
 
 		repack = frappe.new_doc("Stock Entry")
@@ -617,6 +617,51 @@ class TestStockEntry(ERPNextTestSuite):
 		repack.append("items", {"item_code": items["RM B"], "qty": 10, "s_warehouse": warehouse})
 		repack.append(
 			"items", {"item_code": items["FG C"], "qty": 20, "t_warehouse": warehouse, "is_finished_item": 1}
+		)
+		repack.insert()
+
+		self.assertRaises(frappe.ValidationError, repack.submit)
+
+	def test_batch_split_requires_whole_piece_capacity(self):
+		original_value = frappe.db.get_single_value(
+			"Stock Settings", "auto_create_serial_and_batch_bundle_for_outward"
+		)
+		frappe.db.set_single_value("Stock Settings", "auto_create_serial_and_batch_bundle_for_outward", 1)
+		self.addCleanup(
+			frappe.db.set_single_value,
+			"Stock Settings",
+			"auto_create_serial_and_batch_bundle_for_outward",
+			original_value,
+		)
+
+		if not frappe.db.exists("Stock Entry Type", "Batch Split"):
+			frappe.new_doc("Stock Entry Type", purpose="Repack", batch_split=1).insert(
+				set_name="Batch Split", ignore_permissions=True
+			)
+
+		warehouse = "_Test Warehouse - _TC"
+		items = {}
+		for suffix in ("RM", "FG"):
+			items[suffix] = make_item(
+				f"Batch Split Capacity {suffix}",
+				{
+					"is_stock_item": 1,
+					"has_batch_no": 1,
+					"create_new_batch": 1,
+					"batch_number_series": f"BS-CAP-{suffix}-.####",
+				},
+			).name
+
+		make_stock_entry(item_code=items["RM"], target=warehouse, qty=25, basic_rate=200)
+		make_stock_entry(item_code=items["RM"], target=warehouse, qty=25, basic_rate=200)
+
+		repack = frappe.new_doc("Stock Entry")
+		repack.stock_entry_type = "Batch Split"
+		repack.company = "_Test Company"
+		repack.weight_per_piece = 10
+		repack.append("items", {"item_code": items["RM"], "qty": 50, "s_warehouse": warehouse})
+		repack.append(
+			"items", {"item_code": items["FG"], "qty": 50, "t_warehouse": warehouse, "is_finished_item": 1}
 		)
 		repack.insert()
 

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -551,8 +551,10 @@ class TestStockEntry(ERPNextTestSuite):
 			},
 		).name
 
-		receipt = make_stock_entry(item_code=rm, target=warehouse, qty=50, basic_rate=200)
-		parent_batch = get_batch_from_bundle(receipt.items[0].serial_and_batch_bundle)
+		first_receipt = make_stock_entry(item_code=rm, target=warehouse, qty=25, basic_rate=200)
+		first_parent = get_batch_from_bundle(first_receipt.items[0].serial_and_batch_bundle)
+		second_receipt = make_stock_entry(item_code=rm, target=warehouse, qty=25, basic_rate=200)
+		second_parent = get_batch_from_bundle(second_receipt.items[0].serial_and_batch_bundle)
 
 		repack = frappe.new_doc("Stock Entry")
 		repack.stock_entry_type = "Batch Split"
@@ -570,10 +572,47 @@ class TestStockEntry(ERPNextTestSuite):
 		)
 
 		self.assertEqual(len(entries), 5)
+		parent_wise_pieces = {}
 		for entry in entries:
 			self.assertEqual(flt(entry.qty), 1.0)
-			self.assertTrue(entry.batch_no.startswith(parent_batch))
-			self.assertEqual(frappe.db.get_value("Batch", entry.batch_no, "parent_batch"), parent_batch)
+			parent = frappe.db.get_value("Batch", entry.batch_no, "parent_batch")
+			self.assertTrue(entry.batch_no.startswith(parent))
+			parent_wise_pieces[parent] = parent_wise_pieces.get(parent, 0) + 1
+
+		self.assertEqual(parent_wise_pieces, {first_parent: 2, second_parent: 3})
+
+	def test_batch_split_requires_single_batch_input(self):
+		if not frappe.db.exists("Stock Entry Type", "Batch Split"):
+			frappe.new_doc("Stock Entry Type", purpose="Repack", batch_split=1).insert(
+				set_name="Batch Split", ignore_permissions=True
+			)
+
+		warehouse = "_Test Warehouse - _TC"
+		items = {}
+		for suffix in ("RM A", "RM B", "FG C"):
+			items[suffix] = make_item(
+				f"Batch Split Multi {suffix}",
+				{
+					"is_stock_item": 1,
+					"has_batch_no": 1,
+					"create_new_batch": 1,
+					"batch_number_series": f"BS-M-{suffix[-1]}-.####",
+				},
+			).name
+			if suffix != "FG C":
+				make_stock_entry(item_code=items[suffix], target=warehouse, qty=10, basic_rate=100)
+
+		repack = frappe.new_doc("Stock Entry")
+		repack.stock_entry_type = "Batch Split"
+		repack.company = "_Test Company"
+		repack.append("items", {"item_code": items["RM A"], "qty": 10, "s_warehouse": warehouse})
+		repack.append("items", {"item_code": items["RM B"], "qty": 10, "s_warehouse": warehouse})
+		repack.append(
+			"items", {"item_code": items["FG C"], "qty": 2, "t_warehouse": warehouse, "is_finished_item": 1}
+		)
+		repack.insert()
+
+		self.assertRaises(frappe.ValidationError, repack.submit)
 
 	def test_repack_with_additional_costs(self):
 		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -579,7 +579,7 @@ class TestStockEntry(ERPNextTestSuite):
 			parent = frappe.db.get_value("Batch", entry.batch_no, "parent_batch")
 			parent_wise_pieces[parent] = parent_wise_pieces.get(parent, 0) + 1
 
-		self.assertEqual(parent_wise_pieces, {first_parent: 2, second_parent: 3})
+		self.assertEqual(parent_wise_pieces, {first_parent: 3, second_parent: 2})
 
 		repack.reload()
 		repack.cancel()

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -514,6 +514,67 @@ class TestStockEntry(ERPNextTestSuite):
 			frappe.db.exists("GL Entry", {"voucher_type": "Stock Entry", "voucher_no": repack.name})
 		)
 
+	def test_batch_split_stock_entry_type(self):
+		original_value = frappe.db.get_single_value(
+			"Stock Settings", "auto_create_serial_and_batch_bundle_for_outward"
+		)
+		frappe.db.set_single_value("Stock Settings", "auto_create_serial_and_batch_bundle_for_outward", 1)
+		self.addCleanup(
+			frappe.db.set_single_value,
+			"Stock Settings",
+			"auto_create_serial_and_batch_bundle_for_outward",
+			original_value,
+		)
+
+		if not frappe.db.exists("Stock Entry Type", "Batch Split"):
+			frappe.new_doc("Stock Entry Type", purpose="Repack", batch_split=1).insert(
+				set_name="Batch Split", ignore_permissions=True
+			)
+
+		warehouse = "_Test Warehouse - _TC"
+		rm = make_item(
+			"Batch Split Repack RM",
+			{
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "BS-RP-RM-.####",
+			},
+		).name
+		fg = make_item(
+			"Batch Split Repack FG",
+			{
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "BS-RP-FG-.####",
+			},
+		).name
+
+		receipt = make_stock_entry(item_code=rm, target=warehouse, qty=50, basic_rate=200)
+		parent_batch = get_batch_from_bundle(receipt.items[0].serial_and_batch_bundle)
+
+		repack = frappe.new_doc("Stock Entry")
+		repack.stock_entry_type = "Batch Split"
+		repack.company = "_Test Company"
+		repack.append("items", {"item_code": rm, "qty": 50, "s_warehouse": warehouse})
+		repack.append("items", {"item_code": fg, "qty": 5, "t_warehouse": warehouse, "is_finished_item": 1})
+		repack.insert()
+		repack.submit()
+
+		fg_row = next(row for row in repack.items if row.item_code == fg)
+		entries = frappe.get_all(
+			"Serial and Batch Entry",
+			filters={"parent": fg_row.serial_and_batch_bundle},
+			fields=["batch_no", "qty"],
+		)
+
+		self.assertEqual(len(entries), 5)
+		for entry in entries:
+			self.assertEqual(flt(entry.qty), 1.0)
+			self.assertTrue(entry.batch_no.startswith(parent_batch))
+			self.assertEqual(frappe.db.get_value("Batch", entry.batch_no, "parent_batch"), parent_batch)
+
 	def test_repack_with_additional_costs(self):
 		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")
 

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -576,33 +576,16 @@ class TestStockEntry(ERPNextTestSuite):
 		for entry in entries:
 			self.assertEqual(flt(entry.qty), 1.0)
 			parent = frappe.db.get_value("Batch", entry.batch_no, "parent_batch")
-			self.assertTrue(entry.batch_no.startswith(parent))
 			parent_wise_pieces[parent] = parent_wise_pieces.get(parent, 0) + 1
 
 		self.assertEqual(parent_wise_pieces, {first_parent: 2, second_parent: 3})
 
-		fg_bundle = fg_row.serial_and_batch_bundle
-		draft_issue = frappe.new_doc("Stock Entry")
-		draft_issue.stock_entry_type = "Material Issue"
-		draft_issue.company = "_Test Company"
-		draft_issue.append(
-			"items",
-			{
-				"item_code": fg,
-				"qty": 1,
-				"s_warehouse": warehouse,
-				"batch_no": entries[0].batch_no,
-				"use_serial_batch_fields": 1,
-			},
-		)
-		draft_issue.insert()
-
 		repack.reload()
 		repack.cancel()
 
-		self.assertTrue(frappe.db.exists("Serial and Batch Bundle", fg_bundle))
 		for entry in entries:
 			self.assertTrue(frappe.db.exists("Batch", entry.batch_no))
+			self.assertTrue(frappe.db.get_value("Batch", entry.batch_no, "parent_batch"))
 
 	def test_batch_split_requires_single_batch_input(self):
 		if not frappe.db.exists("Stock Entry Type", "Batch Split"):

--- a/erpnext/stock/doctype/stock_entry_type/stock_entry_type.json
+++ b/erpnext/stock/doctype/stock_entry_type/stock_entry_type.json
@@ -8,6 +8,7 @@
  "field_order": [
   "purpose",
   "add_to_transit",
+  "batch_split",
   "is_standard"
  ],
  "fields": [
@@ -30,6 +31,14 @@
   },
   {
    "default": "0",
+   "depends_on": "eval: doc.purpose == 'Repack'",
+   "description": "On submission of the stock entry, the consumed batch is split into one child batch per finished piece",
+   "fieldname": "batch_split",
+   "fieldtype": "Check",
+   "label": "Batch Split"
+  },
+  {
+   "default": "0",
    "fieldname": "is_standard",
    "fieldtype": "Check",
    "label": "Is Standard",
@@ -38,7 +47,7 @@
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2025-09-04 13:03:31.283348",
+ "modified": "2026-08-28 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry Type",

--- a/erpnext/stock/doctype/stock_entry_type/stock_entry_type.json
+++ b/erpnext/stock/doctype/stock_entry_type/stock_entry_type.json
@@ -35,7 +35,8 @@
    "description": "On submission of the stock entry, the consumed batch is split into one child batch per finished piece",
    "fieldname": "batch_split",
    "fieldtype": "Check",
-   "label": "Batch Split"
+   "label": "Batch Split",
+   "read_only": 1
   },
   {
    "default": "0",
@@ -47,7 +48,7 @@
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2026-08-28 12:00:00.000000",
+ "modified": "2026-08-28 14:00:00.000000",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry Type",

--- a/erpnext/stock/doctype/stock_entry_type/stock_entry_type.py
+++ b/erpnext/stock/doctype/stock_entry_type/stock_entry_type.py
@@ -131,12 +131,15 @@ class ManufactureEntry:
 				available_serial_batches = self.get_transferred_serial_batches()
 
 			production_share = self.get_production_share()
+			batch_split_item = self.get_batch_split_input_item(item_dict)
 			for item_code, _dict in item_dict.items():
 				_dict.s_warehouse = self.source_wh.get(item_code) or self.wip_warehouse
 				_dict.t_warehouse = ""
 				_dict.item_code = item_code
 
-				derived_qty = self.get_batch_split_qty(item_code)
+				derived_qty = 0.0
+				if batch_split_item and item_code == batch_split_item:
+					derived_qty = flt(self.for_quantity) * flt(self.weight_per_piece)
 
 				if backflush_based_on != "BOM" and not self.skip_material_transfer:
 					calculated_qty = flt(_dict.transferred_qty) - flt(_dict.consumed_qty)
@@ -162,14 +165,22 @@ class ManufactureEntry:
 
 				self.stock_entry.append("items", _dict)
 
-	def get_batch_split_qty(self, item_code):
+	def get_batch_split_input_item(self, item_dict):
 		if not getattr(self, "batch_split", 0) or not flt(getattr(self, "weight_per_piece", 0)):
-			return 0
+			return None
 
-		if not frappe.get_cached_value("Item", item_code, "has_batch_no"):
-			return 0
+		batch_items = [
+			item_code for item_code in item_dict if frappe.get_cached_value("Item", item_code, "has_batch_no")
+		]
 
-		return flt(self.for_quantity) * flt(self.weight_per_piece)
+		if len(batch_items) != 1:
+			frappe.throw(
+				_(
+					"The Batch Split operation requires exactly one batch tracked raw material, found {0} ({1})."
+				).format(len(batch_items), ", ".join(sorted(batch_items)))
+			)
+
+		return batch_items[0]
 
 	def validate_batch_split_consumption(self, item_code, derived_qty, available_qty):
 		if derived_qty > available_qty:

--- a/erpnext/stock/doctype/stock_entry_type/stock_entry_type.py
+++ b/erpnext/stock/doctype/stock_entry_type/stock_entry_type.py
@@ -131,15 +131,10 @@ class ManufactureEntry:
 				available_serial_batches = self.get_transferred_serial_batches()
 
 			production_share = self.get_production_share()
-			batch_split_item = self.get_batch_split_input_item(item_dict)
 			for item_code, _dict in item_dict.items():
 				_dict.s_warehouse = self.source_wh.get(item_code) or self.wip_warehouse
 				_dict.t_warehouse = ""
 				_dict.item_code = item_code
-
-				derived_qty = 0.0
-				if batch_split_item and item_code == batch_split_item:
-					derived_qty = flt(self.for_quantity) * flt(self.weight_per_piece)
 
 				if backflush_based_on != "BOM" and not self.skip_material_transfer:
 					calculated_qty = flt(_dict.transferred_qty) - flt(_dict.consumed_qty)
@@ -149,14 +144,10 @@ class ManufactureEntry:
 						)
 
 					_dict.qty = calculated_qty
-					if derived_qty:
-						self.validate_batch_split_consumption(item_code, derived_qty, calculated_qty)
-						_dict.qty = derived_qty
-
 					self.update_available_serial_batches(_dict, available_serial_batches)
 				else:
 					remaining_qty = max(flt(_dict.qty) - flt(_dict.consumed_qty), 0)
-					_dict.qty = derived_qty or min(flt(_dict.qty) * production_share, remaining_qty)
+					_dict.qty = min(flt(_dict.qty) * production_share, remaining_qty)
 					if not _dict.qty:
 						continue
 
@@ -164,31 +155,6 @@ class ManufactureEntry:
 						set_previous_operation_serial_batch(self.stock_entry, _dict)
 
 				self.stock_entry.append("items", _dict)
-
-	def get_batch_split_input_item(self, item_dict):
-		if not getattr(self, "batch_split", 0) or not flt(getattr(self, "weight_per_piece", 0)):
-			return None
-
-		batch_items = [
-			item_code for item_code in item_dict if frappe.get_cached_value("Item", item_code, "has_batch_no")
-		]
-
-		if len(batch_items) != 1:
-			frappe.throw(
-				_(
-					"The Batch Split operation requires exactly one batch tracked raw material, found {0} ({1})."
-				).format(len(batch_items), ", ".join(sorted(batch_items)))
-			)
-
-		return batch_items[0]
-
-	def validate_batch_split_consumption(self, item_code, derived_qty, available_qty):
-		if derived_qty > available_qty:
-			frappe.throw(
-				_(
-					"As per the Batch Split operation, {0} qty of the item {1} is required to be consumed but only {2} is available."
-				).format(derived_qty, item_code, available_qty)
-			)
 
 	def get_production_share(self):
 		"""Fraction of the job card's production this entry accounts for; raw materials are

--- a/erpnext/stock/doctype/stock_entry_type/stock_entry_type.py
+++ b/erpnext/stock/doctype/stock_entry_type/stock_entry_type.py
@@ -23,6 +23,7 @@ class StockEntryType(Document):
 		from frappe.types import DF
 
 		add_to_transit: DF.Check
+		batch_split: DF.Check
 		is_standard: DF.Check
 		purpose: DF.Literal[
 			"Material Issue",
@@ -45,6 +46,9 @@ class StockEntryType(Document):
 		self.validate_standard_type()
 		if self.add_to_transit and self.purpose != "Material Transfer":
 			self.add_to_transit = 0
+
+		if self.batch_split and self.purpose != "Repack":
+			self.batch_split = 0
 
 	def validate_standard_type(self):
 		if self.is_standard and self.name not in [
@@ -132,6 +136,8 @@ class ManufactureEntry:
 				_dict.t_warehouse = ""
 				_dict.item_code = item_code
 
+				derived_qty = self.get_batch_split_qty(item_code)
+
 				if backflush_based_on != "BOM" and not self.skip_material_transfer:
 					calculated_qty = flt(_dict.transferred_qty) - flt(_dict.consumed_qty)
 					if calculated_qty < 0:
@@ -140,10 +146,14 @@ class ManufactureEntry:
 						)
 
 					_dict.qty = calculated_qty
+					if derived_qty:
+						self.validate_batch_split_consumption(item_code, derived_qty, calculated_qty)
+						_dict.qty = derived_qty
+
 					self.update_available_serial_batches(_dict, available_serial_batches)
 				else:
 					remaining_qty = max(flt(_dict.qty) - flt(_dict.consumed_qty), 0)
-					_dict.qty = min(flt(_dict.qty) * production_share, remaining_qty)
+					_dict.qty = derived_qty or min(flt(_dict.qty) * production_share, remaining_qty)
 					if not _dict.qty:
 						continue
 
@@ -151,6 +161,23 @@ class ManufactureEntry:
 						set_previous_operation_serial_batch(self.stock_entry, _dict)
 
 				self.stock_entry.append("items", _dict)
+
+	def get_batch_split_qty(self, item_code):
+		if not getattr(self, "batch_split", 0) or not flt(getattr(self, "weight_per_piece", 0)):
+			return 0
+
+		if not frappe.get_cached_value("Item", item_code, "has_batch_no"):
+			return 0
+
+		return flt(self.for_quantity) * flt(self.weight_per_piece)
+
+	def validate_batch_split_consumption(self, item_code, derived_qty, available_qty):
+		if derived_qty > available_qty:
+			frappe.throw(
+				_(
+					"As per the Batch Split operation, {0} qty of the item {1} is required to be consumed but only {2} is available."
+				).format(derived_qty, item_code, available_qty)
+			)
 
 	def get_production_share(self):
 		"""Fraction of the job card's production this entry accounts for; raw materials are

--- a/erpnext/stock/report/batch_split_tree/batch_split_tree.js
+++ b/erpnext/stock/report/batch_split_tree/batch_split_tree.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Batch Split Tree"] = {
+	filters: [
+		{
+			fieldname: "batch",
+			label: __("Parent Batch"),
+			fieldtype: "Link",
+			options: "Batch",
+		},
+		{
+			fieldname: "item_code",
+			label: __("Item Code"),
+			fieldtype: "Link",
+			options: "Item",
+		},
+	],
+	initial_depth: 5,
+};

--- a/erpnext/stock/report/batch_split_tree/batch_split_tree.json
+++ b/erpnext/stock/report/batch_split_tree/batch_split_tree.json
@@ -1,0 +1,33 @@
+{
+ "add_total_row": 0,
+ "creation": "2026-08-28 15:00:00.000000",
+ "disable_prepared_report": 0,
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "idx": 0,
+ "is_standard": "Yes",
+ "modified": "2026-08-28 15:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Stock",
+ "name": "Batch Split Tree",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Batch",
+ "report_name": "Batch Split Tree",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "Stock User"
+  },
+  {
+   "role": "Stock Manager"
+  },
+  {
+   "role": "Manufacturing User"
+  },
+  {
+   "role": "Manufacturing Manager"
+  }
+ ]
+}

--- a/erpnext/stock/report/batch_split_tree/batch_split_tree.py
+++ b/erpnext/stock/report/batch_split_tree/batch_split_tree.py
@@ -1,0 +1,154 @@
+from collections import defaultdict
+
+import frappe
+from frappe import _
+
+
+def execute(filters=None):
+	filters = frappe._dict(filters or {})
+	return get_columns(), get_data(filters)
+
+
+def get_data(filters):
+	roots = get_root_batches(filters)
+	if not roots:
+		return []
+
+	children_map = get_children_map(roots)
+
+	data = []
+	for batch_no in roots:
+		add_rows(batch_no, children_map, data, 0)
+
+	return data
+
+
+def get_root_batches(filters):
+	batch = frappe.qb.DocType("Batch")
+	child = frappe.qb.DocType("Batch").as_("child")
+
+	if filters.batch:
+		return [filters.batch]
+
+	query = (
+		frappe.qb.from_(batch)
+		.inner_join(child)
+		.on(child.parent_batch == batch.name)
+		.select(batch.name)
+		.distinct()
+		.where(batch.parent_batch.isnull())
+		.orderby(batch.name)
+	)
+
+	if filters.item_code:
+		query = query.where(batch.item == filters.item_code)
+
+	return query.run(pluck=True)
+
+
+def get_children_map(roots):
+	batch = frappe.qb.DocType("Batch")
+	tree = frappe.qb.Table("batch_split_tree")
+	fields = [
+		batch.name,
+		batch.parent_batch,
+		batch.item,
+		batch.item_name,
+		batch.batch_qty,
+		batch.stock_uom,
+		batch.reference_doctype,
+		batch.reference_name,
+		batch.manufacturing_date,
+		batch.creation,
+	]
+
+	seed = frappe.qb.from_(batch).select(*fields).where(batch.name.isin(roots))
+	recursion = frappe.qb.from_(batch).inner_join(tree).on(batch.parent_batch == tree.name).select(*fields)
+
+	rows = (
+		frappe.qb.with_(seed + recursion, "batch_split_tree", recursive=True).from_(tree).select(tree.star)
+	).run(as_dict=True)
+
+	children_map = defaultdict(dict)
+	for row in rows:
+		children_map[row.parent_batch][row.name] = row
+
+	return children_map
+
+
+def add_rows(batch_no, children_map, data, indent, batch_details=None):
+	if batch_details is None:
+		batch_details = get_batch_row(batch_no)
+
+	batch_details.batch_no = batch_no
+	batch_details.indent = indent
+	data.append(batch_details)
+
+	children = sorted(children_map.get(batch_no, {}).values(), key=lambda row: row.creation)
+	for child in children:
+		add_rows(child.name, children_map, data, indent + 1, batch_details=child)
+
+
+def get_batch_row(batch_no):
+	return frappe.db.get_value(
+		"Batch",
+		batch_no,
+		[
+			"item",
+			"item_name",
+			"batch_qty",
+			"stock_uom",
+			"reference_doctype",
+			"reference_name",
+			"manufacturing_date",
+		],
+		as_dict=1,
+	)
+
+
+def get_columns():
+	return [
+		{
+			"label": _("Batch"),
+			"fieldname": "batch_no",
+			"fieldtype": "Link",
+			"options": "Batch",
+			"width": 260,
+		},
+		{
+			"label": _("Item Code"),
+			"fieldname": "item",
+			"fieldtype": "Link",
+			"options": "Item",
+			"width": 160,
+		},
+		{"label": _("Item Name"), "fieldname": "item_name", "fieldtype": "Data", "width": 160},
+		{"label": _("Batch Qty"), "fieldname": "batch_qty", "fieldtype": "Float", "width": 110},
+		{
+			"label": _("Stock UOM"),
+			"fieldname": "stock_uom",
+			"fieldtype": "Link",
+			"options": "UOM",
+			"width": 100,
+		},
+		{
+			"label": _("Created Via"),
+			"fieldname": "reference_doctype",
+			"fieldtype": "Link",
+			"options": "DocType",
+			"width": 120,
+		},
+		{
+			"label": _("Reference"),
+			"fieldname": "reference_name",
+			"fieldtype": "Dynamic Link",
+			"options": "reference_doctype",
+			"width": 160,
+		},
+		{
+			"label": _("Manufacturing Date"),
+			"fieldname": "manufacturing_date",
+			"fieldtype": "Date",
+			"width": 130,
+		},
+	]

--- a/erpnext/stock/report/batch_split_tree/batch_split_tree.py
+++ b/erpnext/stock/report/batch_split_tree/batch_split_tree.py
@@ -37,6 +37,7 @@ def get_root_batches(filters):
 		.select(batch.name)
 		.distinct()
 		.where(batch.parent_batch.isnull())
+		.where(child.reference_name.isnotnull() & (child.reference_name != ""))
 		.orderby(batch.name)
 	)
 
@@ -63,7 +64,13 @@ def get_children_map(roots):
 	]
 
 	seed = frappe.qb.from_(batch).select(*fields).where(batch.name.isin(roots))
-	recursion = frappe.qb.from_(batch).inner_join(tree).on(batch.parent_batch == tree.name).select(*fields)
+	recursion = (
+		frappe.qb.from_(batch)
+		.inner_join(tree)
+		.on(batch.parent_batch == tree.name)
+		.select(*fields)
+		.where(batch.reference_name.isnotnull() & (batch.reference_name != ""))
+	)
 
 	rows = (
 		frappe.qb.with_(seed + recursion, "batch_split_tree", recursive=True).from_(tree).select(tree.star)


### PR DESCRIPTION
### Scenario

A rod is purchased in KG (batch tracked) and cut into pieces tracked in Nos — e.g. one 50 KG batch becomes 5 rods of 10 KG each. Today this needs a manual Repack entry plus a customization to create the child batches, so every partner ends up writing a similar script.

### Batch Split as part of the routing

- BOM Operation (with Track Semi Finished Goods) gets a **Batch Split** checkbox and a **Weight Per Piece** field. Both are carried to the Work Order operation row and the Job Card.
- When the Job Card is completed, the Manufacture entry consumes and produces quantities exactly as usual; Weight Per Piece only controls the batching of the produced quantity (number of child batches = produced qty / weight per piece, each batch carrying weight per piece units).
- One child batch is created per piece, named from the item's batch number series, with the parent batch recorded in the Parent Batch field on the Batch for traceability. When consumption spans multiple input batches, each piece is attributed wholly to the single batch it was cut from (FIFO).
- The pieces are attached as a single bundle of qty-1 entries on the finished good row, so valuation is apportioned across the pieces by weight.

Since the split happens inside the Work Order, consumption, costing and production reports stay connected.

### Batch Split stock entry type

For splits done as a stores activity, a **Batch Split** stock entry type (purpose Repack) is shipped via fixtures and a patch. The behaviour is driven by a new `Batch Split` checkbox on Stock Entry Type (kept non-standard so the purpose-to-type resolution for plain Repack entries is untouched). Here the user enters Weight Per Piece on the Stock Entry, and the produced quantity is split accordingly.

### Validations

- BOM: Batch Split needs Track Semi Finished Goods, a positive Weight Per Piece and a batch tracked finished good.
- Stock Entry: the produced quantity must be a multiple of Weight Per Piece, exactly one finished good row, and a batch tracked input.

On cancellation the stock movement is reversed and the child batches are retained with their Parent Batch reference, consistent with how auto-created batches behave elsewhere.


### Traceability

A new **Batch Split Tree** report (linked from the Batch form) shows the split top-down: each parent batch with its child batches indented beneath it, recursing through multi-level splits, along with qty, UOM and the entry that created each batch. The existing Serial No and Batch Traceability report traces via vouchers and cannot express the per-piece parent attribution, which lives on the Parent Batch field.

### Design note: one parent per child batch

A child batch always records exactly one parent batch, because a physical piece is cut from a single source batch. Further splits nest naturally: a child that is split again becomes the parent of its own children, and the Batch Split Tree report renders the full hierarchy top-down. Each piece is sourced wholly from the first input batch (FIFO) that can still supply a full piece; leftover fragments smaller than one piece are never treated as a piece's source. The quantity ledger (bundles and stock ledger) remains exact. Multi-parent lineage was considered and deliberately rejected to keep the model true to the physical process.

Docs https://docs.frappe.io/erpnext/batch-split