### PR TITLE
test: restore ERPNext test coverage

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
@@ -30,14 +30,6 @@ class TestBankTransaction(ERPNextTestSuite):
 			gl_account=gl_account, bank_account_name="Checking Account " + uniq_identifier
 		)
 
-		if self._testMethodName in {
-			"test_cancel_voucher",
-			"test_clearance_date_cleared_on_amend",
-			"test_reconcile",
-		}:
-			add_reconciliation_data(bank_account, gl_account)
-			return
-
 		make_pos_profile()
 		add_transactions(bank_account=bank_account)
 		add_vouchers(gl_account=gl_account)
@@ -54,7 +46,7 @@ class TestBankTransaction(ERPNextTestSuite):
 			from_date=bank_transaction.date,
 			to_date=utils.today(),
 		)
-		self.assertIn("Conrad Electronic", [payment["party"] for payment in linked_payments])
+		self.assertEqual(linked_payments[0]["party"], "Conrad Electronic")
 
 	# This test validates a simple reconciliation leading to the clearance of the bank transaction and the payment
 	def test_reconcile(self):
@@ -352,36 +344,6 @@ def add_transactions(bank_account="_Test Bank - _TC"):
 		}
 	).insert()
 	doc.submit()
-
-
-def add_reconciliation_data(bank_account, gl_account):
-	doc = frappe.get_doc(
-		{
-			"doctype": "Bank Transaction",
-			"description": "1512567 BG/000003025 OPSKATTUZWXXX AT776000000098709849 Herr G",
-			"date": "2018-10-23",
-			"deposit": 1700,
-			"currency": "INR",
-			"bank_account": bank_account,
-		}
-	).insert()
-	doc.submit()
-
-	frappe.get_doc(
-		{
-			"doctype": "Supplier",
-			"supplier_group": "All Supplier Groups",
-			"supplier_type": "Company",
-			"supplier_name": "Mr G",
-		}
-	).insert(ignore_if_duplicate=True)
-
-	pi = make_purchase_invoice(supplier="Mr G", qty=1, rate=1700)
-	pe = get_payment_entry("Purchase Invoice", pi.name, bank_account=gl_account)
-	pe.reference_no = "Herr G Nov 18"
-	pe.reference_date = "2018-11-01"
-	pe.insert()
-	pe.submit()
 
 
 def add_vouchers(gl_account="_Test Bank - _TC"):

--- a/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
@@ -46,7 +46,7 @@ class TestBankTransaction(ERPNextTestSuite):
 			from_date=bank_transaction.date,
 			to_date=utils.today(),
 		)
-		self.assertEqual(linked_payments[0]["party"], "Conrad Electronic")
+		self.assertIn("Conrad Electronic", [payment["party"] for payment in linked_payments])
 
 	# This test validates a simple reconciliation leading to the clearance of the bank transaction and the payment
 	def test_reconcile(self):

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1357,7 +1357,7 @@ class TestWorkOrder(ERPNextTestSuite):
 			wo_order = make_wo_order_test_record(item=fg_item, qty=2, skip_transfer=True)
 			serial_nos = self.get_serial_nos_for_fg(wo_order.name)
 
-			stock_entry = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 2))
+			stock_entry = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 10))
 			stock_entry.set_work_order_details()
 			for row in stock_entry.items:
 				if row.item_code == fg_item:
@@ -1394,10 +1394,10 @@ class TestWorkOrder(ERPNextTestSuite):
 		item.save()
 
 		try:
-			wo_order = make_wo_order_test_record(item=fg_item, batch_size=1, qty=2, skip_transfer=True)
+			wo_order = make_wo_order_test_record(item=fg_item, batch_size=5, qty=10, skip_transfer=True)
 			serial_nos = self.get_serial_nos_for_fg(wo_order.name)
 
-			stock_entry = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 2))
+			stock_entry = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 10))
 			stock_entry.set_work_order_details()
 			for row in stock_entry.items:
 				if row.item_code == fg_item:

--- a/erpnext/selling/doctype/proforma_invoice/test_proforma_invoice.py
+++ b/erpnext/selling/doctype/proforma_invoice/test_proforma_invoice.py
@@ -2,13 +2,9 @@
 # License: GNU General Public License v3. See license.txt
 
 import json
-from contextlib import nullcontext
-from io import BytesIO
-from unittest.mock import patch
 
 import frappe
 from frappe.utils import flt
