### PR TITLE
fix(stock): prorate landed cost charge into transaction currency

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/services/gl_composer.py
+++ b/erpnext/accounts/doctype/purchase_invoice/services/gl_composer.py
@@ -277,6 +277,15 @@ class PurchaseInvoiceGLComposer(BaseGLComposer):
 							if not (entry.amount or entry.base_amount):
 								continue
 
+							lcv_account_currency = get_account_currency(entry.expense_account)
+							credit_in_transaction_currency = (
+								flt(entry.amount)
+								if lcv_account_currency == doc.currency
+								else flt(
+									entry.base_amount / doc.conversion_rate, item.precision("net_amount")
+								)
+							)
+
 							gl_dict = self.get_gl_dict(
 								{
 									"account": entry.expense_account,
@@ -285,7 +294,7 @@ class PurchaseInvoiceGLComposer(BaseGLComposer):
 									"remarks": doc.get("remarks") or _("Accounting Entry for Stock"),
 									"credit": flt(entry.base_amount),
 									"credit_in_account_currency": flt(entry.amount),
-									"credit_in_transaction_currency": item.net_amount,
+									"credit_in_transaction_currency": credit_in_transaction_currency,
 									"project": entry.dimensions.project or item.project or doc.project,
 								},
 								item=item,

--- a/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
@@ -634,6 +634,56 @@ class TestLandedCostVoucher(ERPNextTestSuite):
 			self.assertEqual(entry.credit, amounts[0])
 			self.assertEqual(entry.credit_in_account_currency, amounts[1])
 
+	def test_landed_cost_charge_in_transaction_currency(self):
+		from erpnext.setup.doctype.currency_exchange.test_currency_exchange import save_new_records
+
+		save_new_records(self.globalTestRecords["Currency Exchange"])  # USD -> INR 62.9
+
+		company = "_Test Company with perpetual inventory"
+		creditors_usd = create_account(
+			account_name="_Test Creditors USD",
+			parent_account="Accounts Payable - TCP1",
+			company=company,
+			account_type="Payable",
+			account_currency="USD",
+		)
+
+		pi = make_purchase_invoice(
+			company=company,
+			supplier="_Test Supplier USD",
+			currency="USD",
+			conversion_rate=62.9,
+			update_stock=1,
+			warehouse="Stores - TCP1",
+			supplier_warehouse="Work In Progress - TCP1",
+			cost_center="Main - TCP1",
+			expense_account="_Test Account Cost for Goods Sold - TCP1",
+			qty=10,
+			rate=100,
+			do_not_save=True,
+		)
+		pi.credit_to = creditors_usd
+		pi.save()
+		pi.submit()
+
+		create_landed_cost_voucher("Purchase Invoice", pi.name, pi.company, charges=100)
+
+		charge_gle = frappe.db.get_value(
+			"GL Entry",
+			{
+				"voucher_no": pi.name,
+				"account": get_expense_account(pi.company),
+				"credit": (">", 0),
+				"is_cancelled": 0,
+			},
+			["credit", "credit_in_transaction_currency"],
+			as_dict=True,
+		)
+
+		self.assertEqual(charge_gle.credit, 100.0)
+		self.assertEqual(charge_gle.credit_in_transaction_currency, flt(100 / 62.9, 2))
+		self.assertNotEqual(charge_gle.credit_in_transaction_currency, pi.items[0].net_amount)
+
 	def test_asset_lcv(self):
 		"Check if LCV for an Asset updates the Assets Net Purchase Amount correctly."
 		frappe.db.set_value(


### PR DESCRIPTION
## Problem

`get_gl_dict` deliberately skips deriving `*_in_transaction_currency` values for Purchase Invoices, Sales Invoices, Journal Entries, and Payment Entries. Therefore, the caller must explicitly provide these values.

In the landed-cost charge loop in `purchase_invoice/services/gl_composer.py`, `credit_in_transaction_currency` was incorrectly set to `item.net_amount`, representing the item’s entire net amount rather than the applicable landed-cost charge.

Since #56981, landed-cost charges for an item posted to the same expense account can be split into multiple GL entries based on accounting dimensions. Each split entry was assigned the full `item.net_amount`, causing transaction-currency totals in the General Ledger report to be overstated according to the number of dimension groups.

The value was also incorrect when there was only one charge because it represented the item amount instead of the landed-cost charge. However, the issue became more apparent after dimension-based splitting was introduced.

The following values were already correct:

* `credit` in the company currency
* `credit_in_account_currency`

Only `credit_in_transaction_currency` was affected.

## Scope

This issue affects Purchase Invoices only.

The Purchase Receipt, Stock Entry, and Subcontracting Receipt GL composers allow `get_gl_dict` to derive the transaction-currency value, which is already handled correctly.

## Related PRs

The same fix is included in the #56981 backports where the issue was identified during review:

* #58548 — `version-16-hotfix`
* #58574 — `version-15-hotfix`

## Tests

The multi-currency and accounting-dimension-split Landed Cost Voucher behaviour is covered by the accounting-dimension tests introduced in #56981 and available on `develop`.

A focused assertion for `credit_in_transaction_currency` on a foreign-currency Purchase Invoice can be added in this PR to satisfy the `needs-tests` requirement.
