### PR TITLE
feat: production plan visualizer page and summary report fix

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -151,6 +151,15 @@ frappe.ui.form.on("Production Plan", {
 				__("View")
 			);
 
+			frm.add_custom_button(
+				__("Plan Visualizer"),
+				() => {
+					frappe.route_options = { production_plan: frm.doc.name };
+					frappe.set_route("production-plan-visualizer");
+				},
+				__("View")
+			);
+
 			if (!["Completed", "Closed"].includes(frm.doc.status)) {
 				frm.add_custom_button(__("Schedule Items"), () => {
 					frm.events.show_schedule_dialog(frm);

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -1,0 +1,1075 @@
+frappe.pages["production-plan-visualizer"].on_page_load = function (wrapper) {
+	const page = frappe.ui.make_app_page({
+		parent: wrapper,
+		title: __("Production Plan Visualizer"),
+		single_column: true,
+	});
+
+	frappe.production_plan_visualizer = new erpnext.ProductionPlanVisualizer(page);
+};
+
+frappe.pages["production-plan-visualizer"].on_page_show = function () {
+	const visualizer = frappe.production_plan_visualizer;
+	if (visualizer && frappe.route_options && frappe.route_options.production_plan) {
+		const plan = frappe.route_options.production_plan;
+		frappe.route_options = null;
+		visualizer.plan_field.set_value(plan);
+	}
+};
+
+erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
+	constructor(page) {
+		this.page = page;
+		this.data = null;
+		this.active_tab = "plan";
+		this.schedule_group = "item";
+		this.schedule_scale = "day";
+		this.body = $(this.page.body);
+		this.make();
+	}
+
+	make() {
+		this.body.html(`${this.styles()}<div class="ppv"></div>`);
+		this.container = this.body.find(".ppv");
+		this.make_plan_field();
+		this.render_blank_state();
+	}
+
+	make_plan_field() {
+		this.plan_field = this.page.add_field({
+			fieldname: "production_plan",
+			label: __("Production Plan"),
+			fieldtype: "Link",
+			options: "Production Plan",
+			get_query: () => ({ filters: { docstatus: ["<", 2] } }),
+			change: () => {
+				const value = this.plan_field.get_value();
+				if (value && value !== this.current_plan) {
+					this.load(value);
+				} else if (!value) {
+					this.current_plan = null;
+					this.render_blank_state();
+				}
+			},
+		});
+	}
+
+	render_blank_state() {
+		this.container.empty().append(
+			frappe.ui.empty_state({
+				icon: "layout-dashboard",
+				title: __("Pick a Production Plan"),
+				description: __("See its progress, sub-assemblies, materials and schedule in one place."),
+				css_class: "ppv-blank",
+			})
+		);
+	}
+
+	load(plan) {
+		this.current_plan = plan;
+		this.render_skeleton();
+		frappe
+			.call({
+				method: "erpnext.manufacturing.page.production_plan_visualizer.production_plan_visualizer.get_plan_overview",
+				args: { production_plan: plan },
+			})
+			.then((r) => {
+				if (this.current_plan !== plan) return;
+				this.data = r.message;
+				this.render();
+			});
+	}
+
+	render_skeleton() {
+		const line = (w, h) => frappe.ui.skeleton.html({ width: w, height: h });
+		this.container.html(`
+			<div class="ppv-hero">
+				<div class="ppv-hero-main">
+					${line("240px", "28px")}
+					<div class="mt-2">${line("180px", "14px")}</div>
+					<div class="mt-4">${line("100%", "8px")}</div>
+				</div>
+				<div class="ppv-stats">
+					${[1, 2, 3, 4].map(() => `<div class="ppv-tile">${line("100%", "48px")}</div>`).join("")}
+				</div>
+			</div>
+			<div class="mt-4">${line("100%", "220px")}</div>
+		`);
+	}
+
+	render() {
+		this.container.empty();
+		this.render_hero();
+		this.render_tabs();
+		this.panel = $('<div class="ppv-panel"></div>').appendTo(this.container);
+		this.render_active_panel();
+	}
+
+	render_hero() {
+		const plan = this.data.plan;
+		const hero = $(`
+			<div class="ppv-hero">
+				<div class="ppv-hero-main">
+					<div class="ppv-hero-title">
+						<a class="ppv-plan-link" href="/app/production-plan/${encodeURIComponent(plan.name)}">
+							${frappe.utils.escape_html(plan.name)}</a>
+						<span class="ppv-hero-badge"></span>
+					</div>
+					<div class="ppv-hero-meta">
+						${frappe.utils.escape_html(plan.company)} &middot;
+						${frappe.datetime.str_to_user(plan.posting_date)}
+					</div>
+					<div class="ppv-hero-progress"></div>
+				</div>
+				<div class="ppv-hero-ring"></div>
+				<div class="ppv-stats"></div>
+			</div>
+		`);
+
+		hero.find(".ppv-hero-badge").append(this.status_badge(plan.status, "md"));
+		hero.find(".ppv-hero-progress").append(
+			frappe.ui.progress({
+				value: plan.completion,
+				size: "md",
+				label: __("{0} of {1} produced", [
+					this.format_float(plan.total_produced_qty),
+					this.format_float(plan.total_planned_qty),
+				]),
+				hint: true,
+			})
+		);
+		hero.find(".ppv-hero-ring").html(this.completion_ring(plan.completion));
+		hero.find(".ppv-stats").html(this.stat_tiles());
+		this.container.append(hero);
+	}
+
+	completion_ring(completion) {
+		const radius = 44;
+		const circumference = 2 * Math.PI * radius;
+		const offset = circumference * (1 - Math.min(completion, 100) / 100);
+		return `
+			<svg viewBox="0 0 110 110" class="ppv-ring">
+				<circle class="ppv-ring-track" cx="55" cy="55" r="${radius}"></circle>
+				<circle class="ppv-ring-fill" cx="55" cy="55" r="${radius}"
+					stroke-dasharray="${circumference}" stroke-dashoffset="${offset}"></circle>
+				<text x="55" y="52" class="ppv-ring-value">${Math.round(completion)}%</text>
+				<text x="55" y="70" class="ppv-ring-caption">${__("Complete")}</text>
+			</svg>
+		`;
+	}
+
+	stat_tiles() {
+		const documents = this.all_documents();
+		const tiles = [
+			this.stat_tile(
+				__("Work Orders"),
+				documents.filter((d) => d.doctype === "Work Order")
+			),
+			this.stat_tile(
+				__("Purchase Orders"),
+				documents.filter((d) => d.doctype === "Purchase Order")
+			),
+			this.stat_tile(__("Material Requests"), this.data.material_requests),
+			this.schedule_tile(),
+		];
+		return tiles.join("");
+	}
+
+	stat_tile(label, docs) {
+		const status_dots = Object.entries(this.group_rows(docs, (d) => d.status || __("Draft")))
+			.map(
+				([status, rows]) =>
+					`<span class="ppv-dot-item" title="${frappe.utils.escape_html(status)}">
+						<span class="ppv-dot" data-theme="${this.status_theme(status)}"></span>${rows.length}
+					</span>`
+			)
+			.join("");
+		return `
+			<div class="ppv-tile">
+				<div class="ppv-tile-value">${docs.length}</div>
+				<div class="ppv-tile-label">${frappe.utils.escape_html(label)}</div>
+				<div class="ppv-tile-dots">${status_dots}</div>
+			</div>
+		`;
+	}
+
+	schedule_tile() {
+		const blocks = this.data.schedule || [];
+		const workstations = new Set(blocks.map((d) => d.workstation).filter(Boolean));
+		const caption = workstations.size
+			? __("{0} workstations", [workstations.size])
+			: __("Not scheduled yet");
+		return `
+			<div class="ppv-tile">
+				<div class="ppv-tile-value">${blocks.length}</div>
+				<div class="ppv-tile-label">${__("Schedule Blocks")}</div>
+				<div class="ppv-tile-dots">${frappe.utils.escape_html(caption)}</div>
+			</div>
+		`;
+	}
+
+	all_documents() {
+		const rows = [...this.data.finished_goods, ...this.data.sub_assemblies];
+		return rows.flatMap((row) => row.documents || []);
+	}
+
+	group_rows(rows, key_fn) {
+		return rows.reduce((groups, row) => {
+			const key = key_fn(row);
+			(groups[key] = groups[key] || []).push(row);
+			return groups;
+		}, {});
+	}
+
+	render_tabs() {
+		this.container.append(
+			$('<div class="ppv-tabs"></div>').append(
+				frappe.ui.tab_buttons({
+					label: __("Sections"),
+					type: "ghost",
+					value: this.active_tab,
+					options: [
+						{ label: __("Plan"), value: "plan" },
+						{
+							label: `${__("Schedule")} (${(this.data.schedule || []).length})`,
+							value: "schedule",
+						},
+					],
+					on_change: (value) => {
+						this.active_tab = value;
+						this.render_active_panel();
+					},
+				})
+			)
+		);
+	}
+
+	render_active_panel() {
+		this.panel.empty();
+		if (this.active_tab === "plan") this.render_plan_tree();
+		else this.render_schedule();
+	}
+
+	render_plan_tree() {
+		if (!this.data.finished_goods.length) {
+			this.panel_empty_state(__("No items to manufacture in this plan"));
+			return;
+		}
+		this.panel.append(this.plan_search_bar());
+		this.tree_list = $('<div class="ppv-tree"></div>').appendTo(this.panel);
+		const subs_by_parent = this.group_rows(this.data.sub_assemblies, (d) => d.production_plan_item);
+		const assignments = this.material_assignments();
+
+		for (const fg of this.data.finished_goods) {
+			const branch = $('<div class="ppv-branch"></div>');
+			for (const sub of subs_by_parent[fg.row_name] || []) {
+				const indent = sub.indent || 0;
+				branch.append(this.sub_assembly_row(sub));
+				for (const material of assignments.map[sub.row_name] || []) {
+					branch.append(this.material_row(material, indent + 1));
+				}
+			}
+			delete subs_by_parent[fg.row_name];
+			for (const material of assignments.map[fg.row_name] || []) {
+				branch.append(this.material_row(material, 0));
+			}
+			const node = this.plan_node(fg, branch);
+			node.attr("data-search", node.text().toLowerCase());
+			this.tree_list.append(node);
+		}
+
+		this.append_plan_group(__("Other Sub Assemblies"), Object.values(subs_by_parent).flat(), (d) =>
+			this.sub_assembly_row(d)
+		);
+		this.append_plan_group(__("Other Materials"), assignments.leftovers, (d) => this.material_row(d, 0));
+
+		this.no_results = frappe.ui.empty_state({ icon: "search", title: __("No matching items") }).hide();
+		this.panel.append(this.no_results);
+		this.apply_plan_filter();
+	}
+
+	append_plan_group(label, rows, make_row) {
+		if (!rows.length) return;
+		const group = $('<div class="ppv-group"></div>').append(
+			`<div class="ppv-group-head">${frappe.utils.escape_html(label)}</div>`
+		);
+		for (const row of rows) {
+			const el = make_row(row);
+			el.attr("data-search", el.text().toLowerCase());
+			group.append(el);
+		}
+		this.tree_list.append(group);
+	}
+
+	plan_search_bar() {
+		const bar = $(`
+			<div class="ppv-search">
+				<span class="ppv-search-icon">${frappe.utils.icon("search", "sm", "", "", "", true)}</span>
+				<input type="search" class="ppv-search-input"
+					placeholder="${__("Search item, code or document...")}" />
+				<span class="ppv-search-count"></span>
+			</div>
+		`);
+		this.search_input = bar.find("input");
+		this.search_count = bar.find(".ppv-search-count");
+		this.search_input.val(this.plan_search || "");
+		this.search_input.on("input", () => {
+			this.plan_search = this.search_input.val();
+			this.apply_plan_filter();
+		});
+		return bar;
+	}
+
+	apply_plan_filter() {
+		const query = (this.plan_search || "").trim().toLowerCase();
+		const matches = (el) => !query || ($(el).attr("data-search") || "").includes(query);
+		let visible = 0;
+		let total = 0;
+
+		this.tree_list.children(".ppv-node").each((_, el) => {
+			total += 1;
+			const show = matches(el);
+			$(el).toggle(show);
+			if (show) visible += 1;
+		});
+
+		let group_visible = 0;
+		this.tree_list.children(".ppv-group").each((_, group) => {
+			let shown = 0;
+			$(group)
+				.children("[data-search]")
+				.each((_, el) => {
+					const show = matches(el);
+					$(el).toggle(show);
+					if (show) shown += 1;
+				});
+			$(group).toggle(shown > 0);
+			group_visible += shown;
+		});
+
+		this.search_count.text(query ? __("{0} of {1} items", [visible, total]) : "");
+		this.no_results.toggle(Boolean(query) && !visible && !group_visible);
+	}
+
+	plan_node(fg, branch) {
+		const node = $('<div class="ppv-node"></div>');
+		const card = this.item_card(fg, { show_dates: true });
+		node.append(card);
+		if (!branch.children().length) return node;
+
+		node.append(branch);
+		const caret = frappe.ui.button({
+			icon: "chevron-down",
+			variant: "ghost",
+			size: "sm",
+			title: __("Collapse"),
+			css_class: "ppv-caret",
+			onclick: () => {
+				branch.slideToggle(150);
+				caret.toggleClass("ppv-collapsed");
+			},
+		});
+		card.find(".ppv-card-head").prepend(caret);
+		return node;
+	}
+
+	material_assignments() {
+		const row_materials = this.data.row_materials || {};
+		const bom_consumers = {};
+		for (const [row_name, items] of Object.entries(row_materials)) {
+			for (const item of items) {
+				(bom_consumers[item] = bom_consumers[item] || []).push(row_name);
+			}
+		}
+
+		const map = {};
+		const leftovers = [];
+		for (const material of this.data.materials || []) {
+			const consumers = material.consumers.length
+				? material.consumers
+				: bom_consumers[material.item_code] || [];
+			if (consumers.length) {
+				(map[consumers[0]] = map[consumers[0]] || []).push(material);
+			} else {
+				leftovers.push(material);
+			}
+		}
+		return { map, leftovers };
+	}
+
+	material_row(material, indent) {
+		const completion = material.quantity ? (material.ordered_qty / material.quantity) * 100 : 0;
+		const el = $(`
+			<div class="ppv-sub-row ppv-material-row" style="--ppv-indent: ${indent}">
+				<div class="ppv-sub-item">
+					<div class="ppv-sub-title">
+						<a href="/app/item/${encodeURIComponent(material.item_code)}">
+							${frappe.utils.escape_html(material.item_name || material.item_code)}</a>
+						<span class="ppv-sub-type"></span>
+					</div>
+					<div class="ppv-card-sub">${frappe.utils.escape_html(material.item_code)}</div>
+				</div>
+				<div class="ppv-qty-row ppv-qty-compact">
+					${this.qty_cell(__("Planned"), material.quantity)}
+					${this.qty_cell(__("Requested"), material.requested_qty)}
+					${this.qty_cell(__("Ordered"), material.ordered_qty)}
+				</div>
+				<div class="ppv-sub-progress"></div>
+				<div class="ppv-chips"></div>
+			</div>
+		`);
+		el.find(".ppv-sub-type").append(
+			frappe.ui.badge({
+				label: __(material.material_request_type || "Material"),
+				size: "sm",
+				variant: "ghost",
+			})
+		);
+		el.find(".ppv-sub-progress").append(frappe.ui.progress({ value: completion, hint: true }));
+		this.append_document_chips(el.find(".ppv-chips"), material.documents);
+		return el;
+	}
+
+	item_card(row, { show_dates } = {}) {
+		const completion = row.qty ? (row.produced_qty / row.qty) * 100 : 0;
+		const card = $(`
+			<div class="ppv-card">
+				<div class="ppv-card-head">
+					<div>
+						<div class="ppv-card-title">
+							<a href="/app/item/${encodeURIComponent(row.item_code)}">
+								${frappe.utils.escape_html(row.item_name || row.item_code)}</a>
+						</div>
+						<div class="ppv-card-sub">${frappe.utils.escape_html(row.item_code)}</div>
+					</div>
+					<div class="ppv-card-badges"></div>
+				</div>
+				<div class="ppv-qty-row">
+					${this.qty_cell(__("Planned"), row.qty)}
+					${this.qty_cell(__("Produced"), row.produced_qty)}
+					${this.qty_cell(__("Pending"), row.pending_qty)}
+				</div>
+				<div class="ppv-card-progress"></div>
+				<div class="ppv-chips"></div>
+			</div>
+		`);
+
+		const badges = card.find(".ppv-card-badges");
+		if (row.sales_order) {
+			badges.append(frappe.ui.badge({ label: row.sales_order, theme: "violet", variant: "outline" }));
+		}
+		if (show_dates && row.planned_start_date) {
+			badges.append(
+				frappe.ui.badge({
+					label: frappe.datetime.str_to_user(row.planned_start_date.split(" ")[0]),
+					icon: "calendar",
+					variant: "ghost",
+				})
+			);
+		}
+		card.find(".ppv-card-progress").append(
+			frappe.ui.progress({ value: completion, size: "md", hint: true })
+		);
+		this.append_document_chips(card.find(".ppv-chips"), row.documents);
+		return card;
+	}
+
+	sub_assembly_row(row) {
+		const completion = row.qty ? (row.produced_qty / row.qty) * 100 : 0;
+		const el = $(`
+			<div class="ppv-sub-row" style="--ppv-indent: ${row.indent}">
+				<div class="ppv-sub-item">
+					<div class="ppv-sub-title">
+						<a href="/app/item/${encodeURIComponent(row.item_code)}">
+							${frappe.utils.escape_html(row.item_name || row.item_code)}</a>
+						<span class="ppv-sub-type"></span>
+					</div>
+					<div class="ppv-card-sub">${frappe.utils.escape_html(row.item_code)}</div>
+				</div>
+				<div class="ppv-qty-row ppv-qty-compact">
+					${this.qty_cell(__("Planned"), row.qty)}
+					${this.qty_cell(__("Done"), row.produced_qty)}
+					${this.qty_cell(__("Pending"), row.pending_qty)}
+				</div>
+				<div class="ppv-sub-progress"></div>
+				<div class="ppv-chips"></div>
+			</div>
+		`);
+		el.find(".ppv-sub-type").append(
+			frappe.ui.badge({
+				label: __(row.type_of_manufacturing || "In House"),
+				size: "sm",
+				theme: row.type_of_manufacturing === "Subcontract" ? "amber" : "blue",
+				variant: "outline",
+			})
+		);
+		el.find(".ppv-sub-progress").append(frappe.ui.progress({ value: completion, hint: true }));
+		this.append_document_chips(el.find(".ppv-chips"), row.documents);
+		return el;
+	}
+
+	append_document_chips(target, documents) {
+		if (!documents || !documents.length) {
+			target.append(`<span class="ppv-no-docs">${__("No documents yet")}</span>`);
+			return;
+		}
+		for (const doc of documents) {
+			const route = `/app/${frappe.router.slug(doc.doctype)}/${encodeURIComponent(doc.name)}`;
+			const label = doc.status ? `${doc.name} · ${__(doc.status)}` : doc.name;
+			const icons = {
+				"Purchase Order": "shopping-cart",
+				"Material Request": "clipboard-list",
+			};
+			$(`<a class="ppv-chip-link" href="${route}"></a>`)
+				.append(
+					frappe.ui.badge({
+						label: label,
+						theme: this.status_theme(doc.status),
+						icon: icons[doc.doctype] || "factory",
+					})
+				)
+				.appendTo(target);
+		}
+	}
+
+	render_schedule() {
+		const blocks = this.data.schedule || [];
+		if (!blocks.length) {
+			this.panel_empty_state(
+				__("No schedule yet — use Schedule Items on the Production Plan to build one")
+			);
+			return;
+		}
+		this.panel.append(this.schedule_toolbar());
+		this.panel.append(this.schedule_timeline(blocks));
+	}
+
+	schedule_toolbar() {
+		const toggle = (label, value, options, on_change) =>
+			frappe.ui.tab_buttons({
+				label,
+				type: "subtle",
+				size: "sm",
+				value,
+				options,
+				on_change,
+			});
+		return $('<div class="ppv-schedule-toolbar"></div>')
+			.append(
+				toggle(
+					__("Group by"),
+					this.schedule_group,
+					[
+						{ label: __("By Item"), value: "item" },
+						{ label: __("By Workstation"), value: "workstation" },
+					],
+					(value) => {
+						this.schedule_group = value;
+						this.render_active_panel();
+					}
+				)
+			)
+			.append(
+				toggle(
+					__("Scale"),
+					this.schedule_scale,
+					[
+						{ label: __("Day"), value: "day" },
+						{ label: __("Hour"), value: "hour" },
+					],
+					(value) => {
+						this.schedule_scale = value;
+						this.render_active_panel();
+					}
+				)
+			);
+	}
+
+	schedule_timeline(blocks) {
+		const raw_start = Math.min(...blocks.map((d) => frappe.datetime.str_to_obj(d.from_time).getTime()));
+		const raw_end = Math.max(...blocks.map((d) => frappe.datetime.str_to_obj(d.to_time).getTime()));
+		const axis = this.timeline_ticks(raw_start, raw_end);
+		const span = Math.max(axis.end - axis.start, 1);
+
+		const timeline = $(
+			`<div class="ppv-timeline" style="--ppv-ticks: ${axis.ticks.length}; --ppv-tick-w: ${axis.tick_width}"></div>`
+		);
+		timeline.append(`
+			<div class="ppv-timeline-header">
+				<div class="ppv-timeline-label">${__("Timeline")}</div>
+				<div class="ppv-axis">${axis.ticks
+					.map((tick) => `<div class="ppv-axis-tick">${frappe.utils.escape_html(tick)}</div>`)
+					.join("")}</div>
+			</div>
+		`);
+		for (const descriptor of this.schedule_rows(blocks)) {
+			timeline.append(this.timeline_row(descriptor, axis.start, span));
+		}
+		return $('<div class="ppv-timeline-scroll"></div>').append(timeline);
+	}
+
+	timeline_ticks(start, end) {
+		const hour_ms = 3600000;
+		if (this.schedule_scale === "hour") {
+			const span_hours = Math.max((end - start) / hour_ms, 1);
+			const step = span_hours <= 24 ? 1 : span_hours <= 72 ? 3 : span_hours <= 240 ? 6 : 12;
+			const first = new Date(start);
+			first.setMinutes(0, 0, 0);
+			first.setHours(Math.floor(first.getHours() / step) * step);
+			const ticks = [];
+			for (let time = first.getTime(); time < end; time += step * hour_ms) {
+				const date = new Date(time);
+				ticks.push(
+					date.getHours() === 0
+						? frappe.datetime.obj_to_user(date).slice(0, 5)
+						: `${String(date.getHours()).padStart(2, "0")}:00`
+				);
+			}
+			return {
+				ticks,
+				start: first.getTime(),
+				end: first.getTime() + ticks.length * step * hour_ms,
+				tick_width: "72px",
+			};
+		}
+		const first = new Date(start);
+		first.setHours(0, 0, 0, 0);
+		const ticks = [];
+		for (let time = first.getTime(); time < end; time += 24 * hour_ms) {
+			ticks.push(frappe.datetime.obj_to_user(new Date(time)).slice(0, 5));
+		}
+		return {
+			ticks,
+			start: first.getTime(),
+			end: first.getTime() + ticks.length * 24 * hour_ms,
+			tick_width: "96px",
+		};
+	}
+
+	schedule_rows(blocks) {
+		if (this.schedule_group === "workstation") {
+			const groups = this.group_rows(blocks, (d) => d.workstation || d.supplier || __("Unassigned"));
+			return Object.entries(groups).map(([label, rows]) => ({
+				label,
+				indent: 0,
+				blocks: rows,
+			}));
+		}
+		return this.schedule_tree(blocks);
+	}
+
+	schedule_tree(blocks) {
+		const by_row = this.group_rows(blocks, (d) => d.plan_row || "");
+		const material_blocks = this.group_rows(
+			blocks.filter((d) => d.row_type === "Raw Material"),
+			(d) => d.item_code
+		);
+		const row_materials = this.data.row_materials || {};
+		const subs_by_parent = this.group_rows(this.data.sub_assemblies, (d) => d.production_plan_item);
+		const used_materials = new Set();
+		const used_rows = new Set();
+
+		const material_rows = (row_name, indent) =>
+			(row_materials[row_name] || []).flatMap((item) => {
+				if (used_materials.has(item) || !material_blocks[item]) return [];
+				used_materials.add(item);
+				const rows = material_blocks[item];
+				return [{ label: rows[0].item_name || item, indent, blocks: rows }];
+			});
+
+		const out = [];
+		for (const fg of this.data.finished_goods) {
+			used_rows.add(fg.row_name);
+			const branch = [];
+			for (const sub of subs_by_parent[fg.row_name] || []) {
+				used_rows.add(sub.row_name);
+				const indent = 1 + (sub.indent || 0);
+				const sub_blocks = by_row[sub.row_name] || [];
+				const children = material_rows(sub.row_name, indent + 1);
+				if (sub_blocks.length || children.length) {
+					branch.push(
+						{ label: sub.item_name || sub.item_code, indent, blocks: sub_blocks },
+						...children
+					);
+				}
+			}
+			branch.push(...material_rows(fg.row_name, 1));
+			const fg_blocks = by_row[fg.row_name] || [];
+			if (fg_blocks.length || branch.length) {
+				out.push({ label: fg.item_name || fg.item_code, indent: 0, blocks: fg_blocks }, ...branch);
+			}
+		}
+
+		const leftover = blocks.filter((d) =>
+			d.row_type === "Raw Material" ? !used_materials.has(d.item_code) : !used_rows.has(d.plan_row)
+		);
+		for (const [label, rows] of Object.entries(
+			this.group_rows(leftover, (d) => d.item_name || d.item_code || d.subject)
+		)) {
+			out.push({ label, indent: 0, blocks: rows });
+		}
+		return out;
+	}
+
+	timeline_row(descriptor, start, span) {
+		const { label, indent, blocks } = descriptor;
+		const row = $(`
+			<div class="ppv-timeline-row" data-depth="${indent > 0 ? "child" : "root"}">
+				<div class="ppv-timeline-label" style="--ppv-row-indent: ${indent}"
+					title="${frappe.utils.escape_html(label)}">
+					${indent > 0 ? '<span class="ppv-tree-branch">└</span>' : ""}
+					${frappe.utils.escape_html(label)}</div>
+				<div class="ppv-track"></div>
+			</div>
+		`);
+		const track = row.find(".ppv-track");
+		for (const block of blocks) {
+			const from = frappe.datetime.str_to_obj(block.from_time).getTime();
+			const to = frappe.datetime.str_to_obj(block.to_time).getTime();
+			const left = ((from - start) / span) * 100;
+			const width = Math.max(((to - from) / span) * 100, 0.6);
+			const title = [
+				block.subject,
+				`${frappe.datetime.str_to_user(block.from_time)} → ${frappe.datetime.str_to_user(
+					block.to_time
+				)}`,
+				block.workstation || block.supplier || "",
+			]
+				.filter(Boolean)
+				.join("\n");
+			$(`<a class="ppv-block" data-row-type="${frappe.utils.escape_html(block.row_type || "")}"
+				style="left: ${left}%; width: ${width}%"
+				href="/app/production-plan-schedule/${encodeURIComponent(block.name)}"
+				title="${frappe.utils.escape_html(title)}">
+				<span>${frappe.utils.escape_html(block.operation || block.item_name || block.subject || "")}</span>
+			</a>`).appendTo(track);
+		}
+		return row;
+	}
+
+	qty_cell(label, value, { integer } = {}) {
+		return `
+			<div class="ppv-qty-cell">
+				<div class="ppv-qty-label">${frappe.utils.escape_html(label)}</div>
+				<div class="ppv-qty-value">${integer ? cint(value) : this.format_float(value)}</div>
+			</div>
+		`;
+	}
+
+	format_float(value) {
+		return format_number(flt(value));
+	}
+
+	status_badge(status, size) {
+		return frappe.ui.badge({
+			label: __(status || "Draft"),
+			theme: this.status_theme(status),
+			size: size || "md",
+		});
+	}
+
+	status_theme(status) {
+		const themes = {
+			Completed: "green",
+			Transferred: "green",
+			Received: "green",
+			Ordered: "green",
+			"In Process": "blue",
+			Submitted: "blue",
+			"In Progress": "blue",
+			Pending: "amber",
+			"Not Started": "amber",
+			"Partially Ordered": "amber",
+			"Partially Received": "amber",
+			"To Receive and Bill": "amber",
+			"To Receive": "amber",
+			"To Bill": "amber",
+			Stopped: "red",
+			Cancelled: "red",
+			Draft: "gray",
+			Closed: "gray",
+			"On Hold": "gray",
+		};
+		return themes[status] || "gray";
+	}
+
+	panel_empty_state(title) {
+		this.panel.append(
+			frappe.ui.empty_state({
+				icon: "inbox",
+				title: title,
+				css_class: "ppv-panel-empty",
+			})
+		);
+	}
+
+	styles() {
+		return `<style>
+			.ppv { max-width: 1100px; margin: 0 auto; padding-bottom: var(--padding-2xl); }
+			.ppv-blank, .ppv-panel-empty { min-height: 320px; }
+
+			.ppv-hero {
+				display: grid;
+				grid-template-columns: 1fr auto;
+				gap: var(--padding-lg) var(--padding-2xl);
+				background: var(--card-bg, var(--fg-color));
+				border: 1px solid var(--border-color);
+				border-radius: var(--border-radius-lg);
+				padding: var(--padding-xl);
+				margin-top: var(--padding-md);
+			}
+			.ppv-hero-title { display: flex; align-items: center; gap: 10px; }
+			.ppv-plan-link {
+				font-size: var(--text-xl);
+				font-weight: 600;
+				color: var(--heading-color);
+				text-decoration: none;
+			}
+			.ppv-hero-meta { color: var(--text-muted); margin-top: 2px; font-size: var(--text-sm); }
+			.ppv-hero-progress { margin-top: var(--padding-lg); max-width: 460px; }
+
+			.ppv-ring { width: 110px; height: 110px; }
+			.ppv-ring-track { fill: none; stroke: var(--bg-color); stroke-width: 10; }
+			.ppv-ring-fill {
+				fill: none;
+				stroke: var(--primary);
+				stroke-width: 10;
+				stroke-linecap: round;
+				transform: rotate(-90deg);
+				transform-origin: 55px 55px;
+				transition: stroke-dashoffset 0.6s ease;
+			}
+			.ppv-ring-value {
+				text-anchor: middle;
+				font-size: 22px;
+				font-weight: 700;
+				fill: var(--heading-color);
+			}
+			.ppv-ring-caption { text-anchor: middle; font-size: 10px; fill: var(--text-muted); }
+
+			.ppv-stats {
+				grid-column: 1 / -1;
+				display: grid;
+				grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+				gap: var(--padding-md);
+				border-top: 1px solid var(--border-color);
+				padding-top: var(--padding-lg);
+			}
+			.ppv-tile-value {
+				font-size: var(--text-2xl);
+				font-weight: 700;
+				color: var(--heading-color);
+				font-variant-numeric: tabular-nums;
+			}
+			.ppv-tile-label {
+				font-size: var(--text-xs);
+				text-transform: uppercase;
+				letter-spacing: 0.05em;
+				color: var(--text-muted);
+				margin-top: 2px;
+			}
+			.ppv-tile-dots {
+				display: flex; gap: 10px; margin-top: 6px;
+				font-size: var(--text-xs); color: var(--text-muted);
+			}
+			.ppv-dot-item { display: inline-flex; align-items: center; gap: 4px; }
+			.ppv-dot { width: 7px; height: 7px; border-radius: 999px; background: var(--gray-400); }
+			.ppv-dot[data-theme="green"] { background: var(--green-500); }
+			.ppv-dot[data-theme="blue"] { background: var(--blue-500); }
+			.ppv-dot[data-theme="amber"] { background: var(--yellow-500); }
+			.ppv-dot[data-theme="red"] { background: var(--red-500); }
+
+			.ppv-tabs { margin: var(--padding-lg) 0 var(--padding-md); }
+
+			.ppv-search {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				max-width: 380px;
+				margin-bottom: var(--padding-md);
+				background: var(--fg-color);
+				border: 1px solid var(--border-color);
+				border-radius: var(--border-radius);
+				padding: 6px 10px;
+			}
+			.ppv-search:focus-within { border-color: var(--primary); }
+			.ppv-search-icon { display: flex; color: var(--text-muted); }
+			.ppv-search-input {
+				flex: 1;
+				border: none;
+				outline: none;
+				background: transparent;
+				font-size: var(--text-md);
+				color: var(--text-color);
+			}
+			.ppv-search-count {
+				color: var(--text-muted);
+				font-size: var(--text-xs);
+				white-space: nowrap;
+			}
+
+			.ppv-node { margin-bottom: var(--padding-md); }
+			.ppv-node > .ppv-card { margin-bottom: 0; }
+			.ppv-branch {
+				margin: var(--padding-sm) 0 0 var(--padding-xl);
+				padding-left: var(--padding-lg);
+				border-left: 2px solid var(--border-color);
+			}
+			.ppv-caret { margin-right: 4px; align-self: flex-start; }
+			.ppv-caret svg { transition: transform 0.15s ease; }
+			.ppv-caret.ppv-collapsed svg { transform: rotate(-90deg); }
+			.ppv-material-row { border-style: dashed; }
+			.ppv-material-row .ppv-sub-title a { font-weight: 500; }
+
+			.ppv-card {
+				background: var(--card-bg, var(--fg-color));
+				border: 1px solid var(--border-color);
+				border-radius: var(--border-radius-lg);
+				padding: var(--padding-lg);
+				margin-bottom: var(--padding-md);
+				transition: box-shadow 0.15s ease;
+			}
+			.ppv-card:hover { box-shadow: var(--shadow-sm); }
+			.ppv-card-head { display: flex; gap: var(--padding-md); }
+			.ppv-card-head .ppv-card-badges { margin-left: auto; }
+			.ppv-card-title a { color: var(--heading-color); font-weight: 600; text-decoration: none; }
+			.ppv-card-sub { color: var(--text-muted); font-size: var(--text-sm); margin-top: 1px; }
+			.ppv-card-badges { display: flex; gap: 6px; align-items: flex-start; flex-wrap: wrap; }
+			.ppv-card-progress { margin-top: var(--padding-sm); max-width: 460px; }
+
+			.ppv-qty-row {
+				display: flex;
+				gap: var(--padding-2xl);
+				margin-top: var(--padding-md);
+				justify-content: flex-end;
+			}
+			.ppv-qty-cell { text-align: right; min-width: 90px; }
+			.ppv-qty-label {
+				font-size: var(--text-xs);
+				text-transform: uppercase;
+				letter-spacing: 0.05em;
+				color: var(--text-muted);
+				text-align: right;
+			}
+			.ppv-qty-value {
+				font-size: var(--text-lg);
+				font-weight: 600;
+				color: var(--heading-color);
+				font-variant-numeric: tabular-nums;
+				text-align: right;
+			}
+			.ppv-qty-compact .ppv-qty-value { font-size: var(--text-base); }
+			.ppv-qty-compact { gap: var(--padding-lg); margin-top: 0; }
+
+			.ppv-chips {
+				display: flex; flex-wrap: wrap; gap: 6px;
+				margin-top: var(--padding-md);
+			}
+			.ppv-chip-link { text-decoration: none; }
+			.ppv-no-docs { color: var(--text-muted); font-size: var(--text-sm); }
+
+			.ppv-group-head {
+				font-size: var(--text-xs);
+				text-transform: uppercase;
+				letter-spacing: 0.05em;
+				color: var(--text-muted);
+				margin: var(--padding-lg) 0 var(--padding-sm);
+			}
+			.ppv-sub-row {
+				display: grid;
+				grid-template-columns: minmax(220px, 1.2fr) auto minmax(140px, 0.8fr);
+				gap: var(--padding-sm) var(--padding-xl);
+				align-items: center;
+				background: var(--card-bg, var(--fg-color));
+				border: 1px solid var(--border-color);
+				border-radius: var(--border-radius-lg);
+				padding: var(--padding-md) var(--padding-lg);
+				margin-bottom: var(--padding-sm);
+				margin-left: calc(var(--ppv-indent, 0) * 24px);
+			}
+			.ppv-sub-title { display: flex; align-items: center; gap: 8px; }
+			.ppv-sub-title a { color: var(--heading-color); font-weight: 600; text-decoration: none; }
+			.ppv-sub-row .ppv-chips { grid-column: 1 / -1; margin-top: 0; }
+
+			.ppv-schedule-toolbar {
+				display: flex;
+				gap: var(--padding-md);
+				flex-wrap: wrap;
+				margin-bottom: var(--padding-md);
+			}
+			.ppv-timeline-scroll { overflow-x: auto; border: 1px solid var(--border-color);
+				border-radius: var(--border-radius-lg); background: var(--card-bg, var(--fg-color)); }
+			.ppv-timeline { min-width: calc(220px + var(--ppv-ticks) * var(--ppv-tick-w, 96px)); }
+			.ppv-timeline-header, .ppv-timeline-row {
+				display: grid;
+				grid-template-columns: 220px 1fr;
+				border-bottom: 1px solid var(--border-color);
+			}
+			.ppv-timeline-row:last-child { border-bottom: none; }
+			.ppv-timeline-label {
+				padding: var(--padding-md) var(--padding-lg);
+				padding-left: calc(var(--padding-lg) + var(--ppv-row-indent, 0) * 18px);
+				font-weight: 600;
+				color: var(--heading-color);
+				border-right: 1px solid var(--border-color);
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+			.ppv-timeline-row[data-depth="child"] .ppv-timeline-label {
+				font-weight: 400;
+				color: var(--text-color);
+			}
+			.ppv-tree-branch { color: var(--text-muted); margin-right: 4px; }
+			.ppv-axis { display: grid; grid-template-columns: repeat(var(--ppv-ticks), 1fr); }
+			.ppv-axis-tick {
+				padding: var(--padding-md) 8px;
+				font-size: var(--text-xs);
+				color: var(--text-muted);
+				border-right: 1px dashed var(--border-color);
+				white-space: nowrap;
+			}
+			.ppv-track {
+				position: relative;
+				min-height: 44px;
+				background-image: repeating-linear-gradient(
+					to right,
+					transparent,
+					transparent calc(100% / var(--ppv-ticks) - 1px),
+					var(--border-color) calc(100% / var(--ppv-ticks) - 1px),
+					var(--border-color) calc(100% / var(--ppv-ticks))
+				);
+			}
+			.ppv-block {
+				position: absolute;
+				top: 8px;
+				height: 28px;
+				border-radius: var(--border-radius);
+				background: var(--blue-100);
+				border: 1px solid var(--blue-300);
+				color: var(--blue-700);
+				font-size: var(--text-xs);
+				line-height: 26px;
+				padding: 0 8px;
+				overflow: hidden;
+				white-space: nowrap;
+				text-overflow: ellipsis;
+				text-decoration: none;
+			}
+			.ppv-block:hover { filter: brightness(0.97); text-decoration: none; }
+			.ppv-block[data-row-type="Finished Good"] {
+				background: var(--purple-100); border-color: var(--purple-300); color: var(--purple-700);
+			}
+			.ppv-block[data-row-type="Raw Material"] {
+				background: var(--yellow-100); border-color: var(--yellow-300); color: var(--yellow-700);
+			}
+
+			@media (max-width: 768px) {
+				.ppv-hero { grid-template-columns: 1fr; }
+				.ppv-hero-ring { display: none; }
+				.ppv-qty-row { gap: var(--padding-lg); }
+				.ppv-sub-row { grid-template-columns: 1fr; }
+			}
+		</style>`;
+	}
+};

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -1010,10 +1010,16 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 				background: transparent;
 				border: none;
 				padding: 0;
-				margin: 0 0 var(--padding-sm);
+				margin: 0 2px var(--padding-sm);
 			}
 
-			.ppv { display: flex; flex-direction: column; gap: var(--padding-sm); overflow: hidden; }
+			.ppv {
+				display: flex;
+				flex-direction: column;
+				gap: var(--padding-sm);
+				margin: 0 2px;
+				overflow: hidden;
+			}
 			.ppv-fill { flex: 1 1 auto; display: flex; align-items: center; justify-content: center; }
 			.ppv-muted { color: var(--text-muted); }
 			.ppv-uom { color: var(--text-muted); font-size: var(--text-xs); }

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -177,10 +177,10 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 
 	material_owners(material) {
 		const key = `${material.main_item_code || ""}::${material.from_bom || ""}`;
-		const candidates = this.index.subs_by_signature[key] || [];
-		if (candidates.length) return this.owners_of(candidates.map((d) => d.row_name));
-		if (material.consumer) return this.owners_of([material.consumer]);
-		return this.owners_of(this.index.bom_consumers[material.item_code] || []);
+		const rows = (this.index.subs_by_signature[key] || []).map((d) => d.row_name);
+		if (material.consumer) rows.push(material.consumer);
+		rows.push(...(this.index.bom_consumers[material.item_code] || []));
+		return this.owners_of(rows);
 	}
 
 	owners_of(row_names) {

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -608,7 +608,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 					<div class="ppv-item-sub">${this.esc(row.item_code)}</div>
 				</td>
 				<td class="ppv-num">${this.format_float(row.qty)} <span class="ppv-uom">${this.esc(uom)}</span></td>
-				<td class="ppv-num">${kind === "sub" ? this.format_float(row.available_qty) : "—"}</td>
+				<td class="ppv-num">${kind === "sub" ? this.stock_value(row) : "—"}</td>
 				<td class="ppv-num">${this.format_float(row.produced_qty)}</td>
 				<td class="ppv-num ${row.pending_qty > 0 ? "ppv-pending" : ""}">${this.format_float(row.pending_qty)}</td>
 				<td class="ppv-col-progress"></td>
@@ -699,7 +699,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 				<td class="ppv-num">${this.format_float(material.required_qty)} <span class="ppv-uom">${this.esc(
 			material.uom || ""
 		)}</span></td>
-				<td class="ppv-num">${this.format_float(material.available_qty)}</td>
+				<td class="ppv-num">${this.stock_value(material)}</td>
 				<td class="ppv-num">${this.format_float(material.to_procure_qty)}</td>
 				<td class="ppv-num">${this.format_float(material.requested_qty)}</td>
 				<td class="ppv-num">${this.format_float(material.ordered_qty)}</td>
@@ -1168,6 +1168,15 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		return frappe.utils.escape_html(value == null ? "" : String(value));
 	}
 
+	stock_value(row) {
+		if (!row.stock_known) {
+			return `<span class="ppv-unknown" title="${this.esc(
+				__("Stock for this warehouse is not visible to you")
+			)}">—</span>`;
+		}
+		return this.format_float(row.available_qty);
+	}
+
 	format_float(value) {
 		return format_number(flt(value));
 	}
@@ -1300,6 +1309,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			.ppv-fill { flex: 1 1 auto; display: flex; align-items: center; justify-content: center; }
 			.ppv-muted { color: var(--text-muted); }
 			.ppv-uom { color: var(--text-muted); font-size: var(--text-xs); }
+			.ppv-unknown { color: var(--text-muted); cursor: help; }
 
 			.ppv-kpis {
 				flex: 0 0 auto;

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -144,7 +144,10 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			(subs_by_signature[key] = subs_by_signature[key] || []).push(sub);
 		}
 
-		this.index = { subs_by_parent, owner_of_row, bom_consumers, subs_by_signature };
+		const fg_label = {};
+		for (const fg of this.data.finished_goods) fg_label[fg.row_name] = fg.item_name || fg.item_code;
+
+		this.index = { subs_by_parent, owner_of_row, bom_consumers, subs_by_signature, fg_label };
 		for (const material of this.data.materials || []) {
 			material.owners = this.material_owners(material);
 		}
@@ -616,8 +619,8 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 	}
 
 	render_materials() {
-		const { owned, shared } = this.focused_materials();
-		if (!owned.length && !shared.length) {
+		const { owned, unassigned } = this.focused_materials();
+		if (!owned.length && !unassigned.length) {
 			this.render_empty(__("No raw materials planned for this plan yet"));
 			return;
 		}
@@ -634,9 +637,9 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		]);
 
 		for (const material of owned) body.append(this.material_row(material));
-		if (shared.length) {
-			body.append(this.group_row(__("Shared across finished goods"), 9));
-			for (const material of shared) body.append(this.material_row(material));
+		if (unassigned.length) {
+			body.append(this.group_row(__("Not linked to a finished good"), 9));
+			for (const material of unassigned) body.append(this.material_row(material));
 		}
 		this.detail_body.append(table);
 	}
@@ -645,14 +648,12 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		const materials = [...(this.data.materials || [])].sort(
 			(a, b) => this.open_qty(b) - this.open_qty(a)
 		);
-		const is_shared = (d) => d.owners.length !== 1;
-		if (this.focus === "all") {
-			return { owned: materials.filter((d) => !is_shared(d)), shared: materials.filter(is_shared) };
-		}
-		return {
-			owned: materials.filter((d) => !is_shared(d) && d.owners[0] === this.focus),
-			shared: materials.filter((d) => is_shared(d) && d.owners.includes(this.focus)),
-		};
+		const owned =
+			this.focus === "all"
+				? materials.filter((d) => d.owners.length)
+				: materials.filter((d) => d.owners.includes(this.focus));
+
+		return { owned, unassigned: materials.filter((d) => !d.owners.length) };
 	}
 
 	material_row(material) {
@@ -686,13 +687,15 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 				<td class="ppv-col-docs"></td>
 			</tr>
 		`);
-		tr.find(".ppv-item-tag").append(
+		const tag = tr.find(".ppv-item-tag");
+		tag.append(
 			frappe.ui.badge({
 				label: __(material.material_request_type || "Material"),
 				size: "sm",
 				variant: "ghost",
 			})
 		);
+		if (material.owners.length > 1) tag.append(this.shared_badge(material));
 		tr.find(".ppv-col-status").append(this.material_status(material, open));
 		this.append_document_chips(tr.find(".ppv-col-docs"), material.documents);
 		return tr;
@@ -716,6 +719,17 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			return this.pill(__("Ordered"), "blue");
 		}
 		return this.pill(__("Requested"), "amber");
+	}
+
+	shared_badge(material) {
+		const names = material.owners.map((row_name) => this.index.fg_label[row_name]).filter(Boolean);
+		return frappe.ui.badge({
+			label: __("Shared"),
+			size: "sm",
+			theme: "violet",
+			variant: "outline",
+			title: __("Quantity covers {0}", [names.join(", ")]),
+		});
 	}
 
 	pill(label, theme) {

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -147,18 +147,20 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 
 	build_index() {
 		this.data.schedule = (this.data.schedule || []).filter((d) => d.from_time && d.to_time);
-		const owner_of_row = {};
-		for (const fg of this.data.finished_goods) owner_of_row[fg.row_name] = fg.row_name;
+		const owners_of_row = {};
+		for (const fg of this.data.finished_goods) owners_of_row[fg.row_name] = [fg.row_name];
 		for (const sub of this.data.sub_assemblies) {
-			const owner = owner_of_row[sub.production_plan_item];
-			if (owner) owner_of_row[sub.row_name] = owner;
+			const owners = owners_of_row[sub.production_plan_item];
+			if (owners) owners_of_row[sub.row_name] = [...owners];
 		}
-		this.resolve_nested_owners(owner_of_row);
+		this.resolve_nested_owners(owners_of_row);
 
-		const subs_by_parent = this.group_rows(
-			this.data.sub_assemblies.filter((d) => owner_of_row[d.row_name]),
-			(d) => owner_of_row[d.row_name]
-		);
+		const subs_by_parent = {};
+		for (const sub of this.data.sub_assemblies) {
+			for (const owner of owners_of_row[sub.row_name] || []) {
+				(subs_by_parent[owner] = subs_by_parent[owner] || []).push(sub);
+			}
+		}
 
 		const bom_consumers = {};
 		for (const [row_name, items] of Object.entries(this.data.row_materials || {})) {
@@ -174,35 +176,42 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		const fg_label = {};
 		for (const fg of this.data.finished_goods) fg_label[fg.row_name] = fg.item_name || fg.item_code;
 
-		this.index = { subs_by_parent, owner_of_row, bom_consumers, subs_by_signature, fg_label };
+		this.index = { subs_by_parent, owners_of_row, bom_consumers, subs_by_signature, fg_label };
 		for (const material of this.data.materials || []) {
 			material.owners = this.material_owners(material);
 		}
 		this.compute_stats();
 	}
 
-	resolve_nested_owners(owner_of_row) {
+	resolve_nested_owners(owners_of_row) {
 		const fg_by_item = {};
-		for (const fg of this.data.finished_goods) fg_by_item[fg.item_code] = fg.row_name;
-		const sub_by_item = {};
-		for (const sub of this.data.sub_assemblies) sub_by_item[sub.item_code] = sub;
+		for (const fg of this.data.finished_goods) {
+			(fg_by_item[fg.item_code] = fg_by_item[fg.item_code] || []).push(fg.row_name);
+		}
+		const subs_by_item = {};
+		for (const sub of this.data.sub_assemblies) {
+			(subs_by_item[sub.item_code] = subs_by_item[sub.item_code] || []).push(sub);
+		}
 
 		for (const sub of this.data.sub_assemblies) {
-			if (owner_of_row[sub.row_name]) continue;
-			owner_of_row[sub.row_name] = this.walk_to_finished_good(sub, fg_by_item, sub_by_item);
-			if (!owner_of_row[sub.row_name]) delete owner_of_row[sub.row_name];
+			if (owners_of_row[sub.row_name]) continue;
+			const owners = this.walk_to_finished_goods(sub, fg_by_item, subs_by_item);
+			if (owners.length) owners_of_row[sub.row_name] = owners;
 		}
 	}
 
-	walk_to_finished_good(sub, fg_by_item, sub_by_item) {
+	walk_to_finished_goods(sub, fg_by_item, subs_by_item) {
 		const seen = new Set();
-		let node = sub;
-		while (node && !seen.has(node.row_name)) {
+		const queue = [sub];
+		const owners = new Set();
+		while (queue.length) {
+			const node = queue.shift();
+			if (!node || seen.has(node.row_name)) continue;
 			seen.add(node.row_name);
-			if (fg_by_item[node.parent_item_code]) return fg_by_item[node.parent_item_code];
-			node = sub_by_item[node.parent_item_code];
+			for (const row_name of fg_by_item[node.parent_item_code] || []) owners.add(row_name);
+			queue.push(...(subs_by_item[node.parent_item_code] || []));
 		}
-		return null;
+		return [...owners];
 	}
 
 	material_owners(material) {
@@ -216,8 +225,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 	owners_of(row_names) {
 		const owners = new Set();
 		for (const row_name of row_names) {
-			const owner = this.index.owner_of_row[row_name];
-			if (owner) owners.add(owner);
+			for (const owner of this.index.owners_of_row[row_name] || []) owners.add(owner);
 		}
 		return [...owners];
 	}
@@ -611,7 +619,9 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 
 	append_orphan_subs(body) {
 		if (this.focus !== "all") return;
-		const orphans = this.data.sub_assemblies.filter((d) => !this.index.owner_of_row[d.row_name]);
+		const orphans = this.data.sub_assemblies.filter(
+			(d) => !(this.index.owners_of_row[d.row_name] || []).length
+		);
 		if (!orphans.length) return;
 		body.append(this.group_row(__("Unlinked Sub Assemblies"), 7));
 		for (const sub of orphans) body.append(this.manufacture_row(sub, { kind: "sub", indent: 1 }));

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -535,7 +535,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 				size: "sm",
 				value: this.active_tab,
 				options: [
-					{ label: __("Work Orders"), value: "manufacture" },
+					{ label: __("Items to Manufacture"), value: "manufacture" },
 					{ label: __("Raw Materials"), value: "materials" },
 					{ label: __("Schedule"), value: "schedule" },
 				],
@@ -574,7 +574,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 
 	render_detail_body() {
 		this.detail_body.empty();
-		if (this.active_tab === "manufacture") this.render_work_orders();
+		if (this.active_tab === "manufacture") this.render_manufacture_items();
 		else if (this.active_tab === "materials") this.render_materials();
 		else this.render_schedule();
 		this.apply_detail_filter();
@@ -591,107 +591,92 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		return { table, body: table.find("tbody") };
 	}
 
-	render_work_orders() {
-		const { documents, pending } = this.focused_documents();
-		if (!documents.length && !pending.length) {
-			this.render_empty(__("No work orders created from this plan yet"));
+	render_manufacture_items() {
+		const goods = this.focused_goods();
+		if (!goods.length) {
+			this.render_empty(__("No items to manufacture in this plan"));
 			return;
 		}
 		const { table, body } = this.make_table([
-			{ label: __("Document") },
 			{ label: __("Item") },
-			{ label: __("Qty"), class: "ppv-num" },
+			{ label: __("Planned Qty"), class: "ppv-num" },
+			{ label: __("Qty In Stock"), class: "ppv-num" },
 			{ label: __("Produced Qty"), class: "ppv-num" },
 			{ label: __("Pending Qty"), class: "ppv-num" },
 			{ label: __("Progress"), class: "ppv-col-progress" },
-			{ label: __("Status"), class: "ppv-col-status" },
+			{ label: __("Documents"), class: "ppv-col-docs" },
 		]);
 
-		for (const entry of documents) body.append(this.work_order_row(entry));
-		if (pending.length) {
-			body.append(this.group_row(__("Not created yet"), 7));
-			for (const row of pending) body.append(this.pending_row(row));
+		for (const fg of goods) {
+			body.append(this.manufacture_row(fg, "fg"));
+			for (const sub of this.index.subs_by_parent[fg.row_name] || []) {
+				body.append(this.manufacture_row(sub, "sub"));
+			}
 		}
 		this.detail_body.append(table);
+		this.append_orphan_subs(body);
 	}
 
-	focused_documents() {
-		const documents = [];
-		const pending = [];
-		for (const row of this.focused_rows()) {
-			for (const doc of row.documents || []) documents.push({ doc, row });
-			if (!(row.documents || []).length) pending.push(row);
-		}
-		return { documents, pending };
-	}
-
-	focused_rows() {
-		const rows = [];
-		for (const fg of this.focused_goods()) {
-			rows.push(fg, ...(this.index.subs_by_parent[fg.row_name] || []));
-		}
-		if (this.focus !== "all") return rows;
-		return rows.concat(
-			this.data.sub_assemblies.filter((d) => !(this.index.owners_of_row[d.row_name] || []).length)
+	append_orphan_subs(body) {
+		if (this.focus !== "all") return;
+		const orphans = this.data.sub_assemblies.filter(
+			(d) => !(this.index.owners_of_row[d.row_name] || []).length
 		);
+		if (!orphans.length) return;
+		body.append(this.group_row(__("Unlinked Sub Assemblies"), 7));
+		for (const sub of orphans) body.append(this.manufacture_row(sub, "sub"));
 	}
 
 	group_row(label, span) {
 		return $(`<tr class="ppv-row-group"><td colspan="${span}">${this.esc(label)}</td></tr>`);
 	}
 
-	work_order_row({ doc, row }) {
-		const qty = flt(doc.qty);
-		const produced = flt(doc.produced_qty);
-		const completion = qty ? (produced / qty) * 100 : 0;
-		const item_code = doc.item_code || row.item_code;
+	manufacture_row(row, kind) {
+		const completion = row.qty ? (row.produced_qty / row.qty) * 100 : 0;
+		const uom = row.stock_uom || row.uom || "";
 		const tr = $(`
-			<tr data-search="${this.esc(
-				`${doc.name} ${item_code} ${row.item_name || ""} ${doc.status || ""}`.toLowerCase()
-			)}">
-				<td>
+			<tr data-kind="${kind}" data-search="${this.esc(
+			`${row.item_name || ""} ${row.item_code} ${(row.documents || [])
+				.map((d) => d.name)
+				.join(" ")}`.toLowerCase()
+		)}">
+				<td class="ppv-cell-item">
 					<div class="ppv-item-line">
