### PR TITLE
fix: filter fully ordered items when creating RFQ from Material Request

### DIFF
--- a/erpnext/stock/doctype/material_request/mapper.py
+++ b/erpnext/stock/doctype/material_request/mapper.py
@@ -139,6 +139,15 @@ def make_purchase_order(
 
 @frappe.whitelist()
 def make_request_for_quotation(source_name: str, target_doc: str | dict | Document | None = None):
+	def update_item(obj, target, source_parent):
+		qty = obj.ordered_qty or obj.received_qty
+		target.qty = flt(flt(obj.stock_qty) - flt(qty)) / target.conversion_factor
+		target.stock_qty = target.qty * target.conversion_factor
+
+	def select_item(d):
+		qty = d.ordered_qty or d.received_qty
+		return qty < d.stock_qty
+
 	doclist = get_mapped_doc(
 		"Material Request",
 		source_name,
@@ -155,6 +164,8 @@ def make_request_for_quotation(source_name: str, target_doc: str | dict | Docume
 					["project", "project_name"],
 					["cost_center", "cost_center"],
 				],
+				"postprocess": update_item,
+				"condition": select_item,
 			},
 		},
 		target_doc,

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -14,6 +14,7 @@ from erpnext.stock.doctype.material_request.mapper import (
 	create_pick_list,
 	make_in_transit_stock_entry,
 	make_purchase_order,
+	make_request_for_quotation,
 	make_stock_entry,
 	make_supplier_quotation,
 )
@@ -51,6 +52,24 @@ class TestMaterialRequest(ERPNextTestSuite):
 
 		self.assertEqual(po.doctype, "Purchase Order")
 		self.assertEqual(len(po.get("items")), len(mr.get("items")))
+
+	def test_make_request_for_quotation_skips_ordered_items(self):
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0]).insert()
+		mr = frappe.get_doc("Material Request", mr.name)
+		mr.submit()
+
+		# fully order the first item, leave the second pending
+		po = make_purchase_order(mr.name)
+		po.supplier = "_Test Supplier"
+		po.items = [po.items[0]]
+		po.insert()
+		po.submit()
+
+		rfq = make_request_for_quotation(mr.name)
+
+		self.assertEqual(len(rfq.get("items")), 1)
+		self.assertEqual(rfq.items[0].material_request_item, mr.items[1].name)
+		self.assertEqual(rfq.items[0].qty, mr.items[1].qty)
 
 	def test_make_subcontracted_purchase_order(self):
 		from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -61,7 +61,9 @@ class TestMaterialRequest(ERPNextTestSuite):
 		# fully order the first item, leave the second pending
 		po = make_purchase_order(mr.name)
 		po.supplier = "_Test Supplier"
+		po.schedule_date = today()
 		po.items = [po.items[0]]
+		po.items[0].schedule_date = today()
 		po.insert()
 		po.submit()
 


### PR DESCRIPTION
Create → Request for Quotation from a Material Request was copying all items, including those already fully covered by Purchase Orders. It now filters on pending quantity and sets the RFQ row qty to the pending qty, matching the Create → Purchase Order flow.

https://support.frappe.io/helpdesk/tickets/76461?view=VIEW-HD+Ticket-70178