### PR TITLE
fix: include purchase returns in uae vat 201 input vat

### DIFF
--- a/erpnext/regional/report/uae_vat_201/test_uae_vat_201.py
+++ b/erpnext/regional/report/uae_vat_201/test_uae_vat_201.py
@@ -96,6 +96,54 @@ class TestUaeVat201(ERPNextTestSuite):
 		self.assertEqual(get_standard_rated_expenses_total(filters), 917.5)
 		self.assertEqual(get_standard_rated_expenses_tax(filters), 50)
 
+	def test_uae_vat_201_report_with_purchase_return(self):
+		def make_pi(**kwargs):
+			pi = make_purchase_invoice(
+				company="_Test Company UAE VAT",
+				supplier="_Test UAE Supplier",
+				supplier_warehouse="_Test UAE VAT Supplier Warehouse - _TCUV",
+				warehouse="_Test UAE VAT Supplier Warehouse - _TCUV",
+				currency="AED",
+				cost_center="Main - _TCUV",
+				expense_account="Cost of Goods Sold - _TCUV",
+				item="_Test UAE VAT Item",
+				rate=100,
+				do_not_save=1,
+				uom="Nos",
+				**kwargs,
+			)
+			pi.append(
+				"taxes",
+				{
+					"charge_type": "On Net Total",
+					"account_head": "VAT 5% - _TCUV",
+					"cost_center": "Main - _TCUV",
+					"description": "VAT 5% @ 5.0",
+					"rate": 5.0,
+				},
+			)
+			return pi
+
+		pi = make_pi(qty=10)
+		pi.recoverable_standard_rated_expenses = 50
+		pi.save().submit()
+
+		linked_return = make_pi(qty=-4, is_return=1, return_against=pi.name)
+		linked_return.recoverable_standard_rated_expenses = 20
+		linked_return.save().submit()
+
+		standalone_return = make_pi(qty=-2, is_return=1)
+		standalone_return.recoverable_standard_rated_expenses = -10
+		standalone_return.save().submit()
+
+		typo = make_pi(qty=3)
+		typo.recoverable_standard_rated_expenses = -5
+		typo.save().submit()
+
+		filters = {"company": "_Test Company UAE VAT"}
+		self.assertEqual(get_standard_rated_expenses_total(filters), 400)
+		self.assertEqual(get_standard_rated_expenses_tax(filters), 20)
+
 
 def set_vat_accounts():
 	if not frappe.db.exists("UAE VAT Settings", "_Test Company UAE VAT"):

--- a/erpnext/regional/report/uae_vat_201/uae_vat_201.py
+++ b/erpnext/regional/report/uae_vat_201/uae_vat_201.py
@@ -4,7 +4,8 @@
 
 import frappe
 from frappe import _
-from frappe.query_builder.functions import Sum
+from frappe.query_builder import Case
+from frappe.query_builder.functions import Abs, Sum
 
 from erpnext import get_region
 
@@ -286,42 +287,40 @@ def get_conditions_join(filters, p):
 	return conditions
 
 
+def standard_rated_expenses_scope(p):
+	recoverable = p.recoverable_standard_rated_expenses
+	return ((p.is_return != 1) & (recoverable > 0)) | ((p.is_return == 1) & (recoverable != 0))
+
+
 def get_standard_rated_expenses_total(filters):
-	"""Returns the sum of the total of each Purchase invoice made with recoverable reverse charge."""
-	query_filters = get_filters(filters)
-	query_filters.append(["recoverable_standard_rated_expenses", ">", 0])
-	query_filters.append(["docstatus", "=", 1])
+	"""Returns the net base amount of standard rated purchases, less purchase returns."""
+	p = frappe.qb.DocType("Purchase Invoice")
+	query = (
+		frappe.qb.from_(p)
+		.select(Sum(p.base_total))
+		.where((p.docstatus == 1) & standard_rated_expenses_scope(p))
+	)
+	for condition in get_conditions_join(filters, p):
+		query = query.where(condition)
 	try:
-		return (
-			frappe.db.get_all(
-				"Purchase Invoice",
-				filters=query_filters,
-				fields=[{"SUM": "base_total"}],
-				as_list=True,
-				limit=1,
-			)[0][0]
-			or 0
-		)
+		return query.run()[0][0] or 0
 	except (IndexError, TypeError):
 		return 0
 
 
 def get_standard_rated_expenses_tax(filters):
-	"""Returns the sum of the tax of each Purchase invoice made."""
-	query_filters = get_filters(filters)
-	query_filters.append(["recoverable_standard_rated_expenses", ">", 0])
-	query_filters.append(["docstatus", "=", 1])
+	"""Returns the net recoverable standard rated input VAT, less purchase returns."""
+	p = frappe.qb.DocType("Purchase Invoice")
+	recoverable = p.recoverable_standard_rated_expenses
+	query = (
+		frappe.qb.from_(p)
+		.select(Sum(Case().when(p.is_return == 1, Abs(recoverable) * -1).else_(recoverable)))
+		.where((p.docstatus == 1) & standard_rated_expenses_scope(p))
+	)
+	for condition in get_conditions_join(filters, p):
+		query = query.where(condition)
 	try:
-		return (
-			frappe.db.get_all(
-				"Purchase Invoice",
-				filters=query_filters,
-				fields=[{"SUM": "recoverable_standard_rated_expenses"}],
-				as_list=True,
-				limit=1,
-			)[0][0]
-			or 0
-		)
+		return query.run()[0][0] or 0
 	except (IndexError, TypeError):
 		return 0
 


### PR DESCRIPTION
**Issue Statement:**
The Input VAT amount shown in the UAE VAT 201 report does not match our actual Input VAT ledger balance, for the period 1 June 2026 to 31 July 2026. This is on the Purchase Invoice side.

**Issue Detailed Description:**
We track VAT using two separate ledger accounts in our Chart of Accounts - one for Input VAT (tax paid on purchases) and one for Output VAT (tax collected on sales).

For the period 1 June 2026 to 31 July 2026: Input VAT ledger account balance (net) is AED 103,566.77. Input VAT shown in the UAE VAT 201 report (Box 9 - Standard Rated Expenses) is AED 103,824.04. The difference is about AED 257.52, with VAT 201 showing a higher amount than our actual ledger.

The Output VAT side matches correctly between the ledger and the VAT 201 report, so this issue only affects the Purchase Invoice / Input VAT side.

We believe this is related to Purchase Return invoices (credit notes) raised against purchases in this period. Some of these returns are linked to their original Purchase Invoice, and some are not linked to any Purchase Invoice. It looks like these return invoices are not being included in the VAT 201 report’s Input VAT figure, even though they are correctly reducing our Input VAT ledger balance.

**Steps to Replicate the issue:**

1.Open the UAE VAT 201 report in the ERP.

2.Set Company = INTERCLEAN DETERGENTS & DISINFECTANTS MANUFACTURING L.L.C, From Date = 01-06-2026, To Date = 31-07-2026, and run the report. Note the Input VAT amount under Box 9 “Standard Rated Expenses”.

3.Separately, check the actual balance of the Input VAT ledger account for the same period (via Trial Balance or General Ledger) and compare it to the VAT 201 figure above.