-						<a class="ppv-doc-link" href="${this.form_route(doc.doctype, doc.name)}">${this.esc(doc.name)}</a>
+						<a href="/app/item/${encodeURIComponent(row.item_code)}">${this.esc(row.item_name || row.item_code)}</a>
+						<span class="ppv-item-tag"></span>
 					</div>
-					<div class="ppv-item-sub">${this.esc(__(doc.doctype))}${
-			doc.supplier ? ` &middot; ${this.esc(doc.supplier)}` : ""
-		}</div>
+					<div class="ppv-item-sub">${this.esc(row.item_code)}</div>
 				</td>
-				<td>
-					<div class="ppv-item-line">${this.esc(doc.item_name || row.item_name || item_code)}</div>
-					<div class="ppv-item-sub">${this.esc(item_code)}</div>
-				</td>
-				<td class="ppv-num">${this.format_float(qty)}</td>
-				<td class="ppv-num">${this.format_float(produced)}</td>
-				<td class="ppv-num ${qty - produced > 0 ? "ppv-pending" : ""}">${this.format_float(qty - produced)}</td>
+				<td class="ppv-num">${this.format_float(row.qty)} <span class="ppv-uom">${this.esc(uom)}</span></td>
+				<td class="ppv-num">${kind === "sub" ? this.stock_value(row) : "—"}</td>
+				<td class="ppv-num">${this.format_float(row.produced_qty)}</td>
+				<td class="ppv-num ${row.pending_qty > 0 ? "ppv-pending" : ""}">${this.format_float(row.pending_qty)}</td>
 				<td class="ppv-col-progress"></td>