-from pypdf import PdfWriter
 
 from erpnext.selling.doctype.proforma_invoice.proforma_invoice import (
 	get_sales_order_items,
@@ -19,34 +15,13 @@ from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_orde
 from erpnext.tests.utils import ERPNextTestSuite
 
 
-def _make_test_pdf():
-	content = BytesIO()
-	writer = PdfWriter()
-	writer.add_blank_page(width=72, height=72)
-	writer.write(content)
-	return content.getvalue()
-
-
-TEST_PDF = _make_test_pdf()
-
-
 class TestProformaInvoice(ERPNextTestSuite):
 	def setUp(self):
 		frappe.db.set_single_value("Selling Settings", "enable_proforma_invoice", 1)
 
-	def create_proforma(self, sales_order, lines, use_real_pdf_renderer=False, **kwargs):
-		items = [line if isinstance(line, dict) else {"so_detail": line[0], "qty": line[1]} for line in lines]
-		pdf_renderer = (
-			nullcontext()
-			if use_real_pdf_renderer
-			else patch.object(
-				frappe,
-				"attach_print",
-				return_value={"fname": "proforma.pdf", "fcontent": TEST_PDF},
-			)
-		)
-		with pdf_renderer:
-			name = make_proforma_invoice(sales_order.name, json.dumps(items), **kwargs)
+	def create_proforma(self, sales_order, lines, **kwargs):
+		items = [{"so_detail": so_detail, "qty": qty} for so_detail, qty in lines]
+		name = make_proforma_invoice(sales_order.name, json.dumps(items), **kwargs)
 		return frappe.get_doc("Proforma Invoice", name)
 
 	def test_partial_proforma_is_non_blocking(self):
@@ -54,7 +29,7 @@ class TestProformaInvoice(ERPNextTestSuite):
 		sales_order = make_sales_order(qty=10)
 		so_detail = sales_order.items[0].name
 
-		proforma = self.create_proforma(sales_order, [(so_detail, 4)], use_real_pdf_renderer=True)
+		proforma = self.create_proforma(sales_order, [(so_detail, 4)])
 
 		self.assertEqual(proforma.status, "Issued")
 		self.assertEqual(proforma.docstatus, 1)
@@ -95,11 +70,12 @@ class TestProformaInvoice(ERPNextTestSuite):
 		sales_order = make_sales_order(qty=10)  # rate 100
 		so_detail = sales_order.items[0].name
 
-		proforma = self.create_proforma(
-			sales_order,
-			[{"so_detail": so_detail, "qty": 5, "amount": 250}],
+		name = make_proforma_invoice(
+			sales_order.name,
+			json.dumps([{"so_detail": so_detail, "qty": 5, "amount": 250}]),
 			based_on="Amount",
 		)
+		proforma = frappe.get_doc("Proforma Invoice", name)
 
 		self.assertEqual(proforma.based_on, "Amount")
 		item = proforma.items[0]
@@ -141,22 +117,22 @@ class TestProformaInvoice(ERPNextTestSuite):
 		sales_order = make_sales_order(qty=10)
 		so_detail = sales_order.items[0].name
 
-		amount_based = self.create_proforma(
-			sales_order,
-			[{"so_detail": so_detail, "qty": 5, "amount": 250}],
+		amount_based = make_proforma_invoice(
+			sales_order.name,
+			json.dumps([{"so_detail": so_detail, "qty": 5, "amount": 250}]),
 			based_on="Amount",
 			hide_item_qty=1,
 		)
-		self.assertEqual(amount_based.hide_item_qty, 1)
+		self.assertEqual(frappe.db.get_value("Proforma Invoice", amount_based, "hide_item_qty"), 1)
 
 		# ignored outside Amount basis
-		qty_based = self.create_proforma(
-			sales_order,
-			[(so_detail, 4)],
+		qty_based = make_proforma_invoice(
+			sales_order.name,
+			json.dumps([{"so_detail": so_detail, "qty": 4}]),
 			based_on="Quantity",
 			hide_item_qty=1,
 		)
-		self.assertEqual(qty_based.hide_item_qty, 0)
+		self.assertEqual(frappe.db.get_value("Proforma Invoice", qty_based, "hide_item_qty"), 0)
 
 	def test_feature_toggle_is_enforced(self):
 		sales_order = make_sales_order(qty=10)

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -25,7 +25,7 @@ from erpnext.stock.doctype.item.item import (
 	validate_is_stock_item,
 )
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
-from erpnext.stock.get_item_details import get_item_details, get_item_tax_map, get_item_tax_template
+from erpnext.stock.get_item_details import get_item_details
 from erpnext.tests.assertions import assert_raises_with_savepoint
 from erpnext.tests.utils import ERPNextTestSuite
 
@@ -304,34 +304,27 @@ class TestItem(ERPNextTestSuite):
 			},
 		}
 
-		for index, data in enumerate(expected_item_tax_template):
-			ctx = frappe._dict(
-				{
-					"item_code": data["item_code"],
-					"tax_category": data["tax_category"],
-					"company": "_Test Company",
-					"price_list": "_Test Price List",
-					"currency": "_Test Currency",
-					"doctype": "Sales Order",
-					"conversion_rate": 1,
-					"price_list_currency": "_Test Currency",
-					"plc_conversion_rate": 1,
-					"order_type": "Sales",
-					"customer": "_Test Customer",
-					"conversion_factor": 1,
-					"price_list_uom_dependant": 1,
-					"ignore_pricing_rule": 1,
-				}
-			)
-
-			if index == 0:
-				details = get_item_details(ctx)
-			else:
-				details = frappe._dict()
-				get_item_tax_template(ctx, out=details)
-				details.item_tax_rate = get_item_tax_map(
-					doc=ctx, tax_template=details.item_tax_template, as_json=True
+		for data in expected_item_tax_template:
+			details = get_item_details(
+				frappe._dict(
+					{
+						"item_code": data["item_code"],
+						"tax_category": data["tax_category"],
+						"company": "_Test Company",
+						"price_list": "_Test Price List",
+						"currency": "_Test Currency",
+						"doctype": "Sales Order",
+						"conversion_rate": 1,
+						"price_list_currency": "_Test Currency",
+						"plc_conversion_rate": 1,
+						"order_type": "Sales",
+						"customer": "_Test Customer",
+						"conversion_factor": 1,
+						"price_list_uom_dependant": 1,
+						"ignore_pricing_rule": 1,
+					}
 				)
+			)
 
 			self.assertEqual(details.item_tax_template, data["item_tax_template"])
 			self.assertEqual(
@@ -1221,13 +1214,13 @@ class TestItem(ERPNextTestSuite):
 		items = {
 			"Test Opening Stock for Serial No": {
 				"has_serial_no": 1,
-				"opening_stock": 1,
+				"opening_stock": 5,
 				"serial_no_series": "SN-TOPN-.####",
 				"valuation_rate": 100,
 			},
 			"Test Opening Stock for Batch No": {
 				"has_batch_no": 1,
-				"opening_stock": 1,
+				"opening_stock": 5,
 				"batch_number_series": "BCH-TOPN-.####",
 				"valuation_rate": 100,
 				"create_new_batch": 1,
@@ -1235,7 +1228,7 @@ class TestItem(ERPNextTestSuite):
 			"Test Opening Stock for Serial and Batch No": {
 				"has_serial_no": 1,
 				"has_batch_no": 1,
-				"opening_stock": 1,
+				"opening_stock": 5,
 				"batch_number_series": "SN-BCH-TOPN-.####",
 				"serial_no_series": "BCH-SN-TOPN-.####",
 				"valuation_rate": 100,

--- a/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
@@ -1373,7 +1373,7 @@ class TestStockLedgerEntry(ERPNextTestSuite, StockTestMixin):
 		)
 
 		dns = []
-		for i in range(3):
+		for i in range(5):
 			dns.append(
 				create_delivery_note(
 					item_code=item,
@@ -1384,17 +1384,17 @@ class TestStockLedgerEntry(ERPNextTestSuite, StockTestMixin):
 					posting_time=posting_time,
 				)
 			)
-		dn = dns[1]
+		dn = dns[2]
 		dn.cancel()
 
-		expected_qty_after_transaction = 60
-		qty_after_transaction = frappe.db.get_value(
+		expected_qty_after_transaction_of_dns3 = 40
+		qty_after_transaction_of_dns3 = frappe.db.get_value(
 			"Stock Ledger Entry",
-			{"voucher_no": dns[2].name, "is_cancelled": 0},
+			{"voucher_no": dns[3].name, "is_cancelled": 0},
 			"qty_after_transaction",
 		)
 
-		self.assertEqual(expected_qty_after_transaction, qty_after_transaction)
+		self.assertEqual(expected_qty_after_transaction_of_dns3, qty_after_transaction_of_dns3)
 
 	def test_get_next_stock_reco_respects_creation_order(self):
 		# A stock reco sharing the exact posting timestamp of the current entry must only count as the

--- a/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
@@ -200,9 +200,9 @@ class TestStockReservationEntry(ERPNextTestSuite):
 				{
 					"item_code": item_code,
 					"warehouse": self.warehouse,
-					"qty": randint(11, 100),
+					"qty": 80,
 					"uom": properties.stock_uom,
-					"rate": randint(10, 400),
+					"rate": 100,
 				}
 			)
 
@@ -624,9 +624,9 @@ class TestStockReservationEntry(ERPNextTestSuite):
 				{
 					"item_code": item_code,
 					"warehouse": self.warehouse,
-					"qty": randint(11, 100),
+					"qty": 80,
 					"uom": properties.stock_uom,
-					"rate": randint(10, 400),
+					"rate": 100,
 				}
 			)
 

--- a/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
@@ -200,9 +200,9 @@ class TestStockReservationEntry(ERPNextTestSuite):
 				{
 					"item_code": item_code,
 					"warehouse": self.warehouse,
-					"qty": 20,
+					"qty": randint(11, 100),
 					"uom": properties.stock_uom,
-					"rate": 100,
+					"rate": randint(10, 400),
 				}
 			)
 
@@ -233,7 +233,7 @@ class TestStockReservationEntry(ERPNextTestSuite):
 			se.cancel()
 
 			# Test - 3: Stock should be fully Reserved if the Available Qty to Reserve is greater than the Un-reserved Qty.
-			create_material_receipt(items_details, self.warehouse, qty=25)
+			create_material_receipt(items_details, self.warehouse, qty=110)
 			so.create_stock_reservation_entries()
 			so.load_from_db()
 
@@ -270,6 +270,9 @@ class TestStockReservationEntry(ERPNextTestSuite):
 				do_not_submit=True,
 			)
 
+			for row in so.items:
+				row.qty = 80
+
 			so.save()
 			so.submit()
 			so.create_stock_reservation_entries()
@@ -301,7 +304,7 @@ class TestStockReservationEntry(ERPNextTestSuite):
 				dn2 = make_delivery_note(so.name)
 
 				for item in dn2.items:
-					item.qty = 15
+					item.qty = 70
 
 				dn2.save()
 				dn2.submit()
@@ -613,7 +616,7 @@ class TestStockReservationEntry(ERPNextTestSuite):
 	)
 	def test_auto_reserve_serial_and_batch(self) -> None:
 		items_details = create_items()
-		create_material_receipt(items_details, self.warehouse, qty=2)
+		create_material_receipt(items_details, self.warehouse, qty=100)
 
 		item_list = []
 		for item_code, properties in items_details.items():
@@ -621,9 +624,9 @@ class TestStockReservationEntry(ERPNextTestSuite):
 				{
 					"item_code": item_code,
 					"warehouse": self.warehouse,
-					"qty": 2,
+					"qty": randint(11, 100),
 					"uom": properties.stock_uom,
-					"rate": 100,
+					"rate": randint(10, 400),
 				}
 			)
 


### PR DESCRIPTION
## Summary

Follow-up to #58507. Some runtime reductions also narrowed the behavior covered by the tests. This restores those scenarios while keeping the safe isolation and fixture reuse work.

- exercise the full bank reconciliation fixture and verify the expected payment remains a valid match
- restore Work Order overproduction and batch-size coverage
- render real Proforma Invoice PDFs instead of replacing the renderer
- run every item-tax case through `get_item_details` and restore multi-unit opening stock
- restore the five-entry same-timestamp stock ledger cancellation scenario
- restore high-volume Stock Reservation coverage with fixed, reproducible quantities

No production code is changed.

## Tests

- Bank Transaction test module: 8 tests passed, 1 skipped
- Work Order serial and serial-batch tests: 2 passed
- Proforma Invoice test module: 9 passed
- Item tax and opening-stock tests: 2 passed
- Stock Ledger same-timestamp cancellation test: 1 passed
- Stock Reservation sales-order and serial-batch tests: 2 passed
- focused review-fix tests: 3 passed
- `pre-commit run --files` for all changed files