### PR TITLE
feat(buying): show supplier quotation order status

### DIFF
--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js
@@ -97,6 +97,17 @@ frappe.query_reports["Supplier Quotation Comparison"] = {
 			default: "Submitted",
 		},
 		{
+			fieldname: "order_status",
+			label: __("Order Status"),
+			fieldtype: "Select",
+			options: [
+				{ label: "", value: "" },
+				{ label: __("Not Ordered"), value: "Not Ordered" },
+				{ label: __("Partially Ordered"), value: "Partially Ordered" },
+				{ label: __("Ordered"), value: "Ordered" },
+			],
+		},
+		{
 			fieldtype: "Check",
 			label: __("Include Expired"),
 			fieldname: "include_expired",

--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 
 import frappe
 from frappe import _
+from frappe.query_builder.functions import Sum
 from frappe.utils import cint, flt
 
 
@@ -87,7 +88,68 @@ def get_data(filters):
 
 	supplier_quotation_data = query.run(as_dict=True)
 
+	return add_order_status(supplier_quotation_data, filters.get("order_status"))
+
+
+def add_order_status(supplier_quotation_data, order_status=None):
+	quotation_names = {row.parent for row in supplier_quotation_data}
+	status_by_quotation = get_order_status_map(quotation_names)
+
+	for row in supplier_quotation_data:
+		row.order_status = status_by_quotation[row.parent]
+
+	if order_status:
+		return [row for row in supplier_quotation_data if row.order_status == order_status]
+
 	return supplier_quotation_data
+
+
+def get_order_status_map(quotation_names):
+	if not quotation_names:
+		return {}
+
+	items_by_quotation = defaultdict(list)
+	for item in frappe.get_all(
+		"Supplier Quotation Item",
+		filters={"parent": ["in", quotation_names]},
+		fields=["name", "parent", "stock_qty"],
+	):
+		items_by_quotation[item.parent].append(item)
+
+	ordered_qty_by_item = get_ordered_qty_by_quotation_item(quotation_names)
+	return {
+		quotation: get_order_status(items, ordered_qty_by_item)
+		for quotation, items in items_by_quotation.items()
+	}
+
+
+def get_ordered_qty_by_quotation_item(quotation_names):
+	purchase_order_item = frappe.qb.DocType("Purchase Order Item")
+	ordered_items = (
+		frappe.qb.from_(purchase_order_item)
+		.select(
+			purchase_order_item.supplier_quotation_item,
+			Sum(purchase_order_item.stock_qty).as_("ordered_qty"),
+		)
+		.where(
+			(purchase_order_item.docstatus == 1)
+			& (purchase_order_item.supplier_quotation.isin(quotation_names))
+		)
+		.groupby(purchase_order_item.supplier_quotation_item)
+	).run(as_dict=True)
+
+	return {row.supplier_quotation_item: row.ordered_qty for row in ordered_items}
+
+
+def get_order_status(quotation_items, ordered_qty_by_item):
+	if not any(item.name in ordered_qty_by_item for item in quotation_items):
+		return "Not Ordered"
+
+	for item in quotation_items:
+		if item.name not in ordered_qty_by_item or flt(item.stock_qty) > flt(ordered_qty_by_item[item.name]):
+			return "Partially Ordered"
+
+	return "Ordered"
 
 
 def prepare_data(supplier_quotation_data, filters):
@@ -109,6 +171,7 @@ def prepare_data(supplier_quotation_data, filters):
 			else data.get("item_code"),  # leave blank if group by field
 			"supplier_name": "" if group_by_field == "supplier_name" else data.get("supplier_name"),
 			"quotation": data.get("parent"),
+			"order_status": data.get("order_status"),
 			"qty": data.get("qty"),
 			"price": flt(data.get("amount"), float_precision),
 			"uom": data.get("uom"),
@@ -264,6 +327,12 @@ def get_columns(filters):
 			"fieldtype": "Link",
 			"options": "Supplier Quotation",
 			"width": 200,
+		},
+		{
+			"fieldname": "order_status",
+			"label": _("Order Status"),
+			"fieldtype": "Data",
+			"width": 130,
 		},
 		{"fieldname": "valid_till", "label": _("Valid Till"), "fieldtype": "Date", "width": 100},
 		{

--- a/erpnext/buying/report/supplier_quotation_comparison/test_supplier_quotation_comparison.py
+++ b/erpnext/buying/report/supplier_quotation_comparison/test_supplier_quotation_comparison.py
@@ -2,7 +2,9 @@
 # See license.txt
 
 import frappe
+from frappe.utils import add_days, today
 
+from erpnext.buying.doctype.supplier_quotation.mapper import make_purchase_order
 from erpnext.buying.report.supplier_quotation_comparison.supplier_quotation_comparison import execute
 from erpnext.tests.utils import ERPNextTestSuite
 
@@ -37,6 +39,15 @@ class TestSupplierQuotationComparison(ERPNextTestSuite):
 		filters = frappe._dict({"company": COMPANY, "from_date": "2026-01-01", "to_date": "2026-12-31"})
 		filters.update(extra)
 		return execute(filters)[1]
+
+	def make_order(self, supplier_quotation, qty):
+		purchase_order = make_purchase_order(supplier_quotation.name)
+		purchase_order.naming_series = "_T-Purchase Order-"
+		purchase_order.items[0].qty = qty
+		purchase_order.items[0].schedule_date = add_days(today(), 1)
+		purchase_order.insert()
+		purchase_order.submit()
+		return purchase_order
 
 	def test_no_filters_returns_empty(self):
 		self.assertEqual(execute(None)[1], [])
@@ -83,3 +94,34 @@ class TestSupplierQuotationComparison(ERPNextTestSuite):
 		both = names(status="")
 		self.assertIn(draft.name, both)
 		self.assertIn(submitted.name, both)
+
+	def test_order_status_and_filter(self):
+		supplier_quotation = self.make_quotation("_Test Supplier", qty=10, rate=100)
+
+		def get_order_status():
+			return next(
+				row["order_status"]
+				for row in self.run_report(item_code=ITEM)
+				if row["quotation"] == supplier_quotation.name
+			)
+
+		def quotations_with_status(order_status):
+			return {row["quotation"] for row in self.run_report(item_code=ITEM, order_status=order_status)}
+
+		self.assertEqual(get_order_status(), "Not Ordered")
+		self.assertIn(supplier_quotation.name, quotations_with_status("Not Ordered"))
+
+		partial_order = self.make_order(supplier_quotation, qty=4)
+		self.assertEqual(get_order_status(), "Partially Ordered")
+		self.assertIn(supplier_quotation.name, quotations_with_status("Partially Ordered"))
+		self.assertNotIn(supplier_quotation.name, quotations_with_status("Ordered"))
+
+		complete_order = self.make_order(supplier_quotation, qty=6)
+		self.assertEqual(get_order_status(), "Ordered")
+		self.assertIn(supplier_quotation.name, quotations_with_status("Ordered"))
+
+		complete_order.cancel()
+		self.assertEqual(get_order_status(), "Partially Ordered")
+
+		partial_order.cancel()
+		self.assertEqual(get_order_status(), "Not Ordered")


### PR DESCRIPTION

  ### Issue

  The Supplier Quotation Comparison report does not indicate whether a Supplier Quotation has been converted into a Purchase Order.

**Fixes:** [#58556](https://github.com/frappe/erpnext/issues/58556)
 
  ### Steps to reproduce

  1. Create and submit a Supplier Quotation.
  2. Create and submit a Purchase Order from the Supplier Quotation.
  3. Open the Supplier Quotation Comparison report.
  4. Check the quotation’s ordering status.

  ### Actual behaviour

  The report displays quotation and pricing information but does not show whether the quotation is not ordered, partially ordered, or fully ordered.

  ### Expected behaviour

  The report should display an Order Status column and provide a filter with these values:

  - Not Ordered
  - Partially Ordered
  - Ordered

  Only submitted Purchase Orders should affect the status. Draft and cancelled Purchase Orders should be excluded.
  
  
  No-docs