-				<td class="ppv-col-status"></td>
+				<td class="ppv-col-docs"></td>
 			</tr>
 		`);
-		tr.find(".ppv-doc-link").on("click", (e) => this.on_chip_click(e, doc));
+		tr.find(".ppv-item-tag").append(this.manufacture_tag(row, kind));
 		tr.find(".ppv-col-progress").append(frappe.ui.progress({ value: completion, hint: true }));
-		tr.find(".ppv-col-status").append(this.status_badge(doc.status, "sm"));
+		this.append_document_chips(tr.find(".ppv-col-docs"), row.documents);
 		return tr;
 	}
 
-	pending_row(row) {
-		const tr = $(`
-			<tr data-search="${this.esc(`${row.item_name || ""} ${row.item_code}`.toLowerCase())}">
-				<td><span class="ppv-no-docs">${__("Not created")}</span></td>
-				<td>
-					<div class="ppv-item-line">${this.esc(row.item_name || row.item_code)}</div>
-					<div class="ppv-item-sub">${this.esc(row.item_code)}</div>
-				</td>
-				<td class="ppv-num">${this.format_float(row.qty)}</td>
-				<td class="ppv-num">${this.format_float(0)}</td>
-				<td class="ppv-num ppv-pending">${this.format_float(row.qty)}</td>
-				<td class="ppv-col-progress"></td>
-				<td class="ppv-col-status"></td>
-			</tr>
-		`);
-		tr.find(".ppv-col-progress").append(frappe.ui.progress({ value: 0, hint: true }));
-		tr.find(".ppv-col-status").append(this.pill(__("Not Started"), "amber"));
-		return tr;
+	manufacture_tag(row, kind) {
+		if (kind === "fg") {
+			if (!row.sales_order) return frappe.ui.badge({ label: __("Finished Good"), size: "sm" });
+			return frappe.ui.badge({
+				label: row.sales_order,
+				theme: "violet",
+				variant: "outline",
+				size: "sm",
+			});
+		}
+		return frappe.ui.badge({
+			label: __(row.type_of_manufacturing || "In House"),
+			size: "sm",
+			theme: row.type_of_manufacturing === "Subcontract" ? "amber" : "blue",
+			variant: "outline",
+		});
 	}
 
 	render_materials() {
@@ -1600,7 +1585,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			.ppv-cell-item { min-width: 220px; }
 			.ppv-item-line { display: flex; align-items: center; gap: 6px; }
 			.ppv-item-line a { color: var(--heading-color); font-weight: 500; text-decoration: none; }
-			.ppv-doc-link { cursor: pointer; }
+			.ppv-table tr[data-kind="fg"] .ppv-item-line a { font-weight: 600; }
 			.ppv-item-sub { font-size: var(--text-xs); color: var(--text-muted); }
 			.ppv-pending { color: var(--yellow-700); }
 			.ppv-col-progress { width: 130px; }

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -155,16 +155,19 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		}
 		this.resolve_nested_owners(owners_of_row);
 
+		const bom_consumers = {};
+		for (const [row_name, items] of Object.entries(this.data.row_materials || {})) {
+			for (const item of items) (bom_consumers[item] = bom_consumers[item] || []).push(row_name);
+		}
+		if (this.data.plan.combine_sub_items) {
+			this.expand_combined_owners(owners_of_row, bom_consumers);
+		}
+
 		const subs_by_parent = {};
 		for (const sub of this.data.sub_assemblies) {
 			for (const owner of owners_of_row[sub.row_name] || []) {
 				(subs_by_parent[owner] = subs_by_parent[owner] || []).push(sub);
 			}
-		}
-
-		const bom_consumers = {};
-		for (const [row_name, items] of Object.entries(this.data.row_materials || {})) {
-			for (const item of items) (bom_consumers[item] = bom_consumers[item] || []).push(row_name);
 		}
 
 		const subs_by_signature = {};
@@ -181,6 +184,25 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			material.owners = this.material_owners(material);
 		}
 		this.compute_stats();
+	}
+
+	expand_combined_owners(owners_of_row, bom_consumers) {
+		let changed = true;
+		let passes = 0;
+		while (changed && passes++ <= this.data.sub_assemblies.length) {
+			changed = false;
+			for (const sub of this.data.sub_assemblies) {
+				const owners = new Set(owners_of_row[sub.row_name] || []);
+				const before = owners.size;
+				for (const row_name of bom_consumers[sub.item_code] || []) {
+					for (const owner of owners_of_row[row_name] || []) owners.add(owner);
+				}
+				if (owners.size !== before) {
+					owners_of_row[sub.row_name] = [...owners];
+					changed = true;
+				}
+			}
+		}
 	}
 
 	resolve_nested_owners(owners_of_row) {

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -10,20 +10,24 @@ frappe.pages["production-plan-visualizer"].on_page_load = function (wrapper) {
 
 frappe.pages["production-plan-visualizer"].on_page_show = function () {
 	const visualizer = frappe.production_plan_visualizer;
-	if (visualizer && frappe.route_options && frappe.route_options.production_plan) {
+	if (!visualizer) return;
+	if (frappe.route_options && frappe.route_options.production_plan) {
 		const plan = frappe.route_options.production_plan;
 		frappe.route_options = null;
 		visualizer.plan_field.set_value(plan);
 	}
+	visualizer.fit_viewport();
 };
 
 erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 	constructor(page) {
 		this.page = page;
 		this.data = null;
-		this.active_tab = "plan";
+		this.focus = "all";
+		this.active_tab = "manufacture";
 		this.schedule_group = "item";
 		this.schedule_scale = "day";
+		this.today_offset = null;
 		this.body = $(this.page.body);
 		this.make();
 	}
@@ -32,6 +36,10 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		this.body.html(`${this.styles()}<div class="ppv"></div>`);
 		this.container = this.body.find(".ppv");
 		this.make_plan_field();
+		$(window).on(
+			"resize.ppv",
+			frappe.utils.debounce(() => this.fit_viewport(), 150)
+		);
 		this.render_blank_state();
 	}
 
@@ -54,15 +62,26 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		});
 	}
 
+	fit_viewport() {
+		if (!this.container || !this.container.is(":visible")) return;
+		const top = this.container[0].getBoundingClientRect().top;
+		const height = Math.max(window.innerHeight - top - 20, 460);
+		this.container.css("height", `${height}px`);
+	}
+
 	render_blank_state() {
 		this.container.empty().append(
-			frappe.ui.empty_state({
-				icon: "layout-dashboard",
-				title: __("Pick a Production Plan"),
-				description: __("See its progress, sub-assemblies, materials and schedule in one place."),
-				css_class: "ppv-blank",
-			})
+			$('<div class="ppv-fill"></div>').append(
+				frappe.ui.empty_state({
+					icon: "layout-dashboard",
+					title: __("Pick a Production Plan"),
+					description: __(
+						"Track readiness, shortages, work orders and the shop floor schedule on one screen."
+					),
+				})
+			)
 		);
+		this.fit_viewport();
 	}
 
 	load(plan) {
@@ -76,6 +95,8 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			.then((r) => {
 				if (this.current_plan !== plan) return;
 				this.data = r.message;
+				this.focus = "all";
+				this.active_tab = "manufacture";
 				this.render();
 			});
 	}
@@ -83,129 +104,83 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 	render_skeleton() {
 		const line = (w, h) => frappe.ui.skeleton.html({ width: w, height: h });
 		this.container.html(`
-			<div class="ppv-hero">
-				<div class="ppv-hero-main">
-					${line("240px", "28px")}
-					<div class="mt-2">${line("180px", "14px")}</div>
-					<div class="mt-4">${line("100%", "8px")}</div>
-				</div>
-				<div class="ppv-stats">
-					${[1, 2, 3, 4].map(() => `<div class="ppv-tile">${line("100%", "48px")}</div>`).join("")}
-				</div>
+			<div class="ppv-kpis">
+				${[1, 2, 3, 4, 5].map(() => `<div class="ppv-kpi">${line("100%", "44px")}</div>`).join("")}
 			</div>
-			<div class="mt-4">${line("100%", "220px")}</div>
+			<div class="ppv-workspace">
+				<div class="ppv-pane"><div style="padding: 12px">${line("100%", "240px")}</div></div>
+				<div class="ppv-pane"><div style="padding: 12px">${line("100%", "240px")}</div></div>
+			</div>
 		`);
+		this.fit_viewport();
 	}
 
 	render() {
+		this.build_index();
 		this.container.empty();
-		this.render_hero();
-		this.render_tabs();
-		this.panel = $('<div class="ppv-panel"></div>').appendTo(this.container);
-		this.render_active_panel();
+		this.render_kpis();
+		this.render_workspace();
+		this.fit_viewport();
 	}
 
-	render_hero() {
-		const plan = this.data.plan;
-		const hero = $(`
-			<div class="ppv-hero">
-				<div class="ppv-hero-main">
-					<div class="ppv-hero-title">
-						<a class="ppv-plan-link" href="/app/production-plan/${encodeURIComponent(plan.name)}">
-							${frappe.utils.escape_html(plan.name)}</a>
-						<span class="ppv-hero-badge"></span>
-					</div>
-					<div class="ppv-hero-meta">
-						${frappe.utils.escape_html(plan.company)} &middot;
-						${frappe.datetime.str_to_user(plan.posting_date)}
-					</div>
-					<div class="ppv-hero-progress"></div>
-				</div>
-				<div class="ppv-hero-ring"></div>
-				<div class="ppv-stats"></div>
-			</div>
-		`);
+	build_index() {
+		this.data.schedule = (this.data.schedule || []).filter((d) => d.from_time && d.to_time);
+		const subs_by_parent = this.group_rows(this.data.sub_assemblies, (d) => d.production_plan_item);
+		const owner_of_row = {};
+		for (const fg of this.data.finished_goods) {
+			owner_of_row[fg.row_name] = fg.row_name;
+			for (const sub of subs_by_parent[fg.row_name] || []) owner_of_row[sub.row_name] = fg.row_name;
+		}
 
-		hero.find(".ppv-hero-badge").append(this.status_badge(plan.status, "md"));
-		hero.find(".ppv-hero-progress").append(
-			frappe.ui.progress({
-				value: plan.completion,
-				size: "md",
-				label: __("{0} of {1} produced", [
-					this.format_float(plan.total_produced_qty),
-					this.format_float(plan.total_planned_qty),
-				]),
-				hint: true,
-			})
-		);
-		hero.find(".ppv-hero-ring").html(this.completion_ring(plan.completion));
-		hero.find(".ppv-stats").html(this.stat_tiles());
-		this.container.append(hero);
+		const bom_consumers = {};
+		for (const [row_name, items] of Object.entries(this.data.row_materials || {})) {
+			for (const item of items) (bom_consumers[item] = bom_consumers[item] || []).push(row_name);
+		}
+
+		this.index = { subs_by_parent, owner_of_row, bom_consumers };
+		for (const material of this.data.materials || []) {
+			material.owners = this.material_owners(material);
+		}
+		this.compute_stats();
 	}
 
-	completion_ring(completion) {
-		const radius = 44;
-		const circumference = 2 * Math.PI * radius;
-		const offset = circumference * (1 - Math.min(completion, 100) / 100);
-		return `
-			<svg viewBox="0 0 110 110" class="ppv-ring">
-				<circle class="ppv-ring-track" cx="55" cy="55" r="${radius}"></circle>
-				<circle class="ppv-ring-fill" cx="55" cy="55" r="${radius}"
-					stroke-dasharray="${circumference}" stroke-dashoffset="${offset}"></circle>
-				<text x="55" y="52" class="ppv-ring-value">${Math.round(completion)}%</text>
-				<text x="55" y="70" class="ppv-ring-caption">${__("Complete")}</text>
-			</svg>
-		`;
+	material_owners(material) {
+		if (material.consumer) {
+			const owner = this.index.owner_of_row[material.consumer];
+			return owner ? [owner] : [];
+		}
+		const owners = new Set();
+		for (const row_name of this.index.bom_consumers[material.item_code] || []) {
+			const owner = this.index.owner_of_row[row_name];
+			if (owner) owners.add(owner);
+		}
+		return [...owners];
 	}
 
-	stat_tiles() {
+	compute_stats() {
 		const documents = this.all_documents();
-		const tiles = [
-			this.stat_tile(
-				__("Work Orders"),
-				documents.filter((d) => d.doctype === "Work Order")
-			),
-			this.stat_tile(
-				__("Purchase Orders"),
-				documents.filter((d) => d.doctype === "Purchase Order")
-			),
-			this.stat_tile(__("Material Requests"), this.data.material_requests),
-			this.schedule_tile(),
-		];
-		return tiles.join("");
+		const materials = this.data.materials || [];
+		const rows = [...this.data.finished_goods, ...this.data.sub_assemblies];
+		this.stats = {
+			work_orders: documents.filter((d) => d.doctype === "Work Order"),
+			purchase_orders: documents.filter((d) => d.doctype === "Purchase Order"),
+			material_requests: this.data.material_requests || [],
+			short_materials: materials.filter((d) => this.open_qty(d) > 0),
+			unstarted: rows.filter((d) => !(d.documents || []).length),
+			coverage: this.material_coverage(materials),
+			schedule: this.data.schedule || [],
+		};
 	}
 
-	stat_tile(label, docs) {
-		const status_dots = Object.entries(this.group_rows(docs, (d) => d.status || __("Draft")))
-			.map(
-				([status, rows]) =>
-					`<span class="ppv-dot-item" title="${frappe.utils.escape_html(status)}">
-						<span class="ppv-dot" data-theme="${this.status_theme(status)}"></span>${rows.length}
-					</span>`
-			)
-			.join("");
-		return `
-			<div class="ppv-tile">
-				<div class="ppv-tile-value">${docs.length}</div>
-				<div class="ppv-tile-label">${frappe.utils.escape_html(label)}</div>
-				<div class="ppv-tile-dots">${status_dots}</div>
-			</div>
-		`;
+	open_qty(material) {
+		return flt(flt(material.to_procure_qty) - flt(material.requested_qty), 6);
 	}
 
-	schedule_tile() {
-		const blocks = this.data.schedule || [];
-		const workstations = new Set(blocks.map((d) => d.workstation).filter(Boolean));
-		const caption = workstations.size
-			? __("{0} workstations", [workstations.size])
-			: __("Not scheduled yet");
-		return `
-			<div class="ppv-tile">
-				<div class="ppv-tile-value">${blocks.length}</div>
-				<div class="ppv-tile-label">${__("Schedule Blocks")}</div>
-				<div class="ppv-tile-dots">${frappe.utils.escape_html(caption)}</div>
-			</div>
-		`;
+	material_coverage(materials) {
+		const to_procure = materials.reduce((sum, d) => sum + flt(d.to_procure_qty), 0);
+		if (!to_procure) return 100;
+		const open = materials.reduce((sum, d) => sum + Math.max(this.open_qty(d), 0), 0);
+		return ((to_procure - open) / to_procure) * 100;
 	}
 
 	all_documents() {
@@ -214,350 +189,576 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 	}
 
 	group_rows(rows, key_fn) {
-		return rows.reduce((groups, row) => {
+		return (rows || []).reduce((groups, row) => {
 			const key = key_fn(row);
 			(groups[key] = groups[key] || []).push(row);
 			return groups;
 		}, {});
 	}
 
-	render_tabs() {
-		this.container.append(
-			$('<div class="ppv-tabs"></div>').append(
-				frappe.ui.tab_buttons({
-					label: __("Sections"),
-					type: "ghost",
-					value: this.active_tab,
-					options: [
-						{ label: __("Plan"), value: "plan" },
-						{
-							label: `${__("Schedule")} (${(this.data.schedule || []).length})`,
-							value: "schedule",
-						},
-					],
-					on_change: (value) => {
-						this.active_tab = value;
-						this.render_active_panel();
-					},
-				})
+	render_kpis() {
+		const stats = this.stats;
+		const rail = $('<div class="ppv-kpis"></div>').appendTo(this.container);
+		rail.append(this.hero_tile());
+		rail.append(
+			this.kpi_tile({
+				label: __("Material Readiness"),
+				value: `${Math.round(stats.coverage)}%`,
+				tone: stats.short_materials.length ? "red" : "green",
+				hint: stats.short_materials.length
+					? __("{0} materials still to request", [stats.short_materials.length])
+					: __("Everything requested or in stock"),
+				tab: "materials",
+			})
+		);
+		rail.append(
+			this.kpi_tile({
+				label: __("Work Orders"),
+				value: stats.work_orders.length,
+				tone: stats.unstarted.length ? "amber" : null,
+				hint: stats.unstarted.length
+					? __("{0} rows not started", [stats.unstarted.length])
+					: __("Every row has a document"),
+				dots: stats.work_orders,
+				tab: "manufacture",
+			})
+		);
+		rail.append(this.procurement_tile());
+		rail.append(this.schedule_tile());
+	}
+
+	hero_tile() {
+		const plan = this.data.plan;
+		const tile = $(`
+			<div class="ppv-kpi ppv-hero">
+				<div class="ppv-ring-wrap">${this.completion_ring(plan.completion)}</div>
+				<div class="ppv-hero-body">
+					<div class="ppv-hero-top">
+						<a class="ppv-hero-name" href="/app/production-plan/${encodeURIComponent(plan.name)}"
+							title="${this.esc(plan.name)}">${this.esc(plan.name)}</a>
+						<span class="ppv-hero-status"></span>
+					</div>
+					<div class="ppv-hero-qty">
+						<b>${this.format_float(plan.total_produced_qty)}</b>
+						<span class="ppv-muted">&nbsp;/&nbsp;${this.format_float(plan.total_planned_qty)}&nbsp;${__(
+			"produced"
+		)}</span>
+					</div>
+					<div class="ppv-hero-meta">${this.esc(plan.company)} &middot; ${frappe.datetime.str_to_user(
+			plan.posting_date
+		)}</div>
+				</div>
+			</div>
+		`);
+		tile.find(".ppv-hero-status").append(this.status_badge(plan.status, "sm"));
+		return tile;
+	}
+
+	kpi_tile({ label, value, hint, tone, dots, tab }) {
+		const tile = $(`
+			<div class="ppv-kpi" data-tone="${tone || ""}" data-clickable="${tab ? 1 : 0}">
+				<div class="ppv-kpi-label">${this.esc(label)}</div>
+				<div class="ppv-kpi-value">${this.esc(value)}</div>
+				<div class="ppv-kpi-hint">${this.esc(hint)}</div>
+			</div>
+		`);
+		if (dots && dots.length) tile.find(".ppv-kpi-hint").prepend(this.status_dots(dots));
+		if (tab) tile.on("click", () => this.set_tab(tab));
+		return tile;
+	}
+
+	status_dots(rows) {
+		return Object.entries(this.group_rows(rows, (d) => d.status || __("Draft")))
+			.map(
+				([status, group]) =>
+					`<span class="ppv-dot-item" title="${this.esc(status)}">
+						<span class="ppv-dot" data-theme="${this.status_theme(status)}"></span>${group.length}
+					</span>`
 			)
-		);
+			.join("");
 	}
 
-	render_active_panel() {
-		this.panel.empty();
-		if (this.active_tab === "plan") this.render_plan_tree();
-		else this.render_schedule();
+	procurement_tile() {
+		const orders = this.stats.purchase_orders;
+		const requests = this.stats.material_requests;
+		return this.kpi_tile({
+			label: __("Procurement"),
+			value: orders.length + requests.length,
+			hint: __("{0} requests · {1} orders", [requests.length, orders.length]),
+			dots: [...orders, ...requests],
+			tab: "materials",
+		});
 	}
 
-	render_plan_tree() {
-		if (!this.data.finished_goods.length) {
-			this.panel_empty_state(__("No items to manufacture in this plan"));
-			return;
+	schedule_tile() {
+		const blocks = this.stats.schedule;
+		if (!blocks.length) {
+			return this.kpi_tile({
+				label: __("Schedule"),
+				value: "—",
+				hint: __("Not scheduled yet"),
+			});
 		}
-		this.panel.append(this.plan_search_bar());
-		this.tree_list = $('<div class="ppv-tree"></div>').appendTo(this.panel);
-		const subs_by_parent = this.group_rows(this.data.sub_assemblies, (d) => d.production_plan_item);
-		const assignments = this.material_assignments();
-
-		for (const fg of this.data.finished_goods) {
-			const branch = $('<div class="ppv-branch"></div>');
-			for (const sub of subs_by_parent[fg.row_name] || []) {
-				const indent = sub.indent || 0;
-				branch.append(this.sub_assembly_row(sub));
-				for (const material of assignments.map[sub.row_name] || []) {
-					branch.append(this.material_row(material, indent + 1));
-				}
-			}
-			delete subs_by_parent[fg.row_name];
-			for (const material of assignments.map[fg.row_name] || []) {
-				branch.append(this.material_row(material, 0));
-			}
-			const node = this.plan_node(fg, branch);
-			node.attr("data-search", node.text().toLowerCase());
-			this.tree_list.append(node);
-		}
-
-		this.append_plan_group(__("Other Sub Assemblies"), Object.values(subs_by_parent).flat(), (d) =>
-			this.sub_assembly_row(d)
+		const workstations = new Set(blocks.map((d) => d.workstation).filter(Boolean));
+		const start = frappe.datetime.str_to_user(blocks[0].from_time.split(" ")[0]);
+		const end = frappe.datetime.str_to_user(
+			blocks.reduce((max, d) => (d.to_time > max ? d.to_time : max), blocks[0].to_time).split(" ")[0]
 		);
-		this.append_plan_group(__("Other Materials"), assignments.leftovers, (d) => this.material_row(d, 0));
-
-		this.no_results = frappe.ui.empty_state({ icon: "search", title: __("No matching items") }).hide();
-		this.panel.append(this.no_results);
-		this.apply_plan_filter();
+		return this.kpi_tile({
+			label: __("Schedule"),
+			value: blocks.length,
+			hint: `${start} → ${end} · ${__("{0} workstations", [workstations.size])}`,
+			tab: "schedule",
+		});
 	}
 
-	append_plan_group(label, rows, make_row) {
-		if (!rows.length) return;
-		const group = $('<div class="ppv-group"></div>').append(
-			`<div class="ppv-group-head">${frappe.utils.escape_html(label)}</div>`
-		);
-		for (const row of rows) {
-			const el = make_row(row);
-			el.attr("data-search", el.text().toLowerCase());
-			group.append(el);
-		}
-		this.tree_list.append(group);
+	completion_ring(completion) {
+		const radius = 26;
+		const circumference = 2 * Math.PI * radius;
+		const offset = circumference * (1 - Math.min(completion, 100) / 100);
+		return `
+			<svg viewBox="0 0 64 64" class="ppv-ring">
+				<circle class="ppv-ring-track" cx="32" cy="32" r="${radius}"></circle>
+				<circle class="ppv-ring-fill" cx="32" cy="32" r="${radius}"
+					stroke-dasharray="${circumference}" stroke-dashoffset="${offset}"></circle>
+				<text x="32" y="36" class="ppv-ring-value">${Math.round(completion)}%</text>
+			</svg>
+		`;
 	}
 
-	plan_search_bar() {
+	render_workspace() {
+		const workspace = $('<div class="ppv-workspace"></div>').appendTo(this.container);
+		this.rail = $('<div class="ppv-pane ppv-rail"></div>').appendTo(workspace);
+		this.detail = $('<div class="ppv-pane ppv-detail"></div>').appendTo(workspace);
+		this.render_rail();
+		this.render_detail();
+	}
+
+	render_rail() {
+		this.rail.empty().append(`
+			<div class="ppv-pane-head">
+				<span class="ppv-pane-title">${__("Finished Goods")}</span>
+				<span class="ppv-count">${this.data.finished_goods.length}</span>
+			</div>
+		`);
+		this.rail.append(this.rail_search());
+		this.rail_body = $('<div class="ppv-pane-body"></div>').appendTo(this.rail);
+		this.rail_body.append(this.rail_row_all());
+		for (const fg of this.data.finished_goods) this.rail_body.append(this.rail_row(fg));
+		this.apply_rail_filter();
+	}
+
+	rail_search() {
 		const bar = $(`
 			<div class="ppv-search">
 				<span class="ppv-search-icon">${frappe.utils.icon("search", "sm", "", "", "", true)}</span>
