### PR TITLE
fix(stock): load available serial no report

### DIFF
--- a/erpnext/stock/report/available_serial_no/available_serial_no.js
+++ b/erpnext/stock/report/available_serial_no/available_serial_no.js
@@ -77,4 +77,4 @@ frappe.query_reports["Available Serial No"] = {
 	},
 };
 
-erpnext.utils.add_inventory_dimensions("Balance Serial No", 10);
+erpnext.utils.add_inventory_dimensions("Available Serial No", 10);


### PR DESCRIPTION
 ### Issue

 - The **Available Serial No** report showed an empty page and raised the following console error:
  **TypeError: Cannot read properties of undefined (reading 'filter')**

 -  The inventory-dimension helper referenced "Balance Serial No" instead of the registered report name "Available Serial No". This interrupted report initialization and left its filters undefined.

  Closes #58549

  ###  Before

<img width="1846" height="928" alt="image" src="https://github.com/user-attachments/assets/0b2694f0-f957-4411-bed4-b501f2ed06b6" />


  ### After

<img width="1852" height="931" alt="image" src="https://github.com/user-attachments/assets/b8567bf6-3249-41ca-86b7-81e38f8b542c" />

Backport Needed  For V16 and V15
