### PR TITLE
fix(stock): auto-select batch no before saving transaction records

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -799,7 +799,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	process_item_selection(doc, cdt, cdn) {
 		var item = frappe.get_doc(cdt, cdn);
-		let update_stock = 0;
+		let update_stock = ["Sales Invoice", "Purchase Invoice"].includes(doc.doctype) ? doc.update_stock : 0;
 		var me = this;
 
 		item.weight_per_unit = 0;

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -343,6 +343,7 @@ class TransactionBase(StatusUpdater):
 					"item_tax_template": item.get("item_tax_template"),
 					"child_doctype": item.get("doctype"),
 					"child_docname": item.get("name"),
+					"use_serial_batch_fields": item.get("use_serial_batch_fields"),
 				}
 			),
 			self,


### PR DESCRIPTION
Fixed the issue where `batch_no` auto-selection was not working before saving on various Transaction DocTypes, including Sales Invoice, for both client-side reactivity and server-side `process_item_selection`.