-				<input type="search" class="ppv-search-input"
-					placeholder="${__("Search item, code or document...")}" />
-				<span class="ppv-search-count"></span>
+				<input type="search" class="ppv-search-input" placeholder="${__("Filter items...")}" />
 			</div>
 		`);
-		this.search_input = bar.find("input");
-		this.search_count = bar.find(".ppv-search-count");
-		this.search_input.val(this.plan_search || "");
-		this.search_input.on("input", () => {
-			this.plan_search = this.search_input.val();
-			this.apply_plan_filter();
+		this.rail_query = "";
+		bar.find("input").on("input", (e) => {
+			this.rail_query = (e.target.value || "").trim().toLowerCase();
+			this.apply_rail_filter();
 		});
 		return bar;
 	}
 
-	apply_plan_filter() {
-		const query = (this.plan_search || "").trim().toLowerCase();
-		const matches = (el) => !query || ($(el).attr("data-search") || "").includes(query);
+	apply_rail_filter() {
 		let visible = 0;
-		let total = 0;
-
-		this.tree_list.children(".ppv-node").each((_, el) => {
-			total += 1;
-			const show = matches(el);
+		this.rail_body.find(".ppv-rail-row[data-search]").each((_, el) => {
+			const show = !this.rail_query || ($(el).attr("data-search") || "").includes(this.rail_query);
 			$(el).toggle(show);
 			if (show) visible += 1;
 		});
-
-		let group_visible = 0;
-		this.tree_list.children(".ppv-group").each((_, group) => {
-			let shown = 0;
-			$(group)
-				.children("[data-search]")
-				.each((_, el) => {
-					const show = matches(el);
-					$(el).toggle(show);
-					if (show) shown += 1;
-				});
-			$(group).toggle(shown > 0);
-			group_visible += shown;
-		});
-
-		this.search_count.text(query ? __("{0} of {1} items", [visible, total]) : "");
-		this.no_results.toggle(Boolean(query) && !visible && !group_visible);
+		this.rail_body.find(".ppv-rail-none").toggle(!visible);
+		this.highlight_focus();
 	}
 
-	plan_node(fg, branch) {
-		const node = $('<div class="ppv-node"></div>');
-		const card = this.item_card(fg, { show_dates: true });
-		node.append(card);
-		if (!branch.children().length) return node;
-
-		node.append(branch);
-		const caret = frappe.ui.button({
-			icon: "chevron-down",
-			variant: "ghost",
-			size: "sm",
-			title: __("Collapse"),
-			css_class: "ppv-caret",
-			onclick: () => {
-				branch.slideToggle(150);
-				caret.toggleClass("ppv-collapsed");
-			},
-		});
-		card.find(".ppv-card-head").prepend(caret);
-		return node;
-	}
-
-	material_assignments() {
-		const row_materials = this.data.row_materials || {};
-		const bom_consumers = {};
-		for (const [row_name, items] of Object.entries(row_materials)) {
-			for (const item of items) {
-				(bom_consumers[item] = bom_consumers[item] || []).push(row_name);
-			}
-		}
-
-		const map = {};
-		const leftovers = [];
-		for (const material of this.data.materials || []) {
-			const consumers = material.consumers.length
-				? material.consumers
-				: bom_consumers[material.item_code] || [];
-			if (consumers.length) {
-				(map[consumers[0]] = map[consumers[0]] || []).push(material);
-			} else {
-				leftovers.push(material);
-			}
-		}
-		return { map, leftovers };
-	}
-
-	material_row(material, indent) {
-		const completion = material.quantity ? (material.ordered_qty / material.quantity) * 100 : 0;
-		const el = $(`
-			<div class="ppv-sub-row ppv-material-row" style="--ppv-indent: ${indent}">
-				<div class="ppv-sub-item">
-					<div class="ppv-sub-title">
-						<a href="/app/item/${encodeURIComponent(material.item_code)}">
-							${frappe.utils.escape_html(material.item_name || material.item_code)}</a>
-						<span class="ppv-sub-type"></span>
-					</div>
-					<div class="ppv-card-sub">${frappe.utils.escape_html(material.item_code)}</div>
+	rail_row_all() {
+		const plan = this.data.plan;
+		const row = $(`
+			<div class="ppv-rail-row ppv-rail-all" data-focus="all" data-risk="all">
+				<div class="ppv-rail-top">
+					<span class="ppv-rail-name">${__("All Items")}</span>
+					<span class="ppv-rail-pct">${Math.round(plan.completion)}%</span>
 				</div>
-				<div class="ppv-qty-row ppv-qty-compact">
-					${this.qty_cell(__("Planned"), material.quantity)}
-					${this.qty_cell(__("Requested"), material.requested_qty)}
-					${this.qty_cell(__("Ordered"), material.ordered_qty)}
-				</div>
-				<div class="ppv-sub-progress"></div>
-				<div class="ppv-chips"></div>
+				<div class="ppv-rail-sub">${__("{0} finished goods · {1} sub assemblies", [
+					this.data.finished_goods.length,
+					this.data.sub_assemblies.length,
+				])}</div>
 			</div>
 		`);
-		el.find(".ppv-sub-type").append(
+		row.on("click", () => this.set_focus("all"));
+		return row;
+	}
+
+	rail_row(fg) {
+		const completion = fg.qty ? (fg.produced_qty / fg.qty) * 100 : 0;
+		const risk = this.risk_of(fg);
+		const row = $(`
+			<div class="ppv-rail-row" data-focus="${this.esc(fg.row_name)}" data-risk="${risk.level}"
+				data-search="${this.esc(`${fg.item_name || ""} ${fg.item_code}`.toLowerCase())}">
+				<div class="ppv-rail-top">
+					<span class="ppv-rail-name" title="${this.esc(fg.item_name || fg.item_code)}">${this.esc(
+			fg.item_name || fg.item_code
+		)}</span>
+					<span class="ppv-rail-pct">${Math.round(completion)}%</span>
+				</div>
+				<div class="ppv-rail-sub">${this.esc(fg.item_code)} &middot; ${this.format_float(fg.qty)} ${this.esc(
+			fg.stock_uom || ""
+		)}</div>
+				<div class="ppv-rail-bar"><span style="width: ${Math.min(completion, 100)}%"></span></div>
+				<div class="ppv-rail-flag">${this.esc(risk.label)}</div>
+			</div>
+		`);
+		row.on("click", () => this.set_focus(fg.row_name));
+		return row;
+	}
+
+	risk_of(fg) {
+		const short = (this.data.materials || []).filter(
+			(d) => this.open_qty(d) > 0 && d.owners.includes(fg.row_name)
+		);
+		if (short.length) {
+			return { level: "short", label: __("{0} materials short", [short.length]) };
+		}
+		if (fg.qty && fg.produced_qty >= fg.qty) return { level: "done", label: __("Completed") };
+		const rows = [fg, ...(this.index.subs_by_parent[fg.row_name] || [])];
+		if (rows.every((d) => !(d.documents || []).length)) {
+			return { level: "idle", label: __("Not started") };
+		}
+		return { level: "running", label: __("In progress") };
+	}
+
+	set_focus(row_name) {
+		this.focus = row_name;
+		this.highlight_focus();
+		this.render_detail_body();
+	}
+
+	highlight_focus() {
+		this.rail_body.find(".ppv-rail-row").each((_, el) => {
+			$(el).toggleClass("is-active", $(el).attr("data-focus") === this.focus);
+		});
+	}
+
+	set_tab(tab) {
+		if (this.active_tab === tab) return;
+		this.active_tab = tab;
+		this.render_detail();
+	}
+
+	focused_goods() {
+		if (this.focus === "all") return this.data.finished_goods;
+		return this.data.finished_goods.filter((d) => d.row_name === this.focus);
+	}
+
+	render_detail() {
+		this.detail.empty();
+		const head = $('<div class="ppv-pane-head"></div>').appendTo(this.detail);
+		head.append(
+			frappe.ui.tab_buttons({
+				type: "subtle",
+				size: "sm",
+				value: this.active_tab,
+				options: [
+					{ label: __("Items to Manufacture"), value: "manufacture" },
+					{ label: __("Raw Materials"), value: "materials" },
+					{ label: __("Schedule"), value: "schedule" },
+				],
+				on_change: (value) => {
+					this.active_tab = value;
+					this.render_detail_body();
+				},
+			})
+		);
+		head.append(this.detail_search());
+		this.detail_body = $('<div class="ppv-pane-body"></div>').appendTo(this.detail);
+		this.render_detail_body();
+	}
+
+	detail_search() {
+		const bar = $(`
+			<div class="ppv-search ppv-search-inline">
+				<span class="ppv-search-icon">${frappe.utils.icon("search", "sm", "", "", "", true)}</span>
+				<input type="search" class="ppv-search-input" placeholder="${__("Search item or document...")}" />
+			</div>
+		`);
+		bar.find("input").on("input", (e) => {
+			this.detail_query = (e.target.value || "").trim().toLowerCase();
+			this.apply_detail_filter();
+		});
+		this.detail_query = "";
+		return bar;
+	}
+
+	apply_detail_filter() {
+		const query = this.detail_query;
+		this.detail_body.find("tr[data-search]").each((_, el) => {
+			$(el).toggle(!query || ($(el).attr("data-search") || "").includes(query));
+		});
+	}
+
+	render_detail_body() {
+		this.detail_body.empty();
+		if (this.active_tab === "manufacture") this.render_manufacture_items();
+		else if (this.active_tab === "materials") this.render_materials();
+		else this.render_schedule();
+		this.apply_detail_filter();
+	}
+
+	make_table(columns) {
+		const head = columns
+			.map(
+				(col) =>
+					`<th class="${col.class || ""}" style="${col.style || ""}">${this.esc(col.label)}</th>`
+			)
+			.join("");
+		const table = $(`<table class="ppv-table"><thead><tr>${head}</tr></thead><tbody></tbody></table>`);
+		return { table, body: table.find("tbody") };
+	}
+
+	render_manufacture_items() {
+		const goods = this.focused_goods();
+		if (!goods.length) {
+			this.render_empty(__("No items to manufacture in this plan"));
+			return;
+		}
+		const { table, body } = this.make_table([
+			{ label: __("Item") },
+			{ label: __("Planned"), class: "ppv-num" },
+			{ label: __("In Stock"), class: "ppv-num" },
+			{ label: __("Done"), class: "ppv-num" },
+			{ label: __("Pending"), class: "ppv-num" },
+			{ label: __("Progress"), class: "ppv-col-progress" },
+			{ label: __("Documents"), class: "ppv-col-docs" },
+		]);
+
+		for (const fg of goods) {
+			body.append(this.manufacture_row(fg, { kind: "fg", indent: 0 }));
+			for (const sub of this.index.subs_by_parent[fg.row_name] || []) {
+				body.append(this.manufacture_row(sub, { kind: "sub", indent: 1 + (sub.indent || 0) }));
+			}
+		}
+		this.detail_body.append(table);
+		this.append_orphan_subs(body);
+	}
+
+	append_orphan_subs(body) {
+		if (this.focus !== "all") return;
+		const orphans = this.data.sub_assemblies.filter((d) => !this.index.owner_of_row[d.row_name]);
+		if (!orphans.length) return;
+		body.append(this.group_row(__("Unlinked Sub Assemblies"), 7));
+		for (const sub of orphans) body.append(this.manufacture_row(sub, { kind: "sub", indent: 1 }));
+	}
+
+	group_row(label, span) {
+		return $(`<tr class="ppv-row-group"><td colspan="${span}">${this.esc(label)}</td></tr>`);
+	}
+
+	manufacture_row(row, { kind, indent }) {
+		const completion = row.qty ? (row.produced_qty / row.qty) * 100 : 0;
+		const uom = row.stock_uom || row.uom || "";
+		const tr = $(`
+			<tr data-kind="${kind}" data-search="${this.esc(
+			`${row.item_name || ""} ${row.item_code} ${(row.documents || [])
+				.map((d) => d.name)
+				.join(" ")}`.toLowerCase()
+		)}">
+				<td class="ppv-cell-item" style="--ppv-indent: ${indent}">
+					<div class="ppv-item-line">
+						<a href="/app/item/${encodeURIComponent(row.item_code)}">${this.esc(row.item_name || row.item_code)}</a>
+						<span class="ppv-item-tag"></span>
+					</div>
+					<div class="ppv-item-sub">${this.esc(row.item_code)}</div>
+				</td>
+				<td class="ppv-num">${this.format_float(row.qty)} <span class="ppv-uom">${this.esc(uom)}</span></td>
+				<td class="ppv-num">${kind === "sub" ? this.format_float(row.available_qty) : "—"}</td>
+				<td class="ppv-num">${this.format_float(row.produced_qty)}</td>
+				<td class="ppv-num ${row.pending_qty > 0 ? "ppv-pending" : ""}">${this.format_float(row.pending_qty)}</td>
+				<td class="ppv-col-progress"></td>
+				<td class="ppv-col-docs"></td>
+			</tr>
+		`);
+		tr.find(".ppv-item-tag").append(this.manufacture_tag(row, kind));
+		tr.find(".ppv-col-progress").append(frappe.ui.progress({ value: completion, hint: true }));
+		this.append_document_chips(tr.find(".ppv-col-docs"), row.documents);
+		return tr;
+	}
+
+	manufacture_tag(row, kind) {
+		if (kind === "fg") {
+			if (!row.sales_order) return frappe.ui.badge({ label: __("Finished Good"), size: "sm" });
+			return frappe.ui.badge({
+				label: row.sales_order,
+				theme: "violet",
+				variant: "outline",
+				size: "sm",
+			});
+		}
+		return frappe.ui.badge({
+			label: __(row.type_of_manufacturing || "In House"),
+			size: "sm",
+			theme: row.type_of_manufacturing === "Subcontract" ? "amber" : "blue",
+			variant: "outline",
+		});
+	}
+
+	render_materials() {
+		const { owned, shared } = this.focused_materials();
+		if (!owned.length && !shared.length) {
+			this.render_empty(__("No raw materials planned for this plan yet"));
+			return;
+		}
+		const { table, body } = this.make_table([
+			{ label: __("Material") },
+			{ label: __("Required"), class: "ppv-num" },
+			{ label: __("In Stock"), class: "ppv-num" },
+			{ label: __("To Procure"), class: "ppv-num" },
+			{ label: __("Requested"), class: "ppv-num" },
+			{ label: __("Ordered"), class: "ppv-num" },
+			{ label: __("Status"), class: "ppv-col-status" },
+			{ label: __("Requests"), class: "ppv-col-docs" },
+		]);
+
+		for (const material of owned) body.append(this.material_row(material));
+		if (shared.length) {
+			body.append(this.group_row(__("Shared across finished goods"), 8));
+			for (const material of shared) body.append(this.material_row(material));
+		}
+		this.detail_body.append(table);
+	}
+
+	focused_materials() {
+		const materials = [...(this.data.materials || [])].sort(
+			(a, b) => this.open_qty(b) - this.open_qty(a)
+		);
+		const is_shared = (d) => d.owners.length !== 1;
+		if (this.focus === "all") {
+			return { owned: materials.filter((d) => !is_shared(d)), shared: materials.filter(is_shared) };
+		}
+		return {
+			owned: materials.filter((d) => !is_shared(d) && d.owners[0] === this.focus),
+			shared: materials.filter((d) => is_shared(d) && d.owners.includes(this.focus)),
+		};
+	}
+
+	material_row(material) {
+		const open = this.open_qty(material);
+		const tr = $(`
+			<tr data-open="${open > 0 ? 1 : 0}" data-search="${this.esc(
+			`${material.item_name || ""} ${material.item_code} ${(material.documents || [])
+				.map((d) => d.name)
+				.join(" ")}`.toLowerCase()
+		)}">
+				<td class="ppv-cell-item">
+					<div class="ppv-item-line">
+						<a href="/app/item/${encodeURIComponent(material.item_code)}">${this.esc(
+			material.item_name || material.item_code
+		)}</a>
+						<span class="ppv-item-tag"></span>
+					</div>
+					<div class="ppv-item-sub">${this.esc(material.item_code)}${
+			material.warehouse ? ` &middot; ${this.esc(material.warehouse)}` : ""
+		}</div>
+				</td>
+				<td class="ppv-num">${this.format_float(material.required_qty)} <span class="ppv-uom">${this.esc(
+			material.uom || ""
+		)}</span></td>
+				<td class="ppv-num">${this.format_float(material.available_qty)}</td>
+				<td class="ppv-num">${this.format_float(material.to_procure_qty)}</td>
+				<td class="ppv-num">${this.format_float(material.requested_qty)}</td>
+				<td class="ppv-num">${this.format_float(material.ordered_qty)}</td>
+				<td class="ppv-col-status"></td>
+				<td class="ppv-col-docs"></td>
+			</tr>
+		`);
+		tr.find(".ppv-item-tag").append(
 			frappe.ui.badge({
 				label: __(material.material_request_type || "Material"),
 				size: "sm",
 				variant: "ghost",
 			})
 		);
-		el.find(".ppv-sub-progress").append(frappe.ui.progress({ value: completion, hint: true }));
-		this.append_document_chips(el.find(".ppv-chips"), material.documents);
-		return el;
+		tr.find(".ppv-col-status").append(this.material_status(material, open));
+		this.append_document_chips(tr.find(".ppv-col-docs"), material.documents);
+		return tr;
 	}
 
-	item_card(row, { show_dates } = {}) {
-		const completion = row.qty ? (row.produced_qty / row.qty) * 100 : 0;
-		const card = $(`
-			<div class="ppv-card">
-				<div class="ppv-card-head">
-					<div>
-						<div class="ppv-card-title">
-							<a href="/app/item/${encodeURIComponent(row.item_code)}">
-								${frappe.utils.escape_html(row.item_name || row.item_code)}</a>
-						</div>
-						<div class="ppv-card-sub">${frappe.utils.escape_html(row.item_code)}</div>
-					</div>
-					<div class="ppv-card-badges"></div>
-				</div>
-				<div class="ppv-qty-row">
-					${this.qty_cell(__("Planned"), row.qty)}
-					${this.qty_cell(__("Produced"), row.produced_qty)}
-					${this.qty_cell(__("Pending"), row.pending_qty)}
-				</div>
-				<div class="ppv-card-progress"></div>
-				<div class="ppv-chips"></div>
-			</div>
-		`);
-
-		const badges = card.find(".ppv-card-badges");
-		if (row.sales_order) {
-			badges.append(frappe.ui.badge({ label: row.sales_order, theme: "violet", variant: "outline" }));
-		}
-		if (show_dates && row.planned_start_date) {
-			badges.append(
-				frappe.ui.badge({
-					label: frappe.datetime.str_to_user(row.planned_start_date.split(" ")[0]),
-					icon: "calendar",
-					variant: "ghost",
-				})
-			);
-		}
-		card.find(".ppv-card-progress").append(
-			frappe.ui.progress({ value: completion, size: "md", hint: true })
-		);
-		this.append_document_chips(card.find(".ppv-chips"), row.documents);
-		return card;
-	}
-
-	sub_assembly_row(row) {
-		const completion = row.qty ? (row.produced_qty / row.qty) * 100 : 0;
-		const el = $(`
-			<div class="ppv-sub-row" style="--ppv-indent: ${row.indent}">
-				<div class="ppv-sub-item">
-					<div class="ppv-sub-title">
-						<a href="/app/item/${encodeURIComponent(row.item_code)}">
-							${frappe.utils.escape_html(row.item_name || row.item_code)}</a>
-						<span class="ppv-sub-type"></span>
-					</div>
-					<div class="ppv-card-sub">${frappe.utils.escape_html(row.item_code)}</div>
-				</div>
-				<div class="ppv-qty-row ppv-qty-compact">
-					${this.qty_cell(__("Planned"), row.qty)}
-					${this.qty_cell(__("Done"), row.produced_qty)}
-					${this.qty_cell(__("Pending"), row.pending_qty)}
-				</div>
-				<div class="ppv-sub-progress"></div>
-				<div class="ppv-chips"></div>
-			</div>
-		`);
-		el.find(".ppv-sub-type").append(
-			frappe.ui.badge({
-				label: __(row.type_of_manufacturing || "In House"),
+	material_status(material, open) {
+		if (open > 0) {
+			return frappe.ui.badge({
+				label: __("Request {0}", [this.format_float(open)]),
+				theme: "red",
 				size: "sm",
-				theme: row.type_of_manufacturing === "Subcontract" ? "amber" : "blue",
-				variant: "outline",
-			})
-		);
-		el.find(".ppv-sub-progress").append(frappe.ui.progress({ value: completion, hint: true }));
-		this.append_document_chips(el.find(".ppv-chips"), row.documents);
-		return el;
+			});
+		}
+		if (!flt(material.to_procure_qty)) {
+			return frappe.ui.badge({ label: __("In Stock"), theme: "green", size: "sm" });
+		}
+		if (flt(material.ordered_qty) >= flt(material.to_procure_qty)) {
+			return frappe.ui.badge({ label: __("Ordered"), theme: "green", size: "sm" });
+		}
+		return frappe.ui.badge({ label: __("Requested"), theme: "blue", size: "sm" });
 	}
 
 	append_document_chips(target, documents) {
 		if (!documents || !documents.length) {
-			target.append(`<span class="ppv-no-docs">${__("No documents yet")}</span>`);
+			target.append(`<span class="ppv-no-docs">${__("None")}</span>`);
 			return;
 		}
+		const icons = { "Purchase Order": "shopping-cart", "Material Request": "clipboard-list" };
 		for (const doc of documents) {
 			const route = `/app/${frappe.router.slug(doc.doctype)}/${encodeURIComponent(doc.name)}`;
-			const label = doc.status ? `${doc.name} · ${__(doc.status)}` : doc.name;
-			const icons = {
-				"Purchase Order": "shopping-cart",
-				"Material Request": "clipboard-list",
-			};
 			$(`<a class="ppv-chip-link" href="${route}"></a>`)
 				.append(
 					frappe.ui.badge({
-						label: label,
+						label: doc.name,
+						size: "sm",
 						theme: this.status_theme(doc.status),
 						icon: icons[doc.doctype] || "factory",
+						title: __(doc.status || "Draft"),
 					})
 				)
 				.appendTo(target);
 		}
 	}
 
+	render_empty(title) {
+		this.detail_body.append(
+			$('<div class="ppv-fill"></div>').append(frappe.ui.empty_state({ icon: "inbox", title }))
+		);
+	}
+
 	render_schedule() {
-		const blocks = this.data.schedule || [];
+		const blocks = this.focused_schedule();
 		if (!blocks.length) {
-			this.panel_empty_state(
-				__("No schedule yet — use Schedule Items on the Production Plan to build one")
-			);
+			this.render_empty(__("No schedule yet — use Schedule Items on the Production Plan to build one"));
 			return;
 		}
-		this.panel.append(this.schedule_toolbar());
-		this.panel.append(this.schedule_timeline(blocks));
+		this.detail_body.append(this.schedule_toolbar());
+		this.detail_body.append(this.schedule_timeline(blocks));
+	}
+
+	focused_schedule() {
+		const blocks = this.data.schedule || [];
+		if (this.focus === "all") return blocks;
+		const rows = new Set([this.focus]);
+		for (const sub of this.index.subs_by_parent[this.focus] || []) rows.add(sub.row_name);
+		const items = new Set(
+			(this.data.materials || []).filter((d) => d.owners.includes(this.focus)).map((d) => d.item_code)
+		);
+		return blocks.filter((d) =>
+			d.row_type === "Raw Material" ? items.has(d.item_code) : rows.has(d.plan_row)
+		);
 	}
 
 	schedule_toolbar() {
-		const toggle = (label, value, options, on_change) =>
-			frappe.ui.tab_buttons({
-				label,
-				type: "subtle",
-				size: "sm",
-				value,
-				options,
-				on_change,
-			});
+		const toggle = (value, options, on_change) =>
+			frappe.ui.tab_buttons({ type: "ghost", size: "sm", value, options, on_change });
 		return $('<div class="ppv-schedule-toolbar"></div>')
 			.append(
 				toggle(
-					__("Group by"),
 					this.schedule_group,
 					[
 						{ label: __("By Item"), value: "item" },
@@ -565,13 +766,12 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 					],
 					(value) => {
 						this.schedule_group = value;
-						this.render_active_panel();
+						this.render_detail_body();
 					}
 				)
 			)
 			.append(
 				toggle(
-					__("Scale"),
 					this.schedule_scale,
 					[
 						{ label: __("Day"), value: "day" },
@@ -579,10 +779,14 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 					],
 					(value) => {
 						this.schedule_scale = value;
-						this.render_active_panel();
+						this.render_detail_body();
 					}
 				)
-			);
+			).append(`<span class="ppv-legend">
+				<span class="ppv-legend-item"><i data-row-type="Finished Good"></i>${__("Finished Good")}</span>
+				<span class="ppv-legend-item"><i data-row-type="Sub Assembly"></i>${__("Sub Assembly")}</span>
+				<span class="ppv-legend-item"><i data-row-type="Raw Material"></i>${__("Raw Material")}</span>
+			</span>`);
 	}
 
 	schedule_timeline(blocks) {
@@ -590,6 +794,8 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		const raw_end = Math.max(...blocks.map((d) => frappe.datetime.str_to_obj(d.to_time).getTime()));
 		const axis = this.timeline_ticks(raw_start, raw_end);
 		const span = Math.max(axis.end - axis.start, 1);
+		const now = new Date().getTime();
+		this.today_offset = now > axis.start && now < axis.end ? ((now - axis.start) / span) * 100 : null;
 
 		const timeline = $(
 			`<div class="ppv-timeline" style="--ppv-ticks: ${axis.ticks.length}; --ppv-tick-w: ${axis.tick_width}"></div>`
@@ -598,7 +804,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			<div class="ppv-timeline-header">
 				<div class="ppv-timeline-label">${__("Timeline")}</div>
 				<div class="ppv-axis">${axis.ticks
-					.map((tick) => `<div class="ppv-axis-tick">${frappe.utils.escape_html(tick)}</div>`)
+					.map((tick) => `<div class="ppv-axis-tick">${this.esc(tick)}</div>`)
 					.join("")}</div>
 			</div>
 		`);
@@ -610,28 +816,8 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 
 	timeline_ticks(start, end) {
 		const hour_ms = 3600000;
-		if (this.schedule_scale === "hour") {
-			const span_hours = Math.max((end - start) / hour_ms, 1);
-			const step = span_hours <= 24 ? 1 : span_hours <= 72 ? 3 : span_hours <= 240 ? 6 : 12;
-			const first = new Date(start);
-			first.setMinutes(0, 0, 0);
-			first.setHours(Math.floor(first.getHours() / step) * step);
-			const ticks = [];
-			for (let time = first.getTime(); time < end; time += step * hour_ms) {
-				const date = new Date(time);
-				ticks.push(
-					date.getHours() === 0
-						? frappe.datetime.obj_to_user(date).slice(0, 5)
-						: `${String(date.getHours()).padStart(2, "0")}:00`
-				);
-			}
-			return {
-				ticks,
-				start: first.getTime(),
-				end: first.getTime() + ticks.length * step * hour_ms,
-				tick_width: "72px",
-			};
-		}
+		if (this.schedule_scale === "hour") return this.hour_ticks(start, end, hour_ms);
+
 		const first = new Date(start);
 		first.setHours(0, 0, 0, 0);
 		const ticks = [];
@@ -642,18 +828,37 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			ticks,
 			start: first.getTime(),
 			end: first.getTime() + ticks.length * 24 * hour_ms,
-			tick_width: "96px",
+			tick_width: "84px",
+		};
+	}
+
+	hour_ticks(start, end, hour_ms) {
+		const span_hours = Math.max((end - start) / hour_ms, 1);
+		const step = span_hours <= 24 ? 1 : span_hours <= 72 ? 3 : span_hours <= 240 ? 6 : 12;
+		const first = new Date(start);
+		first.setMinutes(0, 0, 0);
+		first.setHours(Math.floor(first.getHours() / step) * step);
+		const ticks = [];
+		for (let time = first.getTime(); time < end; time += step * hour_ms) {
+			const date = new Date(time);
+			ticks.push(
+				date.getHours() === 0
+					? frappe.datetime.obj_to_user(date).slice(0, 5)
+					: `${String(date.getHours()).padStart(2, "0")}:00`
+			);
+		}
+		return {
+			ticks,
+			start: first.getTime(),
+			end: first.getTime() + ticks.length * step * hour_ms,
+			tick_width: "64px",
 		};
 	}
 
 	schedule_rows(blocks) {
 		if (this.schedule_group === "workstation") {
 			const groups = this.group_rows(blocks, (d) => d.workstation || d.supplier || __("Unassigned"));
-			return Object.entries(groups).map(([label, rows]) => ({
-				label,
-				indent: 0,
-				blocks: rows,
-			}));
+			return Object.entries(groups).map(([label, rows]) => ({ label, indent: 0, blocks: rows }));
 		}
 		return this.schedule_tree(blocks);
 	}
@@ -665,7 +870,6 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			(d) => d.item_code
 		);
 		const row_materials = this.data.row_materials || {};
-		const subs_by_parent = this.group_rows(this.data.sub_assemblies, (d) => d.production_plan_item);
 		const used_materials = new Set();
 		const used_rows = new Set();
 
@@ -678,10 +882,10 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			});
 
 		const out = [];
-		for (const fg of this.data.finished_goods) {
+		for (const fg of this.focused_goods()) {
 			used_rows.add(fg.row_name);
 			const branch = [];
-			for (const sub of subs_by_parent[fg.row_name] || []) {
+			for (const sub of this.index.subs_by_parent[fg.row_name] || []) {
 				used_rows.add(sub.row_name);
 				const indent = 1 + (sub.indent || 0);
 				const sub_blocks = by_row[sub.row_name] || [];
@@ -700,60 +904,56 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			}
 		}
 
+		return out.concat(this.leftover_rows(blocks, used_rows, used_materials));
+	}
+
+	leftover_rows(blocks, used_rows, used_materials) {
 		const leftover = blocks.filter((d) =>
 			d.row_type === "Raw Material" ? !used_materials.has(d.item_code) : !used_rows.has(d.plan_row)
 		);
-		for (const [label, rows] of Object.entries(
-			this.group_rows(leftover, (d) => d.item_name || d.item_code || d.subject)
-		)) {
-			out.push({ label, indent: 0, blocks: rows });
-		}
-		return out;
+		const groups = this.group_rows(leftover, (d) => d.item_name || d.item_code || d.subject);
+		return Object.entries(groups).map(([label, rows]) => ({ label, indent: 0, blocks: rows }));
 	}
 
 	timeline_row(descriptor, start, span) {
 		const { label, indent, blocks } = descriptor;
 		const row = $(`
 			<div class="ppv-timeline-row" data-depth="${indent > 0 ? "child" : "root"}">
-				<div class="ppv-timeline-label" style="--ppv-row-indent: ${indent}"
-					title="${frappe.utils.escape_html(label)}">
-					${indent > 0 ? '<span class="ppv-tree-branch">└</span>' : ""}
-					${frappe.utils.escape_html(label)}</div>
+				<div class="ppv-timeline-label" style="--ppv-row-indent: ${indent}" title="${this.esc(label)}">
+					${this.esc(label)}</div>
 				<div class="ppv-track"></div>
 			</div>
 		`);
 		const track = row.find(".ppv-track");
-		for (const block of blocks) {
-			const from = frappe.datetime.str_to_obj(block.from_time).getTime();
-			const to = frappe.datetime.str_to_obj(block.to_time).getTime();
-			const left = ((from - start) / span) * 100;
-			const width = Math.max(((to - from) / span) * 100, 0.6);
-			const title = [
-				block.subject,
-				`${frappe.datetime.str_to_user(block.from_time)} → ${frappe.datetime.str_to_user(
-					block.to_time
-				)}`,
-				block.workstation || block.supplier || "",
-			]
-				.filter(Boolean)
-				.join("\n");
-			$(`<a class="ppv-block" data-row-type="${frappe.utils.escape_html(block.row_type || "")}"
-				style="left: ${left}%; width: ${width}%"
-				href="/app/production-plan-schedule/${encodeURIComponent(block.name)}"
-				title="${frappe.utils.escape_html(title)}">
-				<span>${frappe.utils.escape_html(block.operation || block.item_name || block.subject || "")}</span>
-			</a>`).appendTo(track);
+		if (this.today_offset !== null) {
+			track.append(`<span class="ppv-today" style="left: ${this.today_offset}%"></span>`);
 		}
+		for (const block of blocks) track.append(this.timeline_block(block, start, span));
 		return row;
 	}
 
-	qty_cell(label, value, { integer } = {}) {
-		return `
-			<div class="ppv-qty-cell">
-				<div class="ppv-qty-label">${frappe.utils.escape_html(label)}</div>
-				<div class="ppv-qty-value">${integer ? cint(value) : this.format_float(value)}</div>
-			</div>
-		`;
+	timeline_block(block, start, span) {
+		const from = frappe.datetime.str_to_obj(block.from_time).getTime();
+		const to = frappe.datetime.str_to_obj(block.to_time).getTime();
+		const left = ((from - start) / span) * 100;
+		const width = Math.max(((to - from) / span) * 100, 0.6);
+		const title = [
+			block.subject,
+			`${frappe.datetime.str_to_user(block.from_time)} → ${frappe.datetime.str_to_user(block.to_time)}`,
+			block.workstation || block.supplier || "",
+		]
+			.filter(Boolean)
+			.join("\n");
+		return `<a class="ppv-block" data-row-type="${this.esc(block.row_type || "")}"
+			style="left: ${left}%; width: ${width}%"
+			href="/app/production-plan-schedule/${encodeURIComponent(block.name)}"
+			title="${this.esc(title)}"><span>${this.esc(
+			block.operation || block.item_name || block.subject || ""
+		)}</span></a>`;
+	}
+
+	esc(value) {
+		return frappe.utils.escape_html(value == null ? "" : String(value));
 	}
 
 	format_float(value) {
@@ -793,84 +993,55 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		return themes[status] || "gray";
 	}
 
-	panel_empty_state(title) {
-		this.panel.append(
-			frappe.ui.empty_state({
-				icon: "inbox",
-				title: title,
-				css_class: "ppv-panel-empty",
-			})
-		);
-	}
-
 	styles() {
 		return `<style>
-			.ppv { max-width: 1100px; margin: 0 auto; padding-bottom: var(--padding-2xl); }
-			.ppv-blank, .ppv-panel-empty { min-height: 320px; }
+			.ppv { display: flex; flex-direction: column; gap: var(--padding-sm); overflow: hidden; }
+			.ppv-fill { flex: 1 1 auto; display: flex; align-items: center; justify-content: center; }
+			.ppv-muted { color: var(--text-muted); }
+			.ppv-uom { color: var(--text-muted); font-size: var(--text-xs); }
 
-			.ppv-hero {
+			.ppv-kpis {
+				flex: 0 0 auto;
 				display: grid;
-				grid-template-columns: 1fr auto;
-				gap: var(--padding-lg) var(--padding-2xl);
+				grid-template-columns: 1.7fr repeat(4, minmax(0, 1fr));
+				gap: var(--padding-sm);
+			}
+			.ppv-kpi {
+				display: flex;
+				flex-direction: column;
+				justify-content: center;
+				gap: 2px;
+				min-height: 76px;
+				padding: 10px 14px;
 				background: var(--card-bg, var(--fg-color));
 				border: 1px solid var(--border-color);
-				border-radius: var(--border-radius-lg);
-				padding: var(--padding-xl);
-				margin-top: var(--padding-md);
+				border-radius: var(--radius-md);
 			}
-			.ppv-hero-title { display: flex; align-items: center; gap: 10px; }
-			.ppv-plan-link {
-				font-size: var(--text-xl);
-				font-weight: 600;
-				color: var(--heading-color);
-				text-decoration: none;
-			}
-			.ppv-hero-meta { color: var(--text-muted); margin-top: 2px; font-size: var(--text-sm); }
-			.ppv-hero-progress { margin-top: var(--padding-lg); max-width: 460px; }
-
-			.ppv-ring { width: 110px; height: 110px; }
-			.ppv-ring-track { fill: none; stroke: var(--bg-color); stroke-width: 10; }
-			.ppv-ring-fill {
-				fill: none;
-				stroke: var(--primary);
-				stroke-width: 10;
-				stroke-linecap: round;
-				transform: rotate(-90deg);
-				transform-origin: 55px 55px;
-				transition: stroke-dashoffset 0.6s ease;
-			}
-			.ppv-ring-value {
-				text-anchor: middle;
-				font-size: 22px;
-				font-weight: 700;
-				fill: var(--heading-color);
-			}
-			.ppv-ring-caption { text-anchor: middle; font-size: 10px; fill: var(--text-muted); }
-
-			.ppv-stats {
-				grid-column: 1 / -1;
-				display: grid;
-				grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-				gap: var(--padding-md);
-				border-top: 1px solid var(--border-color);
-				padding-top: var(--padding-lg);
-			}
-			.ppv-tile-value {
-				font-size: var(--text-2xl);
-				font-weight: 700;
-				color: var(--heading-color);
-				font-variant-numeric: tabular-nums;
-			}
-			.ppv-tile-label {
+			.ppv-kpi[data-clickable="1"] { cursor: pointer; }
+			.ppv-kpi[data-clickable="1"]:hover { border-color: var(--gray-400); }
+			.ppv-kpi-label {
 				font-size: var(--text-xs);
 				text-transform: uppercase;
 				letter-spacing: 0.05em;
 				color: var(--text-muted);
-				margin-top: 2px;
 			}
-			.ppv-tile-dots {
-				display: flex; gap: 10px; margin-top: 6px;
-				font-size: var(--text-xs); color: var(--text-muted);
+			.ppv-kpi-value {
+				font-size: 22px;
+				line-height: 1.2;
+				font-weight: 700;
+				color: var(--heading-color);
+				font-variant-numeric: tabular-nums;
+			}
+			.ppv-kpi[data-tone="red"] .ppv-kpi-value { color: var(--red-600); }
+			.ppv-kpi[data-tone="green"] .ppv-kpi-value { color: var(--green-600); }
+			.ppv-kpi[data-tone="amber"] .ppv-kpi-value { color: var(--yellow-700); }
+			.ppv-kpi-hint {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				flex-wrap: wrap;
+				font-size: var(--text-xs);
+				color: var(--text-muted);
 			}
 			.ppv-dot-item { display: inline-flex; align-items: center; gap: 4px; }
 			.ppv-dot { width: 7px; height: 7px; border-radius: 999px; background: var(--gray-400); }
@@ -879,136 +1050,235 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			.ppv-dot[data-theme="amber"] { background: var(--yellow-500); }
 			.ppv-dot[data-theme="red"] { background: var(--red-500); }
 
-			.ppv-tabs { margin: var(--padding-lg) 0 var(--padding-md); }
+			.ppv-hero { flex-direction: row; align-items: center; gap: 14px; }
+			.ppv-ring { width: 62px; height: 62px; }
+			.ppv-ring-track { fill: none; stroke: var(--bg-color); stroke-width: 7; }
+			.ppv-ring-fill {
+				fill: none;
+				stroke: var(--primary);
+				stroke-width: 7;
+				stroke-linecap: round;
+				transform: rotate(-90deg);
+				transform-origin: 32px 32px;
+				transition: stroke-dashoffset 0.6s ease;
+			}
+			.ppv-ring-value {
+				text-anchor: middle;
+				font-size: 15px;
+				font-weight: 700;
+				fill: var(--heading-color);
+			}
+			.ppv-hero-body { min-width: 0; }
+			.ppv-hero-top { display: flex; align-items: center; gap: 8px; }
+			.ppv-hero-name {
+				font-size: var(--text-lg);
+				font-weight: 600;
+				color: var(--heading-color);
+				text-decoration: none;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+			.ppv-hero-qty { font-size: var(--text-sm); color: var(--text-color); margin-top: 2px; }
+			.ppv-hero-meta { font-size: var(--text-xs); color: var(--text-muted); }
+
+			.ppv-workspace {
+				flex: 1 1 auto;
+				min-height: 0;
+				display: grid;
+				grid-template-columns: 284px minmax(0, 1fr);
+				gap: var(--padding-sm);
+			}
+			.ppv-pane {
+				display: flex;
+				flex-direction: column;
+				min-height: 0;
+				background: var(--card-bg, var(--fg-color));
+				border: 1px solid var(--border-color);
+				border-radius: var(--radius-md);
+				overflow: hidden;
+			}
+			.ppv-pane-head {
+				flex: 0 0 auto;
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				min-height: 44px;
+				padding: 6px 12px;
+				border-bottom: 1px solid var(--border-color);
+			}
+			.ppv-pane-title { font-weight: 600; font-size: var(--text-sm); color: var(--heading-color); }
+			.ppv-count {
+				font-size: var(--text-xs);
+				color: var(--text-muted);
+				background: var(--bg-color);
+				border-radius: 999px;
+				padding: 1px 7px;
+			}
+			.ppv-pane-body { flex: 1 1 auto; min-height: 0; overflow: auto; }
 
 			.ppv-search {
 				display: flex;
 				align-items: center;
-				gap: 8px;
-				max-width: 380px;
-				margin-bottom: var(--padding-md);
+				gap: 6px;
+				margin: 8px 12px;
 				background: var(--fg-color);
 				border: 1px solid var(--border-color);
-				border-radius: var(--border-radius);
-				padding: 6px 10px;
+				border-radius: var(--radius-sm);
+				padding: 4px 8px;
 			}
+			.ppv-search-inline { margin: 0 0 0 auto; min-width: 200px; max-width: 260px; }
 			.ppv-search:focus-within { border-color: var(--primary); }
 			.ppv-search-icon { display: flex; color: var(--text-muted); }
 			.ppv-search-input {
 				flex: 1;
+				min-width: 0;
 				border: none;
 				outline: none;
-				background: transparent;
-				font-size: var(--text-md);
+				background: var(--fg-color);
+				font-size: var(--text-sm);
 				color: var(--text-color);
 			}
-			.ppv-search-count {
-				color: var(--text-muted);
-				font-size: var(--text-xs);
-				white-space: nowrap;
-			}
 
-			.ppv-node { margin-bottom: var(--padding-md); }
-			.ppv-node > .ppv-card { margin-bottom: 0; }
-			.ppv-branch {
-				margin: var(--padding-sm) 0 0 var(--padding-xl);
-				padding-left: var(--padding-lg);
-				border-left: 2px solid var(--border-color);
+			.ppv-rail-row {
+				position: relative;
+				padding: 9px 12px 9px 15px;
+				border-bottom: 1px solid var(--border-color);
+				cursor: pointer;
 			}
-			.ppv-caret { margin-right: 4px; align-self: flex-start; }
-			.ppv-caret svg { transition: transform 0.15s ease; }
-			.ppv-caret.ppv-collapsed svg { transform: rotate(-90deg); }
-			.ppv-material-row { border-style: dashed; }
-			.ppv-material-row .ppv-sub-title a { font-weight: 500; }
-
-			.ppv-card {
-				background: var(--card-bg, var(--fg-color));
-				border: 1px solid var(--border-color);
-				border-radius: var(--border-radius-lg);
-				padding: var(--padding-lg);
-				margin-bottom: var(--padding-md);
-				transition: box-shadow 0.15s ease;
+			.ppv-rail-row::before {
+				content: "";
+				position: absolute;
+				left: 0; top: 0; bottom: 0;
+				width: 3px;
+				background: transparent;
 			}
-			.ppv-card:hover { box-shadow: var(--shadow-sm); }
-			.ppv-card-head { display: flex; gap: var(--padding-md); }
-			.ppv-card-head .ppv-card-badges { margin-left: auto; }
-			.ppv-card-title a { color: var(--heading-color); font-weight: 600; text-decoration: none; }
-			.ppv-card-sub { color: var(--text-muted); font-size: var(--text-sm); margin-top: 1px; }
-			.ppv-card-badges { display: flex; gap: 6px; align-items: flex-start; flex-wrap: wrap; }
-			.ppv-card-progress { margin-top: var(--padding-sm); max-width: 460px; }
-
-			.ppv-qty-row {
-				display: flex;
-				gap: var(--padding-2xl);
-				margin-top: var(--padding-md);
-				justify-content: flex-end;
-			}
-			.ppv-qty-cell { text-align: right; min-width: 90px; }
-			.ppv-qty-label {
-				font-size: var(--text-xs);
-				text-transform: uppercase;
-				letter-spacing: 0.05em;
-				color: var(--text-muted);
-				text-align: right;
-			}
-			.ppv-qty-value {
-				font-size: var(--text-lg);
+			.ppv-rail-row[data-risk="short"]::before { background: var(--red-500); }
+			.ppv-rail-row[data-risk="idle"]::before { background: var(--yellow-500); }
+			.ppv-rail-row[data-risk="running"]::before { background: var(--blue-500); }
+			.ppv-rail-row[data-risk="done"]::before { background: var(--green-500); }
+			.ppv-rail-row:hover { background: var(--bg-color); }
+			.ppv-rail-row.is-active { background: var(--bg-color); }
+			.ppv-rail-row.is-active .ppv-rail-name { color: var(--primary); }
+			.ppv-rail-top { display: flex; align-items: baseline; gap: 8px; }
+			.ppv-rail-name {
+				flex: 1;
+				min-width: 0;
 				font-weight: 600;
+				font-size: var(--text-sm);
 				color: var(--heading-color);
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+			.ppv-rail-pct {
+				font-size: var(--text-xs);
+				color: var(--text-muted);
 				font-variant-numeric: tabular-nums;
+			}
+			.ppv-rail-sub {
+				font-size: var(--text-xs);
+				color: var(--text-muted);
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+			.ppv-rail-bar {
+				height: 3px;
+				border-radius: 999px;
+				background: var(--bg-color);
+				margin-top: 6px;
+				overflow: hidden;
+			}
+			.ppv-rail-bar span { display: block; height: 100%; background: var(--primary); }
+			.ppv-rail-flag { font-size: var(--text-xs); color: var(--text-muted); margin-top: 4px; }
+			.ppv-rail-row[data-risk="short"] .ppv-rail-flag { color: var(--red-600); }
+
+			.ppv-table { width: 100%; border-collapse: separate; border-spacing: 0; font-size: var(--text-sm); }
+			.ppv-table thead th {
+				position: sticky;
+				top: 0;
+				z-index: 2;
+				background: var(--card-bg, var(--fg-color));
+				border-bottom: 1px solid var(--border-color);
+				padding: 8px 12px;
+				font-size: var(--text-xs);
+				font-weight: 500;
+				text-transform: uppercase;
+				letter-spacing: 0.05em;
+				color: var(--text-muted);
+				white-space: nowrap;
+				text-align: left;
+			}
+			.ppv-table td {
+				padding: 7px 12px;
+				border-bottom: 1px solid var(--border-color);
+				vertical-align: middle;
+			}
+			.ppv-table th.ppv-num, .ppv-table td.ppv-num {
 				text-align: right;
+				white-space: nowrap;
+				font-variant-numeric: tabular-nums;
 			}
-			.ppv-qty-compact .ppv-qty-value { font-size: var(--text-base); }
-			.ppv-qty-compact { gap: var(--padding-lg); margin-top: 0; }
-
-			.ppv-chips {
-				display: flex; flex-wrap: wrap; gap: 6px;
-				margin-top: var(--padding-md);
-			}
-			.ppv-chip-link { text-decoration: none; }
-			.ppv-no-docs { color: var(--text-muted); font-size: var(--text-sm); }
-
-			.ppv-group-head {
+			.ppv-table tbody tr:hover { background: var(--bg-color); }
+			.ppv-table tbody tr[data-open="1"] td:first-child { box-shadow: inset 3px 0 0 var(--red-500); }
+			.ppv-row-group td {
+				background: var(--bg-color);
 				font-size: var(--text-xs);
 				text-transform: uppercase;
 				letter-spacing: 0.05em;
 				color: var(--text-muted);
-				margin: var(--padding-lg) 0 var(--padding-sm);
 			}
-			.ppv-sub-row {
-				display: grid;
-				grid-template-columns: minmax(220px, 1.2fr) auto minmax(140px, 0.8fr);
-				gap: var(--padding-sm) var(--padding-xl);
-				align-items: center;
-				background: var(--card-bg, var(--fg-color));
-				border: 1px solid var(--border-color);
-				border-radius: var(--border-radius-lg);
-				padding: var(--padding-md) var(--padding-lg);
-				margin-bottom: var(--padding-sm);
-				margin-left: calc(var(--ppv-indent, 0) * 24px);
-			}
-			.ppv-sub-title { display: flex; align-items: center; gap: 8px; }
-			.ppv-sub-title a { color: var(--heading-color); font-weight: 600; text-decoration: none; }
-			.ppv-sub-row .ppv-chips { grid-column: 1 / -1; margin-top: 0; }
+			.ppv-cell-item { padding-left: calc(12px + var(--ppv-indent, 0) * 18px) !important; min-width: 220px; }
+			.ppv-item-line { display: flex; align-items: center; gap: 6px; }
+			.ppv-item-line a { color: var(--heading-color); font-weight: 500; text-decoration: none; }
+			.ppv-table tr[data-kind="fg"] .ppv-item-line a { font-weight: 600; }
+			.ppv-item-sub { font-size: var(--text-xs); color: var(--text-muted); }
+			.ppv-pending { color: var(--yellow-700); }
+			.ppv-col-progress { width: 130px; }
+			.ppv-col-status { width: 120px; }
+			.ppv-col-docs { width: 210px; }
+			.ppv-col-docs > * { margin-right: 4px; }
+			.ppv-chip-link { text-decoration: none; }
+			.ppv-no-docs { color: var(--text-muted); font-size: var(--text-xs); }
 
 			.ppv-schedule-toolbar {
 				display: flex;
+				align-items: center;
 				gap: var(--padding-md);
 				flex-wrap: wrap;
-				margin-bottom: var(--padding-md);
+				padding: 8px 12px;
+				border-bottom: 1px solid var(--border-color);
 			}
-			.ppv-timeline-scroll { overflow-x: auto; border: 1px solid var(--border-color);
-				border-radius: var(--border-radius-lg); background: var(--card-bg, var(--fg-color)); }
-			.ppv-timeline { min-width: calc(220px + var(--ppv-ticks) * var(--ppv-tick-w, 96px)); }
+			.ppv-legend { display: flex; gap: 12px; margin-left: auto; font-size: var(--text-xs); color: var(--text-muted); }
+			.ppv-legend-item { display: inline-flex; align-items: center; gap: 5px; }
+			.ppv-legend-item i { width: 10px; height: 10px; border-radius: 3px; display: inline-block; }
+			.ppv-legend-item i[data-row-type="Finished Good"] { background: var(--purple-300); }
+			.ppv-legend-item i[data-row-type="Sub Assembly"] { background: var(--blue-300); }
+			.ppv-legend-item i[data-row-type="Raw Material"] { background: var(--yellow-300); }
+
+			.ppv-timeline-scroll { overflow: auto; }
+			.ppv-timeline { min-width: calc(200px + var(--ppv-ticks) * var(--ppv-tick-w, 84px)); }
 			.ppv-timeline-header, .ppv-timeline-row {
 				display: grid;
-				grid-template-columns: 220px 1fr;
+				grid-template-columns: 200px 1fr;
 				border-bottom: 1px solid var(--border-color);
+			}
+			.ppv-timeline-header {
+				position: sticky;
+				top: 0;
+				z-index: 3;
+				background: var(--card-bg, var(--fg-color));
 			}
 			.ppv-timeline-row:last-child { border-bottom: none; }
 			.ppv-timeline-label {
-				padding: var(--padding-md) var(--padding-lg);
-				padding-left: calc(var(--padding-lg) + var(--ppv-row-indent, 0) * 18px);
+				position: sticky;
+				left: 0;
+				z-index: 2;
+				background: var(--card-bg, var(--fg-color));
+				padding: 8px 10px;
+				padding-left: calc(10px + var(--ppv-row-indent, 0) * 16px);
+				font-size: var(--text-sm);
 				font-weight: 600;
 				color: var(--heading-color);
 				border-right: 1px solid var(--border-color);
@@ -1020,10 +1290,9 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 				font-weight: 400;
 				color: var(--text-color);
 			}
-			.ppv-tree-branch { color: var(--text-muted); margin-right: 4px; }
 			.ppv-axis { display: grid; grid-template-columns: repeat(var(--ppv-ticks), 1fr); }
 			.ppv-axis-tick {
-				padding: var(--padding-md) 8px;
+				padding: 8px 6px;
 				font-size: var(--text-xs);
 				color: var(--text-muted);
 				border-right: 1px dashed var(--border-color);
@@ -1031,7 +1300,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			}
 			.ppv-track {
 				position: relative;
-				min-height: 44px;
+				min-height: 38px;
 				background-image: repeating-linear-gradient(
 					to right,
 					transparent,
@@ -1040,21 +1309,30 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 					var(--border-color) calc(100% / var(--ppv-ticks))
 				);
 			}
+			.ppv-today {
+				position: absolute;
+				top: 0;
+				bottom: 0;
+				width: 2px;
+				background: var(--red-400);
+				z-index: 1;
+			}
 			.ppv-block {
 				position: absolute;
-				top: 8px;
-				height: 28px;
-				border-radius: var(--border-radius);
+				top: 6px;
+				height: 26px;
+				border-radius: var(--radius-sm);
 				background: var(--blue-100);
 				border: 1px solid var(--blue-300);
 				color: var(--blue-700);
 				font-size: var(--text-xs);
-				line-height: 26px;
+				line-height: 24px;
 				padding: 0 8px;
 				overflow: hidden;
 				white-space: nowrap;
 				text-overflow: ellipsis;
 				text-decoration: none;
+				z-index: 2;
 			}
 			.ppv-block:hover { filter: brightness(0.97); text-decoration: none; }
 			.ppv-block[data-row-type="Finished Good"] {
@@ -1064,11 +1342,16 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 				background: var(--yellow-100); border-color: var(--yellow-300); color: var(--yellow-700);
 			}
 
-			@media (max-width: 768px) {
-				.ppv-hero { grid-template-columns: 1fr; }
-				.ppv-hero-ring { display: none; }
-				.ppv-qty-row { gap: var(--padding-lg); }
-				.ppv-sub-row { grid-template-columns: 1fr; }
+			@media (max-width: 1200px) {
+				.ppv-kpis { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+				.ppv-hero { grid-column: span 3; }
+			}
+			@media (max-width: 900px) {
+				.ppv { height: auto !important; overflow: visible; }
+				.ppv-kpis { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+				.ppv-hero { grid-column: span 2; }
+				.ppv-workspace { grid-template-columns: 1fr; }
+				.ppv-pane-body { max-height: 60vh; }
 			}
 		</style>`;
 	}

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -535,7 +535,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 				size: "sm",
 				value: this.active_tab,
 				options: [
-					{ label: __("Items to Manufacture"), value: "manufacture" },
+					{ label: __("Work Orders"), value: "manufacture" },
 					{ label: __("Raw Materials"), value: "materials" },
 					{ label: __("Schedule"), value: "schedule" },
 				],
@@ -574,7 +574,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 
 	render_detail_body() {
 		this.detail_body.empty();
-		if (this.active_tab === "manufacture") this.render_manufacture_items();
+		if (this.active_tab === "manufacture") this.render_work_orders();
 		else if (this.active_tab === "materials") this.render_materials();
 		else this.render_schedule();
 		this.apply_detail_filter();
@@ -591,92 +591,107 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		return { table, body: table.find("tbody") };
 	}
 
-	render_manufacture_items() {
-		const goods = this.focused_goods();
-		if (!goods.length) {
-			this.render_empty(__("No items to manufacture in this plan"));
+	render_work_orders() {
+		const { documents, pending } = this.focused_documents();
+		if (!documents.length && !pending.length) {
+			this.render_empty(__("No work orders created from this plan yet"));
 			return;
 		}
 		const { table, body } = this.make_table([
+			{ label: __("Document") },
 			{ label: __("Item") },
-			{ label: __("Planned Qty"), class: "ppv-num" },
-			{ label: __("Qty In Stock"), class: "ppv-num" },
+			{ label: __("Qty"), class: "ppv-num" },
 			{ label: __("Produced Qty"), class: "ppv-num" },
 			{ label: __("Pending Qty"), class: "ppv-num" },
 			{ label: __("Progress"), class: "ppv-col-progress" },
-			{ label: __("Documents"), class: "ppv-col-docs" },
+			{ label: __("Status"), class: "ppv-col-status" },
 		]);
 
-		for (const fg of goods) {
-			body.append(this.manufacture_row(fg, { kind: "fg", indent: 0 }));
-			for (const sub of this.index.subs_by_parent[fg.row_name] || []) {
-				body.append(this.manufacture_row(sub, { kind: "sub", indent: 1 + (sub.indent || 0) }));
-			}
+		for (const entry of documents) body.append(this.work_order_row(entry));
+		if (pending.length) {
+			body.append(this.group_row(__("Not created yet"), 7));
+			for (const row of pending) body.append(this.pending_row(row));
 		}
 		this.detail_body.append(table);
-		this.append_orphan_subs(body);
 	}
 
-	append_orphan_subs(body) {
-		if (this.focus !== "all") return;
-		const orphans = this.data.sub_assemblies.filter(
-			(d) => !(this.index.owners_of_row[d.row_name] || []).length
+	focused_documents() {
+		const documents = [];
+		const pending = [];
+		for (const row of this.focused_rows()) {
+			for (const doc of row.documents || []) documents.push({ doc, row });
+			if (!(row.documents || []).length) pending.push(row);
+		}
+		return { documents, pending };
+	}
+
+	focused_rows() {
+		const rows = [];
+		for (const fg of this.focused_goods()) {
+			rows.push(fg, ...(this.index.subs_by_parent[fg.row_name] || []));
+		}
+		if (this.focus !== "all") return rows;
+		return rows.concat(
+			this.data.sub_assemblies.filter((d) => !(this.index.owners_of_row[d.row_name] || []).length)
 		);
-		if (!orphans.length) return;
-		body.append(this.group_row(__("Unlinked Sub Assemblies"), 7));
-		for (const sub of orphans) body.append(this.manufacture_row(sub, { kind: "sub", indent: 1 }));
 	}
 
 	group_row(label, span) {
 		return $(`<tr class="ppv-row-group"><td colspan="${span}">${this.esc(label)}</td></tr>`);
 	}
 
-	manufacture_row(row, { kind, indent }) {
-		const completion = row.qty ? (row.produced_qty / row.qty) * 100 : 0;
-		const uom = row.stock_uom || row.uom || "";
+	work_order_row({ doc, row }) {
+		const qty = flt(doc.qty);
+		const produced = flt(doc.produced_qty);
+		const completion = qty ? (produced / qty) * 100 : 0;
+		const item_code = doc.item_code || row.item_code;
 		const tr = $(`
-			<tr data-kind="${kind}" data-search="${this.esc(
-			`${row.item_name || ""} ${row.item_code} ${(row.documents || [])
-				.map((d) => d.name)
-				.join(" ")}`.toLowerCase()
-		)}">
-				<td class="ppv-cell-item" style="--ppv-indent: ${indent}">
+			<tr data-search="${this.esc(
+				`${doc.name} ${item_code} ${row.item_name || ""} ${doc.status || ""}`.toLowerCase()
+			)}">
+				<td>
 					<div class="ppv-item-line">
-						<a href="/app/item/${encodeURIComponent(row.item_code)}">${this.esc(row.item_name || row.item_code)}</a>
-						<span class="ppv-item-tag"></span>
+						<a class="ppv-doc-link" href="${this.form_route(doc.doctype, doc.name)}">${this.esc(doc.name)}</a>
 					</div>
-					<div class="ppv-item-sub">${this.esc(row.item_code)}</div>
+					<div class="ppv-item-sub">${this.esc(__(doc.doctype))}${
+			doc.supplier ? ` &middot; ${this.esc(doc.supplier)}` : ""
+		}</div>
 				</td>
-				<td class="ppv-num">${this.format_float(row.qty)} <span class="ppv-uom">${this.esc(uom)}</span></td>
-				<td class="ppv-num">${kind === "sub" ? this.stock_value(row) : "—"}</td>
-				<td class="ppv-num">${this.format_float(row.produced_qty)}</td>
-				<td class="ppv-num ${row.pending_qty > 0 ? "ppv-pending" : ""}">${this.format_float(row.pending_qty)}</td>
+				<td>
+					<div class="ppv-item-line">${this.esc(doc.item_name || row.item_name || item_code)}</div>
+					<div class="ppv-item-sub">${this.esc(item_code)}</div>
+				</td>
+				<td class="ppv-num">${this.format_float(qty)}</td>
+				<td class="ppv-num">${this.format_float(produced)}</td>
+				<td class="ppv-num ${qty - produced > 0 ? "ppv-pending" : ""}">${this.format_float(qty - produced)}</td>
 				<td class="ppv-col-progress"></td>
-				<td class="ppv-col-docs"></td>
+				<td class="ppv-col-status"></td>
 			</tr>
 		`);
-		tr.find(".ppv-item-tag").append(this.manufacture_tag(row, kind));
+		tr.find(".ppv-doc-link").on("click", (e) => this.on_chip_click(e, doc));
 		tr.find(".ppv-col-progress").append(frappe.ui.progress({ value: completion, hint: true }));
-		this.append_document_chips(tr.find(".ppv-col-docs"), row.documents);
+		tr.find(".ppv-col-status").append(this.status_badge(doc.status, "sm"));
 		return tr;
 	}
 
-	manufacture_tag(row, kind) {
-		if (kind === "fg") {
-			if (!row.sales_order) return frappe.ui.badge({ label: __("Finished Good"), size: "sm" });
-			return frappe.ui.badge({
-				label: row.sales_order,
-				theme: "violet",
-				variant: "outline",
-				size: "sm",
-			});
-		}
-		return frappe.ui.badge({
-			label: __(row.type_of_manufacturing || "In House"),
-			size: "sm",
-			theme: row.type_of_manufacturing === "Subcontract" ? "amber" : "blue",
-			variant: "outline",
-		});
+	pending_row(row) {
+		const tr = $(`
+			<tr data-search="${this.esc(`${row.item_name || ""} ${row.item_code}`.toLowerCase())}">
+				<td><span class="ppv-no-docs">${__("Not created")}</span></td>
+				<td>
+					<div class="ppv-item-line">${this.esc(row.item_name || row.item_code)}</div>
+					<div class="ppv-item-sub">${this.esc(row.item_code)}</div>
+				</td>
+				<td class="ppv-num">${this.format_float(row.qty)}</td>
+				<td class="ppv-num">${this.format_float(0)}</td>
+				<td class="ppv-num ppv-pending">${this.format_float(row.qty)}</td>
+				<td class="ppv-col-progress"></td>
+				<td class="ppv-col-status"></td>
+			</tr>
+		`);
+		tr.find(".ppv-col-progress").append(frappe.ui.progress({ value: 0, hint: true }));
+		tr.find(".ppv-col-status").append(this.pill(__("Not Started"), "amber"));
+		return tr;
 	}
 
 	render_materials() {
@@ -1582,10 +1597,10 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 				letter-spacing: 0.05em;
 				color: var(--text-muted);
 			}
-			.ppv-cell-item { padding-left: calc(12px + var(--ppv-indent, 0) * 18px) !important; min-width: 220px; }
+			.ppv-cell-item { min-width: 220px; }
 			.ppv-item-line { display: flex; align-items: center; gap: 6px; }
 			.ppv-item-line a { color: var(--heading-color); font-weight: 500; text-decoration: none; }
-			.ppv-table tr[data-kind="fg"] .ppv-item-line a { font-weight: 600; }
+			.ppv-doc-link { cursor: pointer; }
 			.ppv-item-sub { font-size: var(--text-xs); color: var(--text-muted); }
 			.ppv-pending { color: var(--yellow-700); }
 			.ppv-col-progress { width: 130px; }

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -147,12 +147,18 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 
 	build_index() {
 		this.data.schedule = (this.data.schedule || []).filter((d) => d.from_time && d.to_time);
-		const subs_by_parent = this.group_rows(this.data.sub_assemblies, (d) => d.production_plan_item);
 		const owner_of_row = {};
-		for (const fg of this.data.finished_goods) {
-			owner_of_row[fg.row_name] = fg.row_name;
-			for (const sub of subs_by_parent[fg.row_name] || []) owner_of_row[sub.row_name] = fg.row_name;
+		for (const fg of this.data.finished_goods) owner_of_row[fg.row_name] = fg.row_name;
+		for (const sub of this.data.sub_assemblies) {
+			const owner = owner_of_row[sub.production_plan_item];
+			if (owner) owner_of_row[sub.row_name] = owner;
 		}
+		this.resolve_nested_owners(owner_of_row);
+
+		const subs_by_parent = this.group_rows(
+			this.data.sub_assemblies.filter((d) => owner_of_row[d.row_name]),
+			(d) => owner_of_row[d.row_name]
+		);
 
 		const bom_consumers = {};
 		for (const [row_name, items] of Object.entries(this.data.row_materials || {})) {
@@ -173,6 +179,30 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			material.owners = this.material_owners(material);
 		}
 		this.compute_stats();
+	}
+
+	resolve_nested_owners(owner_of_row) {
+		const fg_by_item = {};
+		for (const fg of this.data.finished_goods) fg_by_item[fg.item_code] = fg.row_name;
+		const sub_by_item = {};
+		for (const sub of this.data.sub_assemblies) sub_by_item[sub.item_code] = sub;
+
+		for (const sub of this.data.sub_assemblies) {
+			if (owner_of_row[sub.row_name]) continue;
+			owner_of_row[sub.row_name] = this.walk_to_finished_good(sub, fg_by_item, sub_by_item);
+			if (!owner_of_row[sub.row_name]) delete owner_of_row[sub.row_name];
+		}
+	}
+
+	walk_to_finished_good(sub, fg_by_item, sub_by_item) {
+		const seen = new Set();
+		let node = sub;
+		while (node && !seen.has(node.row_name)) {
+			seen.add(node.row_name);
+			if (fg_by_item[node.parent_item_code]) return fg_by_item[node.parent_item_code];
+			node = sub_by_item[node.parent_item_code];
+		}
+		return null;
 	}
 
 	material_owners(material) {

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -155,8 +155,10 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		}
 
 		const bom_consumers = {};
-		for (const [row_name, items] of Object.entries(this.data.row_materials || {})) {
-			for (const item of items) (bom_consumers[item] = bom_consumers[item] || []).push(row_name);
+		for (const [row_name, items] of Object.entries(this.data.row_requirements || {})) {
+			for (const item of Object.keys(items)) {
+				(bom_consumers[item] = bom_consumers[item] || []).push(row_name);
+			}
 		}
 
 		const subs_by_signature = {};
@@ -749,7 +751,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			size: "sm",
 			theme: "violet",
 			variant: "outline",
-			title: __("Quantity covers {0}", [names.join(", ")]),
+			title: __("Needed by {0}. Procurement quantities are for the whole plan.", [names.join(", ")]),
 		});
 	}
 
@@ -1081,12 +1083,12 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			blocks.filter((d) => d.row_type === "Raw Material"),
 			(d) => d.item_code
 		);
-		const row_materials = this.data.row_materials || {};
+		const row_materials = this.data.row_requirements || {};
 		const used_materials = new Set();
 		const used_rows = new Set();
 
 		const material_rows = (row_name, indent) =>
-			(row_materials[row_name] || []).flatMap((item) => {
+			Object.keys(row_materials[row_name] || {}).flatMap((item) => {
 				if (used_materials.has(item) || !material_blocks[item]) return [];
 				used_materials.add(item);
 				const rows = material_blocks[item];
@@ -1166,6 +1168,26 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 
 	esc(value) {
 		return frappe.utils.escape_html(value == null ? "" : String(value));
+	}
+
+	required_cell(material) {
+		const total = flt(material.required_qty);
+		if (this.focus === "all" || material.owners.length < 2) return this.format_float(total);
+
+		const share = this.owner_requirement(material, this.focus);
+		if (!share || share >= total) return this.format_float(total);
+		return `${this.format_float(share)}<div class="ppv-sub-note">${__("of {0} in plan", [
+			this.format_float(total),
+		])}</div>`;
+	}
+
+	owner_requirement(material, owner) {
+		const requirements = this.data.row_requirements || {};
+		const rows = [owner, ...(this.index.subs_by_parent[owner] || []).map((d) => d.row_name)];
+		return rows.reduce(
+			(total, row_name) => total + flt((requirements[row_name] || {})[material.item_code]),
+			0
+		);
 	}
 
 	stock_value(row) {
@@ -1310,6 +1332,11 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			.ppv-muted { color: var(--text-muted); }
 			.ppv-uom { color: var(--text-muted); font-size: var(--text-xs); }
 			.ppv-unknown { color: var(--text-muted); cursor: help; }
+			.ppv-sub-note {
+				font-size: var(--text-xs);
+				font-weight: 400;
+				color: var(--text-muted);
+			}
 
 			.ppv-kpis {
 				flex: 0 0 auto;

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -186,7 +186,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 	resolve_nested_owners(owners_of_row) {
 		const fg_by_item = {};
 		for (const fg of this.data.finished_goods) {
-			(fg_by_item[fg.item_code] = fg_by_item[fg.item_code] || []).push(fg.row_name);
+			(fg_by_item[fg.item_code] = fg_by_item[fg.item_code] || []).push(fg);
 		}
 		const subs_by_item = {};
 		for (const sub of this.data.sub_assemblies) {
@@ -208,10 +208,17 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			const node = queue.shift();
 			if (!node || seen.has(node.row_name)) continue;
 			seen.add(node.row_name);
-			for (const row_name of fg_by_item[node.parent_item_code] || []) owners.add(row_name);
-			queue.push(...(subs_by_item[node.parent_item_code] || []));
+			const parent = node.parent_item_code;
+			for (const fg of this.same_demand(sub, fg_by_item[parent] || [])) owners.add(fg.row_name);
+			queue.push(...this.same_demand(sub, subs_by_item[parent] || []));
 		}
 		return [...owners];
+	}
+
+	same_demand(sub, candidates) {
+		if (!sub.sales_order || candidates.length < 2) return candidates;
+		const scoped = candidates.filter((d) => d.sales_order === sub.sales_order);
+		return scoped.length ? scoped : candidates;
 	}
 
 	material_owners(material) {

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -138,7 +138,13 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			for (const item of items) (bom_consumers[item] = bom_consumers[item] || []).push(row_name);
 		}
 
-		this.index = { subs_by_parent, owner_of_row, bom_consumers };
+		const subs_by_signature = {};
+		for (const sub of this.data.sub_assemblies) {
+			const key = `${sub.item_code}::${sub.bom_no || ""}`;
+			(subs_by_signature[key] = subs_by_signature[key] || []).push(sub);
+		}
+
+		this.index = { subs_by_parent, owner_of_row, bom_consumers, subs_by_signature };
 		for (const material of this.data.materials || []) {
 			material.owners = this.material_owners(material);
 		}
@@ -146,12 +152,16 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 	}
 
 	material_owners(material) {
-		if (material.consumer) {
-			const owner = this.index.owner_of_row[material.consumer];
-			return owner ? [owner] : [];
-		}
+		const key = `${material.main_item_code || ""}::${material.from_bom || ""}`;
+		const candidates = this.index.subs_by_signature[key] || [];
+		if (candidates.length) return this.owners_of(candidates.map((d) => d.row_name));
+		if (material.consumer) return this.owners_of([material.consumer]);
+		return this.owners_of(this.index.bom_consumers[material.item_code] || []);
+	}
+
+	owners_of(row_names) {
 		const owners = new Set();
-		for (const row_name of this.index.bom_consumers[material.item_code] || []) {
+		for (const row_name of row_names) {
 			const owner = this.index.owner_of_row[row_name];
 			if (owner) owners.add(owner);
 		}

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -599,7 +599,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		}
 		const { table, body } = this.make_table([
 			{ label: __("Item") },
-			{ label: __("Planned Qty"), class: "ppv-num" },
+			{ label: __("Planned Qty"), class: "ppv-num ppv-num-uom" },
 			{ label: __("Qty In Stock"), class: "ppv-num" },
 			{ label: __("Produced Qty"), class: "ppv-num" },
 			{ label: __("Pending Qty"), class: "ppv-num" },
@@ -656,7 +656,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			</tr>
 		`);
 		tr.find(".ppv-item-tag").append(this.manufacture_tag(row, kind));
-		tr.find(".ppv-col-progress").append(frappe.ui.progress({ value: completion, hint: true }));
+		tr.find(".ppv-col-progress").append(this.progress_cell(completion));
 		this.append_document_chips(tr.find(".ppv-col-docs"), row.documents);
 		return tr;
 	}
@@ -687,7 +687,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		}
 		const { table, body } = this.make_table([
 			{ label: __("Material") },
-			{ label: __("Reqd Qty (BOM)"), class: "ppv-num" },
+			{ label: __("Reqd Qty (BOM)"), class: "ppv-num ppv-num-uom" },
 			{ label: __("Qty In Stock"), class: "ppv-num" },
 			{ label: __("Required Qty"), class: "ppv-num" },
 			{ label: __("Requested Qty"), class: "ppv-num" },
@@ -1210,6 +1210,13 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		return frappe.utils.escape_html(value == null ? "" : String(value));
 	}
 
+	progress_cell(completion) {
+		const value = Math.min(Math.max(completion, 0), 100);
+		return $('<div class="ppv-progress-cell"></div>')
+			.append(frappe.ui.progress({ value }))
+			.append(`<span class="ppv-progress-pct">${Math.round(value)}%</span>`);
+	}
+
 	stock_value(row) {
 		if (!row.stock_known) {
 			return `<span class="ppv-unknown" title="${this.esc(
@@ -1350,7 +1357,13 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			.ppv-drawer .ppv-table td:first-child { max-width: 190px; }
 			.ppv-fill { flex: 1 1 auto; display: flex; align-items: center; justify-content: center; }
 			.ppv-muted { color: var(--text-muted); }
-			.ppv-uom { color: var(--text-muted); font-size: var(--text-xs); }
+			.ppv-uom {
+				display: inline-block;
+				min-width: 30px;
+				text-align: left;
+				color: var(--text-muted);
+				font-size: var(--text-xs);
+			}
 			.ppv-unknown { color: var(--text-muted); cursor: help; }
 
 			.ppv-kpis {
@@ -1588,7 +1601,18 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			.ppv-table tr[data-kind="fg"] .ppv-item-line a { font-weight: 600; }
 			.ppv-item-sub { font-size: var(--text-xs); color: var(--text-muted); }
 			.ppv-pending { color: var(--yellow-700); }
-			.ppv-col-progress { width: 130px; }
+			.ppv-col-progress { width: 150px; }
+			.ppv-progress-cell { display: flex; align-items: center; gap: 8px; }
+			.ppv-progress-cell .es-progress { flex: 1 1 auto; min-width: 0; }
+			.ppv-table th.ppv-num-uom { padding-right: 46px; }
+			.ppv-progress-pct {
+				flex: 0 0 auto;
+				width: 32px;
+				text-align: right;
+				font-variant-numeric: tabular-nums;
+				font-size: var(--text-xs);
+				color: var(--text-muted);
+			}
 			.ppv-col-status { width: 120px; }
 			.ppv-col-docs { width: 210px; }
 			.ppv-col-docs > * { margin-right: 4px; }

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -41,6 +41,9 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			"resize.ppv",
 			frappe.utils.debounce(() => this.fit_viewport(), 150)
 		);
+		$(document).on("keydown.ppv", (e) => {
+			if (e.key === "Escape") this.close_document();
+		});
 		this.render_blank_state();
 	}
 
@@ -121,7 +124,25 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		this.container.empty();
 		this.render_kpis();
 		this.render_workspace();
+		this.render_drawer();
 		this.fit_viewport();
+	}
+
+	render_drawer() {
+		this.backdrop = $('<div class="ppv-backdrop"></div>').appendTo(this.container);
+		this.drawer = $(`
+			<aside class="ppv-drawer">
+				<div class="ppv-drawer-head">
+					<div>
+						<div class="ppv-drawer-name"></div>
+						<div class="ppv-drawer-sub"></div>
+					</div>
+					<div class="ppv-drawer-actions"></div>
+				</div>
+				<div class="ppv-drawer-body"></div>
+			</aside>
+		`).appendTo(this.container);
+		this.backdrop.on("click", () => this.close_document());
 	}
 
 	build_index() {
@@ -743,8 +764,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		}
 		const icons = { "Purchase Order": "shopping-cart", "Material Request": "clipboard-list" };
 		for (const doc of documents) {
-			const route = `/app/${frappe.router.slug(doc.doctype)}/${encodeURIComponent(doc.name)}`;
-			$(`<a class="ppv-chip-link" href="${route}"></a>`)
+			$(`<a class="ppv-chip-link" href="${this.form_route(doc.doctype, doc.name)}"></a>`)
 				.append(
 					frappe.ui.badge({
 						label: doc.name,
@@ -754,8 +774,166 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 						title: __(doc.status || "Draft"),
 					})
 				)
+				.on("click", (e) => this.on_chip_click(e, doc))
 				.appendTo(target);
 		}
+	}
+
+	form_route(doctype, name) {
+		return `/app/${frappe.router.slug(doctype)}/${encodeURIComponent(name)}`;
+	}
+
+	on_chip_click(event, doc) {
+		if (event.ctrlKey || event.metaKey || event.shiftKey || event.which === 2) return;
+		event.preventDefault();
+		this.show_document(doc.doctype, doc.name);
+	}
+
+	show_document(doctype, name) {
+		this.drawer_key = `${doctype}/${name}`;
+		this.drawer.addClass("is-open");
+		this.backdrop.addClass("is-open");
+		this.drawer.find(".ppv-drawer-name").text(name);
+		this.drawer.find(".ppv-drawer-sub").text(__(doctype));
+		this.drawer.find(".ppv-drawer-actions").empty().append(this.drawer_actions(doctype, name));
+		this.drawer
+			.find(".ppv-drawer-body")
+			.html(frappe.ui.skeleton.html({ width: "100%", height: "200px" }));
+
+		frappe.db.get_doc(doctype, name).then((doc) => {
+			if (this.drawer_key === `${doctype}/${name}`) this.render_document(doc, doctype);
+		});
+	}
+
+	drawer_actions(doctype, name) {
+		const open = frappe.ui.button({
+			label: __("Open"),
+			icon_right: "external-link",
+			variant: "subtle",
+			size: "sm",
+			onclick: () => frappe.set_route("Form", doctype, name),
+		});
+		const close = frappe.ui.button({
+			icon: "x",
+			variant: "ghost",
+			size: "sm",
+			title: __("Close"),
+			onclick: () => this.close_document(),
+		});
+		return [open, close];
+	}
+
+	close_document() {
+		if (!this.drawer) return;
+		this.drawer_key = null;
+		this.drawer.removeClass("is-open");
+		this.backdrop.removeClass("is-open");
+	}
+
+	render_document(doc, doctype) {
+		const body = this.drawer.find(".ppv-drawer-body").empty();
+		this.drawer
+			.find(".ppv-drawer-sub")
+			.empty()
+			.append($(`<span>${this.esc(__(doctype))}</span>`), this.status_badge(doc.status, "sm"));
+
+		const grid = $('<div class="ppv-field-grid"></div>').appendTo(body);
+		for (const [fieldname, label, type] of this.document_fields(doctype)) {
+			grid.append(`
+				<div>
+					<div class="ppv-field-label">${this.esc(label)}</div>
+					<div class="ppv-field-value">${this.esc(this.format_value(doc[fieldname], type))}</div>
+				</div>
+			`);
+		}
+		this.render_document_items(body, doc, doctype);
+	}
+
+	render_document_items(body, doc, doctype) {
+		const { field, columns } = this.document_items(doctype);
+		const rows = doc[field] || [];
+		if (!rows.length) return;
+
+		body.append(`<div class="ppv-drawer-section">${__("Items")}</div>`);
+		const { table, body: tbody } = this.make_table(
+			columns.map(([, label, type]) => ({ label, class: type ? "ppv-num" : "" }))
+		);
+		for (const row of rows) {
+			const cells = columns
+				.map(
+					([fieldname, , type]) =>
+						`<td class="${type ? "ppv-num" : ""}">${this.esc(
+							this.format_value(row[fieldname], type)
+						)}</td>`
+				)
+				.join("");
+			tbody.append(`<tr>${cells}</tr>`);
+		}
+		body.append(table);
+	}
+
+	document_fields(doctype) {
+		const fields = {
+			"Work Order": [
+				["production_item", __("Item")],
+				["bom_no", __("BOM")],
+				["qty", __("Qty to Manufacture"), "float"],
+				["material_transferred_for_manufacturing", __("Transferred"), "float"],
+				["produced_qty", __("Produced"), "float"],
+				["planned_start_date", __("Planned Start"), "datetime"],
+				["planned_end_date", __("Planned End"), "datetime"],
+				["source_warehouse", __("Source Warehouse")],
+				["fg_warehouse", __("Target Warehouse")],
+			],
+			"Purchase Order": [
+				["supplier", __("Supplier")],
+				["transaction_date", __("Date"), "date"],
+				["schedule_date", __("Required By"), "date"],
+				["total_qty", __("Total Qty"), "float"],
+				["per_received", __("Received"), "percent"],
+				["per_billed", __("Billed"), "percent"],
+			],
+			"Material Request": [
+				["material_request_type", __("Type")],
+				["transaction_date", __("Date"), "date"],
+				["schedule_date", __("Required By"), "date"],
+				["per_ordered", __("Ordered"), "percent"],
+				["per_received", __("Received"), "percent"],
+			],
+		};
+		return fields[doctype] || [];
+	}
+
+	document_items(doctype) {
+		if (doctype === "Work Order") {
+			return {
+				field: "required_items",
+				columns: [
+					["item_code", __("Item")],
+					["required_qty", __("Required"), "float"],
+					["transferred_qty", __("Transferred"), "float"],
+					["consumed_qty", __("Consumed"), "float"],
+				],
+			};
+		}
+		const received = doctype === "Purchase Order" ? __("Received") : __("Ordered");
+		const received_field = doctype === "Purchase Order" ? "received_qty" : "ordered_qty";
+		return {
+			field: "items",
+			columns: [
+				["item_code", __("Item")],
+				["qty", __("Qty"), "float"],
+				[received_field, received, "float"],
+			],
+		};
+	}
+
+	format_value(value, type) {
+		if (value === null || value === undefined || value === "") return "—";
+		if (type === "float") return this.format_float(value);
+		if (type === "percent") return `${Math.round(flt(value))}%`;
+		if (type === "date" || type === "datetime") return frappe.datetime.str_to_user(value);
+		return String(value);
 	}
 
 	render_empty(title) {
@@ -1038,12 +1216,87 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			}
 
 			.ppv {
+				position: relative;
 				display: flex;
 				flex-direction: column;
 				gap: var(--padding-sm);
 				margin: 0 2px;
 				overflow: hidden;
 			}
+
+			.ppv-backdrop {
+				position: absolute;
+				inset: 0;
+				z-index: 9;
+				background: rgba(0, 0, 0, 0.22);
+				opacity: 0;
+				pointer-events: none;
+				transition: opacity 0.18s ease;
+			}
+			.ppv-backdrop.is-open { opacity: 1; pointer-events: auto; }
+			.ppv-drawer {
+				position: absolute;
+				top: 0;
+				right: 0;
+				bottom: 0;
+				z-index: 10;
+				width: min(440px, 100%);
+				display: flex;
+				flex-direction: column;
+				background: var(--card-bg, var(--fg-color));
+				border-left: 1px solid var(--border-color);
+				box-shadow: var(--shadow-md);
+				transform: translateX(102%);
+				transition: transform 0.18s ease;
+			}
+			.ppv-drawer.is-open { transform: translateX(0); }
+			.ppv-drawer-head {
+				flex: 0 0 auto;
+				display: flex;
+				align-items: flex-start;
+				gap: 8px;
+				padding: 12px 14px;
+				border-bottom: 1px solid var(--border-color);
+			}
+			.ppv-drawer-name {
+				font-size: var(--text-lg);
+				font-weight: 600;
+				color: var(--heading-color);
+			}
+			.ppv-drawer-sub {
+				display: flex;
+				align-items: center;
+				gap: 6px;
+				margin-top: 2px;
+				font-size: var(--text-xs);
+				color: var(--text-muted);
+			}
+			.ppv-drawer-actions { margin-left: auto; display: flex; align-items: center; gap: 4px; }
+			.ppv-drawer-body { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 14px; }
+			.ppv-field-grid {
+				display: grid;
+				grid-template-columns: repeat(2, minmax(0, 1fr));
+				gap: 12px 16px;
+			}
+			.ppv-field-label {
+				font-size: var(--text-xs);
+				text-transform: uppercase;
+				letter-spacing: 0.05em;
+				color: var(--text-muted);
+			}
+			.ppv-field-value {
+				font-size: var(--text-sm);
+				color: var(--text-color);
+				word-break: break-word;
+			}
+			.ppv-drawer-section {
+				margin: 18px 0 6px;
+				font-size: var(--text-xs);
+				text-transform: uppercase;
+				letter-spacing: 0.05em;
+				color: var(--text-muted);
+			}
+			.ppv-drawer .ppv-table td:first-child { max-width: 190px; }
 			.ppv-fill { flex: 1 1 auto; display: flex; align-items: center; justify-content: center; }
 			.ppv-muted { color: var(--text-muted); }
 			.ppv-uom { color: var(--text-muted); font-size: var(--text-xs); }

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -155,10 +155,8 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		}
 
 		const bom_consumers = {};
-		for (const [row_name, items] of Object.entries(this.data.row_requirements || {})) {
-			for (const item of Object.keys(items)) {
-				(bom_consumers[item] = bom_consumers[item] || []).push(row_name);
-			}
+		for (const [row_name, items] of Object.entries(this.data.row_materials || {})) {
+			for (const item of items) (bom_consumers[item] = bom_consumers[item] || []).push(row_name);
 		}
 
 		const subs_by_signature = {};
@@ -563,10 +561,10 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		}
 		const { table, body } = this.make_table([
 			{ label: __("Item") },
-			{ label: __("Planned"), class: "ppv-num" },
-			{ label: __("In Stock"), class: "ppv-num" },
-			{ label: __("Done"), class: "ppv-num" },
-			{ label: __("Pending"), class: "ppv-num" },
+			{ label: __("Planned Qty"), class: "ppv-num" },
+			{ label: __("Qty In Stock"), class: "ppv-num" },
+			{ label: __("Produced Qty"), class: "ppv-num" },
+			{ label: __("Pending Qty"), class: "ppv-num" },
 			{ label: __("Progress"), class: "ppv-col-progress" },
 			{ label: __("Documents"), class: "ppv-col-docs" },
 		]);
@@ -649,12 +647,12 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		}
 		const { table, body } = this.make_table([
 			{ label: __("Material") },
-			{ label: __("Required"), class: "ppv-num" },
-			{ label: __("In Stock"), class: "ppv-num" },
-			{ label: __("To Procure"), class: "ppv-num" },
-			{ label: __("Requested"), class: "ppv-num" },
-			{ label: __("Ordered"), class: "ppv-num" },
-			{ label: __("Received"), class: "ppv-num" },
+			{ label: __("Reqd Qty (BOM)"), class: "ppv-num" },
+			{ label: __("Qty In Stock"), class: "ppv-num" },
+			{ label: __("Required Qty"), class: "ppv-num" },
+			{ label: __("Requested Qty"), class: "ppv-num" },
+			{ label: __("Ordered Qty"), class: "ppv-num" },
+			{ label: __("Received Qty"), class: "ppv-num" },
 			{ label: __("Status"), class: "ppv-col-status" },
 			{ label: __("Requests"), class: "ppv-col-docs" },
 		]);
@@ -751,7 +749,9 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			size: "sm",
 			theme: "violet",
 			variant: "outline",
-			title: __("Needed by {0}. Procurement quantities are for the whole plan.", [names.join(", ")]),
+			title: __("Needed by {0}. Quantities are the plan totals, as on the Production Plan.", [
+				names.join(", "),
+			]),
 		});
 	}
 
@@ -1083,12 +1083,12 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			blocks.filter((d) => d.row_type === "Raw Material"),
 			(d) => d.item_code
 		);
-		const row_materials = this.data.row_requirements || {};
+		const row_materials = this.data.row_materials || {};
 		const used_materials = new Set();
 		const used_rows = new Set();
 
 		const material_rows = (row_name, indent) =>
-			Object.keys(row_materials[row_name] || {}).flatMap((item) => {
+			(row_materials[row_name] || []).flatMap((item) => {
 				if (used_materials.has(item) || !material_blocks[item]) return [];
 				used_materials.add(item);
 				const rows = material_blocks[item];
@@ -1168,26 +1168,6 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 
 	esc(value) {
 		return frappe.utils.escape_html(value == null ? "" : String(value));
-	}
-
-	required_cell(material) {
-		const total = flt(material.required_qty);
-		if (this.focus === "all" || material.owners.length < 2) return this.format_float(total);
-
-		const share = this.owner_requirement(material, this.focus);
-		if (!share || share >= total) return this.format_float(total);
-		return `${this.format_float(share)}<div class="ppv-sub-note">${__("of {0} in plan", [
-			this.format_float(total),
-		])}</div>`;
-	}
-
-	owner_requirement(material, owner) {
-		const requirements = this.data.row_requirements || {};
-		const rows = [owner, ...(this.index.subs_by_parent[owner] || []).map((d) => d.row_name)];
-		return rows.reduce(
-			(total, row_name) => total + flt((requirements[row_name] || {})[material.item_code]),
-			0
-		);
 	}
 
 	stock_value(row) {
@@ -1332,11 +1312,6 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			.ppv-muted { color: var(--text-muted); }
 			.ppv-uom { color: var(--text-muted); font-size: var(--text-xs); }
 			.ppv-unknown { color: var(--text-muted); cursor: help; }
-			.ppv-sub-note {
-				font-size: var(--text-xs);
-				font-weight: 400;
-				color: var(--text-muted);
-			}
 
 			.ppv-kpis {
 				flex: 0 0 auto;

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -606,7 +606,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		}
 		const { table, body } = this.make_table([
 			{ label: __("Item") },
-			{ label: __("Planned Qty"), class: "ppv-num ppv-num-uom" },
+			{ label: __("Planned Qty"), class: "ppv-num" },
 			{ label: __("Qty In Stock"), class: "ppv-num" },
 			{ label: __("Produced Qty"), class: "ppv-num" },
 			{ label: __("Pending Qty"), class: "ppv-num" },
@@ -652,9 +652,9 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 						<a href="/app/item/${encodeURIComponent(row.item_code)}">${this.esc(row.item_name || row.item_code)}</a>
 						<span class="ppv-item-tag"></span>
 					</div>
-					<div class="ppv-item-sub">${this.esc(row.item_code)}</div>
+					<div class="ppv-item-sub">${this.esc(row.item_code)}${uom ? ` &middot; ${this.esc(uom)}` : ""}</div>
 				</td>
-				<td class="ppv-num">${this.format_float(row.qty)} <span class="ppv-uom">${this.esc(uom)}</span></td>
+				<td class="ppv-num">${this.format_float(row.qty)}</td>
 				<td class="ppv-num">${kind === "sub" ? this.stock_value(row) : "—"}</td>
 				<td class="ppv-num">${this.format_float(row.produced_qty)}</td>
 				<td class="ppv-num ${row.pending_qty > 0 ? "ppv-pending" : ""}">${this.format_float(row.pending_qty)}</td>
@@ -694,7 +694,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		}
 		const { table, body } = this.make_table([
 			{ label: __("Material") },
-			{ label: __("Reqd Qty (BOM)"), class: "ppv-num ppv-num-uom" },
+			{ label: __("Reqd Qty (BOM)"), class: "ppv-num" },
 			{ label: __("Qty In Stock"), class: "ppv-num" },
 			{ label: __("Required Qty"), class: "ppv-num" },
 			{ label: __("Requested Qty"), class: "ppv-num" },
@@ -741,11 +741,9 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 					</div>
 					<div class="ppv-item-sub">${this.esc(material.item_code)}${
 			material.warehouse ? ` &middot; ${this.esc(material.warehouse)}` : ""
-		}</div>
+		}${material.uom ? ` &middot; ${this.esc(material.uom)}` : ""}</div>
 				</td>
-				<td class="ppv-num">${this.format_float(material.required_qty)} <span class="ppv-uom">${this.esc(
-			material.uom || ""
-		)}</span></td>
+				<td class="ppv-num">${this.format_float(material.required_qty)}</td>
 				<td class="ppv-num">${this.stock_value(material)}</td>
 				<td class="ppv-num">${this.format_float(material.to_procure_qty)}</td>
 				<td class="ppv-num">${this.format_float(material.requested_qty)}</td>
@@ -1364,13 +1362,6 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			.ppv-drawer .ppv-table td:first-child { max-width: 190px; }
 			.ppv-fill { flex: 1 1 auto; display: flex; align-items: center; justify-content: center; }
 			.ppv-muted { color: var(--text-muted); }
-			.ppv-uom {
-				display: inline-block;
-				min-width: 30px;
-				text-align: left;
-				color: var(--text-muted);
-				font-size: var(--text-xs);
-			}
 			.ppv-unknown { color: var(--text-muted); cursor: help; }
 
 			.ppv-kpis {
@@ -1611,7 +1602,6 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			.ppv-col-progress { width: 150px; }
 			.ppv-progress-cell { display: flex; align-items: center; gap: 8px; }
 			.ppv-progress-cell .es-progress { flex: 1 1 auto; min-width: 0; }
-			.ppv-table th.ppv-num-uom { padding-right: 46px; }
 			.ppv-progress-pct {
 				flex: 0 0 auto;
 				width: 32px;

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -176,10 +176,21 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			(subs_by_signature[key] = subs_by_signature[key] || []).push(sub);
 		}
 
+		const row_by_name = {};
+		for (const fg of this.data.finished_goods) row_by_name[fg.row_name] = fg;
+		for (const sub of this.data.sub_assemblies) row_by_name[sub.row_name] = sub;
+
 		const fg_label = {};
 		for (const fg of this.data.finished_goods) fg_label[fg.row_name] = fg.item_name || fg.item_code;
 
-		this.index = { subs_by_parent, owners_of_row, bom_consumers, subs_by_signature, fg_label };
+		this.index = {
+			subs_by_parent,
+			owners_of_row,
+			bom_consumers,
+			subs_by_signature,
+			row_by_name,
+			fg_label,
+		};
 		for (const material of this.data.materials || []) {
 			material.owners = this.material_owners(material);
 		}
@@ -248,7 +259,15 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 		const rows = (this.index.subs_by_signature[key] || []).map((d) => d.row_name);
 		if (material.consumer) rows.push(material.consumer);
 		rows.push(...(this.index.bom_consumers[material.item_code] || []));
-		return this.owners_of(rows);
+		return this.owners_of(this.same_sales_order(material, rows));
+	}
+
+	same_sales_order(material, row_names) {
+		if (!material.sales_order || row_names.length < 2) return row_names;
+		const scoped = row_names.filter(
+			(row_name) => (this.index.row_by_name[row_name] || {}).sales_order === material.sales_order
+		);
+		return scoped.length ? scoped : row_names;
 	}
 
 	owners_of(row_names) {

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -33,6 +33,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 	}
 
 	make() {
+		$(this.page.wrapper).addClass("ppv-page");
 		this.body.html(`${this.styles()}<div class="ppv"></div>`);
 		this.container = this.body.find(".ppv");
 		this.make_plan_field();
@@ -1005,6 +1006,13 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 
 	styles() {
 		return `<style>
+			.ppv-page .page-form {
+				background: transparent;
+				border: none;
+				padding: 0;
+				margin: 0 0 var(--padding-sm);
+			}
+
 			.ppv { display: flex; flex-direction: column; gap: var(--padding-sm); overflow: hidden; }
 			.ppv-fill { flex: 1 1 auto; display: flex; align-items: center; justify-content: center; }
 			.ppv-muted { color: var(--text-muted); }

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -617,13 +617,14 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			{ label: __("To Procure"), class: "ppv-num" },
 			{ label: __("Requested"), class: "ppv-num" },
 			{ label: __("Ordered"), class: "ppv-num" },
+			{ label: __("Received"), class: "ppv-num" },
 			{ label: __("Status"), class: "ppv-col-status" },
 			{ label: __("Requests"), class: "ppv-col-docs" },
 		]);
 
 		for (const material of owned) body.append(this.material_row(material));
 		if (shared.length) {
-			body.append(this.group_row(__("Shared across finished goods"), 8));
+			body.append(this.group_row(__("Shared across finished goods"), 9));
 			for (const material of shared) body.append(this.material_row(material));
 		}
 		this.detail_body.append(table);
@@ -669,6 +670,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 				<td class="ppv-num">${this.format_float(material.to_procure_qty)}</td>
 				<td class="ppv-num">${this.format_float(material.requested_qty)}</td>
 				<td class="ppv-num">${this.format_float(material.ordered_qty)}</td>
+				<td class="ppv-num">${this.format_float(material.received_qty)}</td>
 				<td class="ppv-col-status"></td>
 				<td class="ppv-col-docs"></td>
 			</tr>
@@ -686,20 +688,27 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 	}
 
 	material_status(material, open) {
+		const documents = material.documents || [];
 		if (open > 0) {
-			return frappe.ui.badge({
-				label: __("Request {0}", [this.format_float(open)]),
-				theme: "red",
-				size: "sm",
-			});
+			return this.pill(__("Request {0}", [this.format_float(open)]), "red");
 		}
-		if (!flt(material.to_procure_qty)) {
-			return frappe.ui.badge({ label: __("In Stock"), theme: "green", size: "sm" });
+		if (!flt(material.to_procure_qty) && !documents.length) {
+			return this.pill(__("In Stock"), "green");
+		}
+
+		const statuses = [...new Set(documents.map((d) => d.status).filter(Boolean))];
+		if (statuses.length === 1) return this.pill(__(statuses[0]), this.status_theme(statuses[0]));
+		if (flt(material.received_qty) >= flt(material.to_procure_qty)) {
+			return this.pill(__("Received"), "green");
 		}
 		if (flt(material.ordered_qty) >= flt(material.to_procure_qty)) {
-			return frappe.ui.badge({ label: __("Ordered"), theme: "green", size: "sm" });
+			return this.pill(__("Ordered"), "blue");
 		}
-		return frappe.ui.badge({ label: __("Requested"), theme: "blue", size: "sm" });
+		return this.pill(__("Requested"), "amber");
+	}
+
+	pill(label, theme) {
+		return frappe.ui.badge({ label, theme, size: "sm" });
 	}
 
 	append_document_chips(target, documents) {
@@ -974,6 +983,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 			Transferred: "green",
 			Received: "green",
 			Ordered: "green",
+			Issued: "blue",
 			"In Process": "blue",
 			Submitted: "blue",
 			"In Progress": "blue",

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.js
@@ -33,7 +33,7 @@ erpnext.ProductionPlanVisualizer = class ProductionPlanVisualizer {
 	}
 
 	make() {
-		$(this.page.wrapper).addClass("ppv-page");
+		$(this.page.wrapper).addClass("ppv-page").find(".page-head").css("border-bottom", "none");
 		this.body.html(`${this.styles()}<div class="ppv"></div>`);
 		this.container = this.body.find(".ppv");
 		this.make_plan_field();

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.json
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.json
@@ -1,0 +1,29 @@
+{
+ "content": null,
+ "creation": "2026-08-28 10:00:00",
+ "docstatus": 0,
+ "doctype": "Page",
+ "idx": 0,
+ "modified": "2026-08-28 10:00:00",
+ "modified_by": "Administrator",
+ "module": "Manufacturing",
+ "name": "production-plan-visualizer",
+ "owner": "Administrator",
+ "page_name": "production-plan-visualizer",
+ "roles": [
+  {
+   "role": "Manufacturing User"
+  },
+  {
+   "role": "Manufacturing Manager"
+  },
+  {
+   "role": "System Manager"
+  }
+ ],
+ "script": null,
+ "standard": "Yes",
+ "style": null,
+ "system_page": 0,
+ "title": "Production Plan Visualizer"
+}

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.query_builder.functions import Sum
+from frappe.query_builder.functions import IfNull, Sum
 from frappe.utils import flt
 
 
@@ -20,7 +20,7 @@ def get_plan_overview(production_plan: str):
 		"material_requests": get_material_requests(production_plan),
 		"materials": get_materials(plan, production_plan, stock, warehouses),
 		"schedule": schedule,
-		"row_materials": get_row_materials(plan, schedule),
+		"row_requirements": get_row_requirements(plan, schedule),
 	}
 
 
@@ -139,33 +139,62 @@ def get_raised_material_request_items(production_plan):
 	)
 
 
-def get_row_materials(plan, schedule):
+def get_row_requirements(plan, schedule):
 	material_items = {d.item_code for d in schedule if d.row_type == "Raw Material"}
 	material_items.update(row.item_code for row in plan.mr_items)
-	rows = [(d.name, d.bom_no) for d in plan.po_items + plan.sub_assembly_items if d.bom_no]
+	rows = [
+		(d.name, d.bom_no, flt(d.get("planned_qty") or d.get("qty")))
+		for d in plan.po_items + plan.sub_assembly_items
+		if d.bom_no
+	]
 	if not material_items or not rows:
 		return {}
 
 	boms = frappe.get_list(
 		"BOM",
-		filters={"name": ("in", {bom_no for _, bom_no in rows})},
+		filters={"name": ("in", {bom_no for _, bom_no, _ in rows})},
 		pluck="name",
 		limit_page_length=0,
 	)
 	if not boms:
 		return {}
 
-	bom_items = frappe.get_all(
-		"BOM Item",
-		filters={"parent": ("in", boms), "parenttype": "BOM", "item_code": ("in", material_items)},
-		fields=["parent", "item_code"],
+	per_unit = get_bom_requirements(boms, material_items)
+
+	return {
+		name: {item: qty * row_qty for item, qty in per_unit[bom_no].items()}
+		for name, bom_no, row_qty in rows
+		if per_unit.get(bom_no)
+	}
+
+
+def get_bom_requirements(boms, material_items):
+	bom_item = frappe.qb.DocType("BOM Item")
+	bom = frappe.qb.DocType("BOM")
+
+	rows = (
+		frappe.qb.from_(bom_item)
+		.inner_join(bom)
+		.on(bom.name == bom_item.parent)
+		.select(
+			bom_item.parent,
+			bom_item.item_code,
+			Sum(bom_item.stock_qty / IfNull(bom.quantity, 1)).as_("qty"),
+		)
+		.where(
+			bom_item.parent.isin(boms)
+			& (bom_item.parenttype == "BOM")
+			& bom_item.item_code.isin(material_items)
+		)
+		.groupby(bom_item.parent, bom_item.item_code)
+		.run(as_dict=True)
 	)
 
-	by_bom = {}
-	for d in bom_items:
-		by_bom.setdefault(d.parent, []).append(d.item_code)
+	per_unit = {}
+	for d in rows:
+		per_unit.setdefault(d.parent, {})[d.item_code] = flt(d.qty)
 
-	return {name: by_bom[bom_no] for name, bom_no in rows if by_bom.get(bom_no)}
+	return per_unit
 
 
 def get_plan_details(plan):

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
@@ -1,0 +1,279 @@
+import frappe
+from frappe.query_builder.functions import Count, Sum
+from frappe.utils import flt
+
+
+@frappe.whitelist()
+def get_plan_overview(production_plan: str):
+	plan = frappe.get_doc("Production Plan", production_plan)
+	plan.check_permission("read")
+
+	work_orders = get_work_orders(production_plan)
+	purchase_orders = get_purchase_orders(production_plan)
+	schedule = get_schedule(production_plan)
+
+	return {
+		"plan": get_plan_details(plan),
+		"finished_goods": get_finished_goods(plan, work_orders),
+		"sub_assemblies": get_sub_assemblies(plan, work_orders, purchase_orders),
+		"material_requests": get_material_requests(production_plan),
+		"materials": get_materials(plan, production_plan),
+		"schedule": schedule,
+		"row_materials": get_row_materials(plan, schedule),
+	}
+
+
+def get_materials(plan, production_plan):
+	raised = get_raised_material_request_items(production_plan)
+
+	materials = {}
+	for row in plan.mr_items:
+		material = materials.setdefault(
+			row.item_code,
+			frappe._dict(
+				{
+					"item_code": row.item_code,
+					"item_name": row.item_name,
+					"material_request_type": row.material_request_type,
+					"quantity": 0.0,
+					"requested_qty": 0.0,
+					"ordered_qty": 0.0,
+					"consumers": [],
+					"documents": [],
+				}
+			),
+		)
+		material.quantity += flt(row.quantity)
+		reference = row.get("sub_assembly_item_reference")
+		if reference and reference not in material.consumers:
+			material.consumers.append(reference)
+
+	for row in raised:
+		material = materials.get(row.item_code)
+		if not material:
+			continue
+		material.requested_qty += flt(row.qty)
+		material.ordered_qty += flt(row.ordered_qty)
+		material.documents.append({"doctype": "Material Request", "name": row.name, "status": row.status})
+
+	return list(materials.values())
+
+
+def get_raised_material_request_items(production_plan):
+	mr_item = frappe.qb.DocType("Material Request Item")
+	material_request = frappe.qb.DocType("Material Request")
+
+	return (
+		frappe.qb.from_(mr_item)
+		.inner_join(material_request)
+		.on(mr_item.parent == material_request.name)
+		.select(
+			mr_item.parent.as_("name"),
+			mr_item.item_code,
+			mr_item.qty,
+			mr_item.ordered_qty,
+			material_request.status,
+		)
+		.where((mr_item.production_plan == production_plan) & (mr_item.docstatus < 2))
+		.orderby(material_request.transaction_date)
+		.run(as_dict=True)
+	)
+
+
+def get_row_materials(plan, schedule):
+	material_items = {d.item_code for d in schedule if d.row_type == "Raw Material"}
+	material_items.update(row.item_code for row in plan.mr_items)
+	rows = [(d.name, d.bom_no) for d in plan.po_items + plan.sub_assembly_items if d.bom_no]
+	if not material_items or not rows:
+		return {}
+
+	bom_items = frappe.get_all(
+		"BOM Item",
+		filters={
+			"parent": ("in", {bom_no for _, bom_no in rows}),
+			"parenttype": "BOM",
+			"item_code": ("in", material_items),
+		},
+		fields=["parent", "item_code"],
+	)
+
+	by_bom = {}
+	for d in bom_items:
+		by_bom.setdefault(d.parent, []).append(d.item_code)
+
+	return {name: by_bom[bom_no] for name, bom_no in rows if by_bom.get(bom_no)}
+
+
+def get_plan_details(plan):
+	total_planned = flt(plan.total_planned_qty)
+	total_produced = flt(plan.total_produced_qty)
+	return {
+		"name": plan.name,
+		"status": plan.status,
+		"docstatus": plan.docstatus,
+		"company": plan.company,
+		"posting_date": plan.posting_date,
+		"total_planned_qty": total_planned,
+		"total_produced_qty": total_produced,
+		"completion": flt(total_produced / total_planned * 100 if total_planned else 0, 1),
+	}
+
+
+def get_finished_goods(plan, work_orders):
+	rows = []
+	for row in plan.po_items:
+		documents = [d for d in work_orders if d.production_plan_item == row.name]
+		produced_qty = sum(flt(d.produced_qty) for d in documents)
+		rows.append(
+			{
+				"row_name": row.name,
+				"item_code": row.item_code,
+				"item_name": frappe.get_cached_value("Item", row.item_code, "item_name"),
+				"sales_order": row.get("sales_order"),
+				"warehouse": row.warehouse,
+				"planned_start_date": row.planned_start_date,
+				"planned_end_date": row.get("planned_end_date"),
+				"qty": flt(row.planned_qty),
+				"produced_qty": produced_qty,
+				"pending_qty": flt(row.planned_qty) - produced_qty,
+				"stock_uom": row.stock_uom,
+				"documents": documents,
+			}
+		)
+
+	return rows
+
+
+def get_sub_assemblies(plan, work_orders, purchase_orders):
+	rows = []
+	for item in plan.sub_assembly_items:
+		if item.type_of_manufacturing == "Subcontract":
+			documents = [d for d in purchase_orders if d.production_plan_sub_assembly_item == item.name]
+		else:
+			documents = [d for d in work_orders if d.production_plan_sub_assembly_item == item.name]
+
+		produced_qty = sum(flt(d.produced_qty) for d in documents)
+		rows.append(
+			{
+				"row_name": item.name,
+				"production_plan_item": item.production_plan_item,
+				"item_code": item.production_item,
+				"item_name": item.item_name,
+				"qty": flt(item.qty),
+				"produced_qty": produced_qty,
+				"pending_qty": flt(item.qty) - produced_qty,
+				"bom_level": item.bom_level,
+				"indent": item.indent or 0,
+				"type_of_manufacturing": item.type_of_manufacturing,
+				"schedule_date": item.schedule_date,
+				"documents": documents,
+			}
+		)
+
+	return rows
+
+
+def get_work_orders(production_plan):
+	work_orders = frappe.get_all(
+		"Work Order",
+		filters={"production_plan": production_plan, "docstatus": ("<", 2)},
+		fields=[
+			"name",
+			"qty",
+			"produced_qty",
+			"material_transferred_for_manufacturing",
+			"status",
+			"docstatus",
+			"planned_start_date",
+			"production_item as item_code",
+			"item_name",
+			"production_plan_item",
+			"production_plan_sub_assembly_item",
+		],
+		order_by="creation",
+	)
+
+	for row in work_orders:
+		row.doctype = "Work Order"
+
+	return work_orders
+
+
+def get_purchase_orders(production_plan):
+	po_item = frappe.qb.DocType("Purchase Order Item")
+	purchase_order = frappe.qb.DocType("Purchase Order")
+
+	purchase_orders = (
+		frappe.qb.from_(po_item)
+		.inner_join(purchase_order)
+		.on(po_item.parent == purchase_order.name)
+		.select(
+			po_item.parent.as_("name"),
+			po_item.qty.as_("order_qty"),
+			po_item.received_qty,
+			po_item.fg_item,
+			po_item.fg_item_qty,
+			po_item.production_plan_sub_assembly_item,
+			purchase_order.status,
+			purchase_order.docstatus,
+			purchase_order.supplier,
+		)
+		.where((po_item.production_plan == production_plan) & (po_item.docstatus < 2))
+		.run(as_dict=True)
+	)
+
+	for row in purchase_orders:
+		row.doctype = "Purchase Order"
+		row.qty = flt(row.fg_item_qty) if row.fg_item else flt(row.order_qty)
+		row.produced_qty = flt(row.received_qty)
+		if row.fg_item:
+			row.produced_qty = flt(row.received_qty) / (flt(row.order_qty) / flt(row.fg_item_qty) or 1)
+
+	return purchase_orders
+
+
+def get_material_requests(production_plan):
+	mr_item = frappe.qb.DocType("Material Request Item")
+	material_request = frappe.qb.DocType("Material Request")
+
+	return (
+		frappe.qb.from_(mr_item)
+		.inner_join(material_request)
+		.on(mr_item.parent == material_request.name)
+		.select(
+			mr_item.parent.as_("name"),
+			material_request.status,
+			material_request.material_request_type,
+			material_request.transaction_date,
+			material_request.per_ordered,
+			material_request.per_received,
+			Count(mr_item.name).as_("items"),
+			Sum(mr_item.qty).as_("qty"),
+		)
+		.where((mr_item.production_plan == production_plan) & (mr_item.docstatus < 2))
+		.groupby(mr_item.parent)
+		.orderby(material_request.transaction_date)
+		.run(as_dict=True)
+	)
+
+
+def get_schedule(production_plan):
+	return frappe.get_all(
+		"Production Plan Schedule",
+		filters={"production_plan": production_plan},
+		fields=[
+			"name",
+			"subject",
+			"row_type",
+			"plan_row",
+			"item_code",
+			"item_name",
+			"operation",
+			"workstation",
+			"supplier",
+			"from_time",
+			"to_time",
+			"duration_mins",
+		],
+		order_by="from_time",
+	)

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
@@ -101,6 +101,7 @@ def build_material(row, raised, stock, warehouses):
 		"ordered_qty": sum(flt(entry.ordered_qty) for entry in raised),
 		"received_qty": sum(flt(entry.received_qty) for entry in raised),
 		"schedule_date": row.schedule_date,
+		"sales_order": row.get("sales_order"),
 		"consumer": row.get("sub_assembly_item_reference"),
 		"main_item_code": row.get("main_item_code"),
 		"from_bom": row.get("from_bom"),

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
@@ -28,13 +28,31 @@ def get_materials(plan, production_plan):
 	for row in get_raised_material_request_items(production_plan):
 		raised.setdefault(row.material_request_plan_item, []).append(row)
 
-	return [build_material(row, raised.get(row.name) or []) for row in plan.mr_items]
+	stock = get_stock_levels(plan)
+	return [build_material(row, raised.get(row.name) or [], stock) for row in plan.mr_items]
 
 
-def build_material(row, raised):
-	documents = {}
-	for entry in raised:
-		documents[entry.name] = {"doctype": "Material Request", "name": entry.name, "status": entry.status}
+def get_stock_levels(plan):
+	items = {row.item_code for row in plan.mr_items}
+	warehouses = {row.warehouse for row in plan.mr_items if row.warehouse}
+	if not items or not warehouses:
+		return {}
+
+	bins = frappe.get_all(
+		"Bin",
+		filters={"item_code": ("in", items), "warehouse": ("in", warehouses)},
+		fields=["item_code", "warehouse", "actual_qty", "projected_qty"],
+	)
+
+	return {(d.item_code, d.warehouse): d for d in bins}
+
+
+def build_material(row, raised, stock):
+	documents = {
+		entry.name: {"doctype": "Material Request", "name": entry.name, "status": entry.status}
+		for entry in raised
+	}
+	level = stock.get((row.item_code, row.warehouse)) or frappe._dict()
 
 	return {
 		"row_name": row.name,
@@ -45,10 +63,11 @@ def build_material(row, raised):
 		"material_request_type": row.material_request_type,
 		"required_qty": flt(row.required_bom_qty) or flt(row.quantity),
 		"to_procure_qty": flt(row.quantity),
-		"available_qty": flt(row.actual_qty),
-		"projected_qty": flt(row.projected_qty),
+		"available_qty": flt(level.actual_qty) if level else flt(row.actual_qty),
+		"projected_qty": flt(level.projected_qty) if level else flt(row.projected_qty),
 		"requested_qty": flt(row.requested_qty),
 		"ordered_qty": sum(flt(entry.ordered_qty) for entry in raised),
+		"received_qty": sum(flt(entry.received_qty) for entry in raised),
 		"schedule_date": row.schedule_date,
 		"consumer": row.get("sub_assembly_item_reference"),
 		"main_item_code": row.get("main_item_code"),
@@ -73,6 +92,7 @@ def get_raised_material_request_items(production_plan):
 			mr_item.item_code,
 			mr_item.qty,
 			mr_item.ordered_qty,
+			mr_item.received_qty,
 			material_request.status,
 		)
 		.where((mr_item.production_plan == production_plan) & (mr_item.docstatus < 2))

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.query_builder.functions import IfNull, Sum
+from frappe.query_builder.functions import Sum
 from frappe.utils import flt
 
 
@@ -20,7 +20,7 @@ def get_plan_overview(production_plan: str):
 		"material_requests": get_material_requests(production_plan),
 		"materials": get_materials(plan, production_plan, stock, warehouses),
 		"schedule": schedule,
-		"row_requirements": get_row_requirements(plan, schedule),
+		"row_materials": get_row_materials(plan, schedule),
 	}
 
 
@@ -139,62 +139,33 @@ def get_raised_material_request_items(production_plan):
 	)
 
 
-def get_row_requirements(plan, schedule):
+def get_row_materials(plan, schedule):
 	material_items = {d.item_code for d in schedule if d.row_type == "Raw Material"}
 	material_items.update(row.item_code for row in plan.mr_items)
-	rows = [
-		(d.name, d.bom_no, flt(d.get("planned_qty") or d.get("qty")))
-		for d in plan.po_items + plan.sub_assembly_items
-		if d.bom_no
-	]
+	rows = [(d.name, d.bom_no) for d in plan.po_items + plan.sub_assembly_items if d.bom_no]
 	if not material_items or not rows:
 		return {}
 
 	boms = frappe.get_list(
 		"BOM",
-		filters={"name": ("in", {bom_no for _, bom_no, _ in rows})},
+		filters={"name": ("in", {bom_no for _, bom_no in rows})},
 		pluck="name",
 		limit_page_length=0,
 	)
 	if not boms:
 		return {}
 
-	per_unit = get_bom_requirements(boms, material_items)
-
-	return {
-		name: {item: qty * row_qty for item, qty in per_unit[bom_no].items()}
-		for name, bom_no, row_qty in rows
-		if per_unit.get(bom_no)
-	}
-
-
-def get_bom_requirements(boms, material_items):
-	bom_item = frappe.qb.DocType("BOM Item")
-	bom = frappe.qb.DocType("BOM")
-
-	rows = (
-		frappe.qb.from_(bom_item)
-		.inner_join(bom)
-		.on(bom.name == bom_item.parent)
-		.select(
-			bom_item.parent,
-			bom_item.item_code,
-			Sum(bom_item.stock_qty / IfNull(bom.quantity, 1)).as_("qty"),
-		)
-		.where(
-			bom_item.parent.isin(boms)
-			& (bom_item.parenttype == "BOM")
-			& bom_item.item_code.isin(material_items)
-		)
-		.groupby(bom_item.parent, bom_item.item_code)
-		.run(as_dict=True)
+	bom_items = frappe.get_all(
+		"BOM Item",
+		filters={"parent": ("in", boms), "parenttype": "BOM", "item_code": ("in", material_items)},
+		fields=["parent", "item_code"],
 	)
 
-	per_unit = {}
-	for d in rows:
-		per_unit.setdefault(d.parent, {})[d.item_code] = flt(d.qty)
+	by_bom = {}
+	for d in bom_items:
+		by_bom.setdefault(d.parent, []).append(d.item_code)
 
-	return per_unit
+	return {name: by_bom[bom_no] for name, bom_no in rows if by_bom.get(bom_no)}
 
 
 def get_plan_details(plan):

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
@@ -223,6 +223,7 @@ def get_sub_assemblies(plan, work_orders, purchase_orders, stock, warehouses):
 			{
 				"row_name": item.name,
 				"production_plan_item": item.production_plan_item,
+				"parent_item_code": item.parent_item_code,
 				"item_code": item.production_item,
 				"item_name": item.item_name,
 				"qty": flt(item.qty),

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
@@ -11,25 +11,25 @@ def get_plan_overview(production_plan: str):
 	work_orders = get_work_orders(production_plan)
 	purchase_orders = get_purchase_orders(production_plan)
 	schedule = get_schedule(production_plan)
+	stock, warehouses = get_stock_levels(plan)
 
 	return {
 		"plan": get_plan_details(plan),
 		"finished_goods": get_finished_goods(plan, work_orders),
-		"sub_assemblies": get_sub_assemblies(plan, work_orders, purchase_orders),
+		"sub_assemblies": get_sub_assemblies(plan, work_orders, purchase_orders, stock, warehouses),
 		"material_requests": get_material_requests(production_plan),
-		"materials": get_materials(plan, production_plan),
+		"materials": get_materials(plan, production_plan, stock, warehouses),
 		"schedule": schedule,
 		"row_materials": get_row_materials(plan, schedule),
 	}
 
 
-def get_materials(plan, production_plan):
+def get_materials(plan, production_plan, stock, warehouses):
 	raised = {}
 	for row in get_raised_material_request_items(production_plan):
 		raised.setdefault(row.material_request_plan_item, []).append(row)
 
-	stock = get_stock_levels(plan)
-	return [build_material(row, raised.get(row.name) or [], stock) for row in plan.mr_items]
+	return [build_material(row, raised.get(row.name) or [], stock, warehouses) for row in plan.mr_items]
 
 
 def get_permitted_names(doctype, child_doctype, production_plan):
@@ -49,29 +49,40 @@ def get_permitted_names(doctype, child_doctype, production_plan):
 
 
 def get_stock_levels(plan):
-	if not frappe.has_permission("Bin"):
-		return {}
+	pairs = [(row.item_code, row.warehouse) for row in plan.mr_items if row.warehouse]
+	pairs += [(row.production_item, row.fg_warehouse) for row in plan.sub_assembly_items if row.fg_warehouse]
+	items = {item for item, _ in pairs}
+	warehouses = {warehouse for _, warehouse in pairs}
+	if not items or not warehouses or not frappe.has_permission("Bin"):
+		return {}, set()
 
-	items = {row.item_code for row in plan.mr_items}
-	warehouses = {row.warehouse for row in plan.mr_items if row.warehouse}
-	if not items or not warehouses:
-		return {}
+	permitted = set(
+		frappe.get_list(
+			"Warehouse",
+			filters={"name": ("in", warehouses)},
+			pluck="name",
+			limit_page_length=0,
+		)
+	)
+	if not permitted:
+		return {}, permitted
 
 	bins = frappe.get_list(
 		"Bin",
-		filters={"item_code": ("in", items), "warehouse": ("in", warehouses)},
+		filters={"item_code": ("in", items), "warehouse": ("in", permitted)},
 		fields=["item_code", "warehouse", "actual_qty", "projected_qty"],
 		limit_page_length=0,
 	)
 
-	return {(d.item_code, d.warehouse): d for d in bins}
+	return {(d.item_code, d.warehouse): d for d in bins}, permitted
 
 
-def build_material(row, raised, stock):
+def build_material(row, raised, stock, warehouses):
 	documents = {
 		entry.name: {"doctype": "Material Request", "name": entry.name, "status": entry.status}
 		for entry in raised
 	}
+	stock_known = row.warehouse in warehouses
 	level = stock.get((row.item_code, row.warehouse)) or frappe._dict()
 
 	return {
@@ -83,8 +94,9 @@ def build_material(row, raised, stock):
 		"material_request_type": row.material_request_type,
 		"required_qty": flt(row.required_bom_qty) or flt(row.quantity),
 		"to_procure_qty": flt(row.quantity),
-		"available_qty": flt(level.actual_qty) if level else flt(row.actual_qty),
-		"projected_qty": flt(level.projected_qty) if level else flt(row.projected_qty),
+		"available_qty": flt(level.actual_qty) if stock_known else 0.0,
+		"projected_qty": flt(level.projected_qty) if stock_known else 0.0,
+		"stock_known": stock_known,
 		"requested_qty": flt(row.requested_qty),
 		"ordered_qty": sum(flt(entry.ordered_qty) for entry in raised),
 		"received_qty": sum(flt(entry.received_qty) for entry in raised),
@@ -196,7 +208,7 @@ def get_finished_goods(plan, work_orders):
 	return rows
 
 
-def get_sub_assemblies(plan, work_orders, purchase_orders):
+def get_sub_assemblies(plan, work_orders, purchase_orders, stock, warehouses):
 	rows = []
 	for item in plan.sub_assembly_items:
 		if item.type_of_manufacturing == "Subcontract":
@@ -205,6 +217,8 @@ def get_sub_assemblies(plan, work_orders, purchase_orders):
 			documents = [d for d in work_orders if d.production_plan_sub_assembly_item == item.name]
 
 		produced_qty = sum(flt(d.produced_qty) for d in documents)
+		stock_known = item.fg_warehouse in warehouses
+		level = stock.get((item.production_item, item.fg_warehouse)) or frappe._dict()
 		rows.append(
 			{
 				"row_name": item.name,
@@ -214,7 +228,8 @@ def get_sub_assemblies(plan, work_orders, purchase_orders):
 				"qty": flt(item.qty),
 				"produced_qty": produced_qty,
 				"pending_qty": flt(item.qty) - produced_qty,
-				"available_qty": flt(item.actual_qty),
+				"available_qty": flt(level.actual_qty) if stock_known else 0.0,
+				"stock_known": stock_known,
 				"bom_no": item.bom_no,
 				"bom_level": item.bom_level,
 				"indent": item.indent or 0,

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
@@ -224,6 +224,7 @@ def get_sub_assemblies(plan, work_orders, purchase_orders, stock, warehouses):
 				"row_name": item.name,
 				"production_plan_item": item.production_plan_item,
 				"parent_item_code": item.parent_item_code,
+				"sales_order": item.get("sales_order"),
 				"item_code": item.production_item,
 				"item_name": item.item_name,
 				"qty": flt(item.qty),

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
@@ -142,6 +142,7 @@ def get_raised_material_request_items(production_plan):
 def get_row_materials(plan, schedule):
 	material_items = {d.item_code for d in schedule if d.row_type == "Raw Material"}
 	material_items.update(row.item_code for row in plan.mr_items)
+	material_items.update(row.production_item for row in plan.sub_assembly_items)
 	rows = [(d.name, d.bom_no) for d in plan.po_items + plan.sub_assembly_items if d.bom_no]
 	if not material_items or not rows:
 		return {}
@@ -177,6 +178,7 @@ def get_plan_details(plan):
 		"docstatus": plan.docstatus,
 		"company": plan.company,
 		"posting_date": plan.posting_date,
+		"combine_sub_items": plan.combine_sub_items,
 		"total_planned_qty": total_planned,
 		"total_produced_qty": total_produced,
 		"completion": flt(total_produced / total_planned * 100 if total_planned else 0, 1),

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
@@ -32,16 +32,36 @@ def get_materials(plan, production_plan):
 	return [build_material(row, raised.get(row.name) or [], stock) for row in plan.mr_items]
 
 
+def get_permitted_names(doctype, child_doctype, production_plan):
+	if not frappe.has_permission(doctype):
+		return []
+
+	return frappe.get_list(
+		doctype,
+		filters=[
+			[child_doctype, "production_plan", "=", production_plan],
+			[child_doctype, "docstatus", "<", 2],
+		],
+		pluck="name",
+		distinct=True,
+		limit_page_length=0,
+	)
+
+
 def get_stock_levels(plan):
+	if not frappe.has_permission("Bin"):
+		return {}
+
 	items = {row.item_code for row in plan.mr_items}
 	warehouses = {row.warehouse for row in plan.mr_items if row.warehouse}
 	if not items or not warehouses:
 		return {}
 
-	bins = frappe.get_all(
+	bins = frappe.get_list(
 		"Bin",
 		filters={"item_code": ("in", items), "warehouse": ("in", warehouses)},
 		fields=["item_code", "warehouse", "actual_qty", "projected_qty"],
+		limit_page_length=0,
 	)
 
 	return {(d.item_code, d.warehouse): d for d in bins}
@@ -71,12 +91,14 @@ def build_material(row, raised, stock):
 		"schedule_date": row.schedule_date,
 		"consumer": row.get("sub_assembly_item_reference"),
 		"main_item_code": row.get("main_item_code"),
+		"from_bom": row.get("from_bom"),
 		"documents": list(documents.values()),
 	}
 
 
 def get_raised_material_request_items(production_plan):
-	if not frappe.has_permission("Material Request"):
+	names = get_permitted_names("Material Request", "Material Request Item", production_plan)
+	if not names:
 		return []
 
 	mr_item = frappe.qb.DocType("Material Request Item")
@@ -95,7 +117,11 @@ def get_raised_material_request_items(production_plan):
 			mr_item.received_qty,
 			material_request.status,
 		)
-		.where((mr_item.production_plan == production_plan) & (mr_item.docstatus < 2))
+		.where(
+			(mr_item.production_plan == production_plan)
+			& (mr_item.docstatus < 2)
+			& mr_item.parent.isin(names)
+		)
 		.orderby(material_request.transaction_date)
 		.run(as_dict=True)
 	)
@@ -108,13 +134,18 @@ def get_row_materials(plan, schedule):
 	if not material_items or not rows:
 		return {}
 
+	boms = frappe.get_list(
+		"BOM",
+		filters={"name": ("in", {bom_no for _, bom_no in rows})},
+		pluck="name",
+		limit_page_length=0,
+	)
+	if not boms:
+		return {}
+
 	bom_items = frappe.get_all(
 		"BOM Item",
-		filters={
-			"parent": ("in", {bom_no for _, bom_no in rows}),
-			"parenttype": "BOM",
-			"item_code": ("in", material_items),
-		},
+		filters={"parent": ("in", boms), "parenttype": "BOM", "item_code": ("in", material_items)},
 		fields=["parent", "item_code"],
 	)
 
@@ -184,6 +215,7 @@ def get_sub_assemblies(plan, work_orders, purchase_orders):
 				"produced_qty": produced_qty,
 				"pending_qty": flt(item.qty) - produced_qty,
 				"available_qty": flt(item.actual_qty),
+				"bom_no": item.bom_no,
 				"bom_level": item.bom_level,
 				"indent": item.indent or 0,
 				"type_of_manufacturing": item.type_of_manufacturing,
@@ -228,7 +260,8 @@ def get_work_orders(production_plan):
 
 
 def get_purchase_orders(production_plan):
-	if not frappe.has_permission("Purchase Order"):
+	names = get_permitted_names("Purchase Order", "Purchase Order Item", production_plan)
+	if not names:
 		return []
 
 	po_item = frappe.qb.DocType("Purchase Order Item")
@@ -249,7 +282,11 @@ def get_purchase_orders(production_plan):
 			purchase_order.docstatus,
 			purchase_order.supplier,
 		)
-		.where((po_item.production_plan == production_plan) & (po_item.docstatus < 2))
+		.where(
+			(po_item.production_plan == production_plan)
+			& (po_item.docstatus < 2)
+			& po_item.parent.isin(names)
+		)
 		.run(as_dict=True)
 	)
 
@@ -264,7 +301,8 @@ def get_purchase_orders(production_plan):
 
 
 def get_material_requests(production_plan):
-	if not frappe.has_permission("Material Request"):
+	names = get_permitted_names("Material Request", "Material Request Item", production_plan)
+	if not names:
 		return []
 
 	mr_item = frappe.qb.DocType("Material Request Item")
@@ -283,7 +321,11 @@ def get_material_requests(production_plan):
 			material_request.per_received,
 			Sum(mr_item.qty).as_("qty"),
 		)
-		.where((mr_item.production_plan == production_plan) & (mr_item.docstatus < 2))
+		.where(
+			(mr_item.production_plan == production_plan)
+			& (mr_item.docstatus < 2)
+			& mr_item.parent.isin(names)
+		)
 		.groupby(
 			mr_item.parent,
 			material_request.status,

--- a/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
+++ b/erpnext/manufacturing/page/production_plan_visualizer/production_plan_visualizer.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.query_builder.functions import Count, Sum
+from frappe.query_builder.functions import Sum
 from frappe.utils import flt
 
 
@@ -24,42 +24,42 @@ def get_plan_overview(production_plan: str):
 
 
 def get_materials(plan, production_plan):
-	raised = get_raised_material_request_items(production_plan)
+	raised = {}
+	for row in get_raised_material_request_items(production_plan):
+		raised.setdefault(row.material_request_plan_item, []).append(row)
 
-	materials = {}
-	for row in plan.mr_items:
-		material = materials.setdefault(
-			row.item_code,
-			frappe._dict(
-				{
-					"item_code": row.item_code,
-					"item_name": row.item_name,
-					"material_request_type": row.material_request_type,
-					"quantity": 0.0,
-					"requested_qty": 0.0,
-					"ordered_qty": 0.0,
-					"consumers": [],
-					"documents": [],
-				}
-			),
-		)
-		material.quantity += flt(row.quantity)
-		reference = row.get("sub_assembly_item_reference")
-		if reference and reference not in material.consumers:
-			material.consumers.append(reference)
+	return [build_material(row, raised.get(row.name) or []) for row in plan.mr_items]
 
-	for row in raised:
-		material = materials.get(row.item_code)
-		if not material:
-			continue
-		material.requested_qty += flt(row.qty)
-		material.ordered_qty += flt(row.ordered_qty)
-		material.documents.append({"doctype": "Material Request", "name": row.name, "status": row.status})
 
-	return list(materials.values())
+def build_material(row, raised):
+	documents = {}
+	for entry in raised:
+		documents[entry.name] = {"doctype": "Material Request", "name": entry.name, "status": entry.status}
+
+	return {
+		"row_name": row.name,
+		"item_code": row.item_code,
+		"item_name": row.item_name,
+		"uom": row.uom,
+		"warehouse": row.warehouse,
+		"material_request_type": row.material_request_type,
+		"required_qty": flt(row.required_bom_qty) or flt(row.quantity),
+		"to_procure_qty": flt(row.quantity),
+		"available_qty": flt(row.actual_qty),
+		"projected_qty": flt(row.projected_qty),
+		"requested_qty": flt(row.requested_qty),
+		"ordered_qty": sum(flt(entry.ordered_qty) for entry in raised),
+		"schedule_date": row.schedule_date,
+		"consumer": row.get("sub_assembly_item_reference"),
+		"main_item_code": row.get("main_item_code"),
+		"documents": list(documents.values()),
+	}
 
 
 def get_raised_material_request_items(production_plan):
+	if not frappe.has_permission("Material Request"):
+		return []
+
 	mr_item = frappe.qb.DocType("Material Request Item")
 	material_request = frappe.qb.DocType("Material Request")
 
@@ -69,6 +69,7 @@ def get_raised_material_request_items(production_plan):
 		.on(mr_item.parent == material_request.name)
 		.select(
 			mr_item.parent.as_("name"),
+			mr_item.material_request_plan_item,
 			mr_item.item_code,
 			mr_item.qty,
 			mr_item.ordered_qty,
@@ -162,10 +163,13 @@ def get_sub_assemblies(plan, work_orders, purchase_orders):
 				"qty": flt(item.qty),
 				"produced_qty": produced_qty,
 				"pending_qty": flt(item.qty) - produced_qty,
+				"available_qty": flt(item.actual_qty),
 				"bom_level": item.bom_level,
 				"indent": item.indent or 0,
 				"type_of_manufacturing": item.type_of_manufacturing,
+				"supplier": item.get("supplier"),
 				"schedule_date": item.schedule_date,
+				"uom": item.stock_uom or item.uom,
 				"documents": documents,
 			}
 		)
@@ -174,7 +178,10 @@ def get_sub_assemblies(plan, work_orders, purchase_orders):
 
 
 def get_work_orders(production_plan):
-	work_orders = frappe.get_all(
+	if not frappe.has_permission("Work Order"):
+		return []
+
+	work_orders = frappe.get_list(
 		"Work Order",
 		filters={"production_plan": production_plan, "docstatus": ("<", 2)},
 		fields=[
@@ -191,6 +198,7 @@ def get_work_orders(production_plan):
 			"production_plan_sub_assembly_item",
 		],
 		order_by="creation",
+		limit_page_length=0,
 	)
 
 	for row in work_orders:
@@ -200,6 +208,9 @@ def get_work_orders(production_plan):
 
 
 def get_purchase_orders(production_plan):
+	if not frappe.has_permission("Purchase Order"):
+		return []
+
 	po_item = frappe.qb.DocType("Purchase Order Item")
 	purchase_order = frappe.qb.DocType("Purchase Order")
 
@@ -233,6 +244,9 @@ def get_purchase_orders(production_plan):
 
 
 def get_material_requests(production_plan):
+	if not frappe.has_permission("Material Request"):
+		return []
+
 	mr_item = frappe.qb.DocType("Material Request Item")
 	material_request = frappe.qb.DocType("Material Request")
 
@@ -247,18 +261,27 @@ def get_material_requests(production_plan):
 			material_request.transaction_date,
 			material_request.per_ordered,
 			material_request.per_received,
-			Count(mr_item.name).as_("items"),
 			Sum(mr_item.qty).as_("qty"),
 		)
 		.where((mr_item.production_plan == production_plan) & (mr_item.docstatus < 2))
-		.groupby(mr_item.parent)
+		.groupby(
+			mr_item.parent,
+			material_request.status,
+			material_request.material_request_type,
+			material_request.transaction_date,
+			material_request.per_ordered,
+			material_request.per_received,
+		)
 		.orderby(material_request.transaction_date)
 		.run(as_dict=True)
 	)
 
 
 def get_schedule(production_plan):
-	return frappe.get_all(
+	if not frappe.has_permission("Production Plan Schedule"):
+		return []
+
+	return frappe.get_list(
 		"Production Plan Schedule",
 		filters={"production_plan": production_plan},
 		fields=[
@@ -276,4 +299,5 @@ def get_schedule(production_plan):
 			"duration_mins",
 		],
 		order_by="from_time",
+		limit_page_length=0,
 	)

--- a/erpnext/manufacturing/report/production_plan_summary/production_plan_summary.js
+++ b/erpnext/manufacturing/report/production_plan_summary/production_plan_summary.js
@@ -21,12 +21,30 @@ frappe.query_reports["Production Plan Summary"] = {
 	formatter: function (value, row, column, data, default_formatter) {
 		value = default_formatter(value, row, column, data);
 
-		if (column.fieldname == "item_code") {
-			var color = data.pending_qty > 0 ? "red" : "green";
+		if (column.fieldname == "item_code" && !data.document_type) {
+			var color = data.pending_qty > 0 ? "var(--red-500)" : "var(--green-600)";
 			value = `<a style='color:${color}' href="${frappe.utils.get_form_link(
 				"Item",
 				data["item_code"]
 			)}" data-doctype="Item">${frappe.utils.escape_html(data["item_code"])}</a>`;
+		}
+
+		if (column.fieldname == "status" && data.status && frappe.ui.badge) {
+			const themes = {
+				Completed: "green",
+				"In Process": "blue",
+				"Not Started": "amber",
+				Submitted: "blue",
+				Stopped: "red",
+				Closed: "gray",
+				"To Receive and Bill": "amber",
+				"To Receive": "amber",
+				"To Bill": "amber",
+			};
+			value = frappe.ui.badge.html({
+				label: __(data.status),
+				theme: themes[data.status] || "gray",
+			});
 		}
 
 		return value;

--- a/erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py
+++ b/erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py
@@ -8,163 +8,173 @@ from frappe.utils import flt
 
 
 def execute(filters=None):
-	columns, data = [], []
-	data = get_data(filters)
-	columns = get_column(filters)
-
-	return columns, data
+	return get_column(filters), get_data(filters)
 
 
 def get_data(filters):
-	data = []
+	plan = frappe.get_cached_doc("Production Plan", filters.get("production_plan"))
+	work_orders = get_work_orders(filters)
+	purchase_orders = get_purchase_orders(filters)
 
-	order_details = {}
-	get_work_order_details(filters, order_details)
-	get_purchase_order_details(filters, order_details)
-	get_production_plan_item_details(filters, data, order_details)
+	data = []
+	for row in plan.po_items:
+		fg_work_orders = [d for d in work_orders if d.production_plan_item == row.name]
+		data.append(get_finished_good_row(row, fg_work_orders))
+		data.extend(get_document_row(d, indent=1) for d in fg_work_orders)
+		sub_items = [d for d in plan.sub_assembly_items if d.production_plan_item == row.name]
+		add_sub_assembly_rows(sub_items, data, work_orders, purchase_orders)
+
+	po_row_names = {row.name for row in plan.po_items}
+	orphan_items = [d for d in plan.sub_assembly_items if d.production_plan_item not in po_row_names]
+	add_sub_assembly_rows(orphan_items, data, work_orders, purchase_orders)
 
 	return data
 
 
-def get_production_plan_item_details(filters, data, order_details):
-	production_plan_doc = frappe.get_cached_doc("Production Plan", filters.get("production_plan"))
-	for row in production_plan_doc.po_items:
-		work_orders = frappe.get_all(
-			"Work Order",
-			filters={
-				"production_plan_item": row.name,
-				"bom_no": row.bom_no,
-				"production_item": row.item_code,
-				"docstatus": 1,
-			},
-			pluck="name",
-		)
+def get_finished_good_row(row, fg_work_orders):
+	produced_qty = sum(flt(d.produced_qty) for d in fg_work_orders)
+	return {
+		"indent": 0,
+		"item_code": row.item_code,
+		"item_name": frappe.get_cached_value("Item", row.item_code, "item_name"),
+		"sales_order": row.get("sales_order"),
+		"bom_level": 0,
+		"qty": flt(row.planned_qty),
+		"produced_qty": produced_qty,
+		"pending_qty": flt(row.planned_qty) - produced_qty,
+	}
 
-		order_qty = row.planned_qty
-		total_produced_qty = 0.0
-		# default to the full planned qty so a plan without any work order still
-		# reports everything as pending rather than a misleading zero
-		pending_qty = flt(order_qty)
-		for work_order in work_orders:
-			produced_qty = flt(order_details.get((work_order, row.item_code), {}).get("produced_qty", 0))
-			pending_qty = flt(order_qty) - produced_qty
 
-			total_produced_qty += produced_qty
+def add_sub_assembly_rows(items, data, work_orders, purchase_orders):
+	for item in items:
+		if item.type_of_manufacturing == "Subcontract":
+			documents = [d for d in purchase_orders if d.production_plan_sub_assembly_item == item.name]
+		else:
+			documents = [d for d in work_orders if d.production_plan_sub_assembly_item == item.name]
 
-			data.append(
-				{
-					"indent": 0,
-					"item_code": row.item_code,
-					"sales_order": row.get("sales_order"),
-					"item_name": frappe.get_cached_value("Item", row.item_code, "item_name"),
-					"qty": order_qty,
-					"document_type": "Work Order",
-					"document_name": work_order or "",
-					"bom_level": 0,
-					"produced_qty": produced_qty,
-					"pending_qty": pending_qty,
-				}
-			)
-
-			order_qty = pending_qty
-
+		indent = 1 + (item.indent or 0)
+		produced_qty = sum(flt(d.produced_qty) for d in documents)
 		data.append(
 			{
-				"item_code": row.item_code,
-				"indent": 0,
-				"qty": row.planned_qty,
-				"produced_qty": total_produced_qty,
-				"pending_qty": pending_qty,
+				"indent": indent,
+				"item_code": item.production_item,
+				"item_name": item.item_name,
+				"bom_level": item.bom_level,
+				"qty": flt(item.qty),
+				"produced_qty": produced_qty,
+				"pending_qty": flt(item.qty) - produced_qty,
 			}
 		)
-
-		get_production_plan_sub_assembly_item_details(filters, row, production_plan_doc, data, order_details)
-
-
-def get_production_plan_sub_assembly_item_details(filters, row, production_plan_doc, data, order_details):
-	for item in production_plan_doc.sub_assembly_items:
-		if row.name == item.production_plan_item:
-			subcontracted_item = item.type_of_manufacturing == "Subcontract"
-
-			if subcontracted_item:
-				docnames = frappe.get_all(
-					"Purchase Order Item",
-					filters={"production_plan_sub_assembly_item": item.name, "docstatus": 1},
-					fields=["parent"],
-					order_by="creation",
-					pluck="parent",
-				)
-			else:
-				docnames = frappe.get_all(
-					"Work Order",
-					filters={"production_plan_sub_assembly_item": item.name, "docstatus": 1},
-					fields=["name"],
-					order_by="creation",
-					pluck="name",
-				)
-
-			for docname in docnames:
-				data_to_append = {
-					"indent": 1 + item.indent,
-					"item_code": item.production_item,
-					"item_name": item.item_name,
-					"qty": item.qty,
-					"document_type": "Work Order" if not subcontracted_item else "Purchase Order",
-					"document_name": docname or "",
-					"bom_level": item.bom_level,
-					"produced_qty": order_details.get((docname, item.production_item), {}).get(
-						"produced_qty", 0
-					),
-					"pending_qty": flt(item.qty)
-					- flt(order_details.get((docname, item.production_item), {}).get("produced_qty", 0)),
-				}
-				if data[-1] and data[-1]["item_code"] == item.production_item:
-					data_to_append["pending_qty"] = data[-1]["pending_qty"] - data_to_append["produced_qty"]
-				data.append(data_to_append)
+		data.extend(get_document_row(d, indent=indent + 1) for d in documents)
 
 
-def get_work_order_details(filters, order_details):
-	for row in frappe.get_all(
+def get_document_row(doc, indent):
+	return {
+		"indent": indent,
+		"item_code": doc.item_code,
+		"item_name": doc.item_name,
+		"sales_order": doc.get("sales_order"),
+		"document_type": doc.document_type,
+		"document_name": doc.document_name,
+		"status": doc.status,
+		"qty": flt(doc.qty),
+		"produced_qty": flt(doc.produced_qty),
+		"pending_qty": flt(doc.qty) - flt(doc.produced_qty),
+	}
+
+
+def get_work_orders(filters):
+	work_orders = frappe.get_all(
 		"Work Order",
 		filters={"production_plan": filters.get("production_plan"), "docstatus": 1},
-		fields=["name", "produced_qty", "production_plan", "production_item", "sales_order"],
-	):
-		order_details.setdefault((row.name, row.production_item), row)
+		fields=[
+			"name",
+			"qty",
+			"produced_qty",
+			"status",
+			"sales_order",
+			"production_item as item_code",
+			"item_name",
+			"production_plan_item",
+			"production_plan_sub_assembly_item",
+		],
+	)
+
+	for row in work_orders:
+		row.document_type = "Work Order"
+		row.document_name = row.name
+
+	return work_orders
 
 
-def get_purchase_order_details(filters, order_details):
-	for row in frappe.get_all(
-		"Purchase Order Item",
-		filters={"production_plan": filters.get("production_plan"), "docstatus": 1},
-		fields=["parent", "qty", "received_qty as produced_qty", "item_code", "fg_item", "fg_item_qty"],
-	):
-		if row.fg_item:
-			row.produced_qty /= row.qty / row.fg_item_qty or 1
-		order_details.setdefault((row.parent, row.fg_item or row.item_code), row)
+def get_purchase_orders(filters):
+	po_item = frappe.qb.DocType("Purchase Order Item")
+	purchase_order = frappe.qb.DocType("Purchase Order")
+
+	purchase_orders = (
+		frappe.qb.from_(po_item)
+		.inner_join(purchase_order)
+		.on(po_item.parent == purchase_order.name)
+		.select(
+			po_item.parent.as_("document_name"),
+			po_item.qty.as_("order_qty"),
+			po_item.received_qty,
+			po_item.item_code.as_("po_item_code"),
+			po_item.item_name.as_("po_item_name"),
+			po_item.fg_item,
+			po_item.fg_item_qty,
+			po_item.production_plan_sub_assembly_item,
+			purchase_order.status,
+		)
+		.where((po_item.production_plan == filters.get("production_plan")) & (po_item.docstatus == 1))
+		.run(as_dict=True)
+	)
+
+	return [get_purchase_order_row(row) for row in purchase_orders]
+
+
+def get_purchase_order_row(row):
+	produced_qty = flt(row.received_qty)
+	if row.fg_item:
+		produced_qty = flt(row.received_qty) / (flt(row.order_qty) / flt(row.fg_item_qty) or 1)
+
+	item_code = row.fg_item or row.po_item_code
+	return frappe._dict(
+		{
+			"document_type": "Purchase Order",
+			"document_name": row.document_name,
+			"status": row.status,
+			"item_code": item_code,
+			"item_name": frappe.get_cached_value("Item", item_code, "item_name"),
+			"qty": flt(row.fg_item_qty) if row.fg_item else flt(row.order_qty),
+			"produced_qty": produced_qty,
+			"production_plan_sub_assembly_item": row.production_plan_sub_assembly_item,
+		}
+	)
 
 
 def get_column(filters):
 	return [
 		{
-			"label": _("Finished Good"),
+			"label": _("Item Code"),
 			"fieldtype": "Link",
 			"fieldname": "item_code",
 			"width": 240,
 			"options": "Item",
 		},
-		{"label": _("Item Name"), "fieldtype": "data", "fieldname": "item_name", "width": 150},
+		{"label": _("Item Name"), "fieldtype": "Data", "fieldname": "item_name", "width": 180},
 		{
 			"label": _("Sales Order"),
 			"options": "Sales Order",
 			"fieldtype": "Link",
 			"fieldname": "sales_order",
-			"width": 100,
+			"width": 120,
 		},
 		{
 			"label": _("Document Type"),
 			"fieldtype": "Data",
 			"fieldname": "document_type",
-			"width": 150,
+			"width": 120,
 		},
 		{
 			"label": _("Document Name"),
@@ -173,6 +183,7 @@ def get_column(filters):
 			"options": "document_type",
 			"width": 180,
 		},
+		{"label": _("Status"), "fieldtype": "Data", "fieldname": "status", "width": 110},
 		{"label": _("BOM Level"), "fieldtype": "Int", "fieldname": "bom_level", "width": 100},
 		{"label": _("Order Qty"), "fieldtype": "Float", "fieldname": "qty", "width": 120},
 		{


### PR DESCRIPTION
## What

**1. Fixed the Production Plan Summary report**

The report had several data problems:
- The finished good's summary row was emitted *after* its work order rows, with item name, sales order and document fields missing.
- "Order Qty" on work order rows showed a running remainder chain instead of the actual Work Order qty.
- Sub-assembly rows silently disappeared on amended plans whose `sub_assembly_items.production_plan_item` still references pre-amend parent row names — they are now appended after the matched groups so no data is lost.

Now the report renders a proper tree: finished good first (indent 0) with full details, its work orders beneath with real document quantities, sub-assembly summary rows nested by BOM level with their work orders / subcontract purchase orders one level deeper. Also added a Status column (rendered as badges) and per-document pending = order qty − produced.

**2. New desk page: Production Plan Visualizer** (`/app/production-plan-visualizer`)

### Items to Manufacture
<img width="1439" height="702" alt="Screenshot 2026-08-31 at 2 30 02 PM" src="https://github.com/user-attachments/assets/7a2eb8b4-e773-4056-831e-f99e0b084b06" />


### Raw Materials
<img width="1439" height="702" alt="Screenshot 2026-08-31 at 9 31 14 AM" src="https://github.com/user-attachments/assets/524baaaa-60f3-4bb7-b9ec-3395bd87b643" />


### Schedule
<img width="1439" height="702" alt="Screenshot 2026-08-31 at 9 31 23 AM" src="https://github.com/user-attachments/assets/b04790e8-c1fe-4431-ab4a-af52fb537942" />


docs https://docs.frappe.io/erpnext/production-plan-visualizer