### PR TITLE
fix(sms_settings): add patch to pre-fill roles into SMS Settings Role Table

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -516,3 +516,4 @@ erpnext.patches.v16_0.recalculate_mixed_purchase_receipt_billing_status
 erpnext.patches.v16_0.repair_work_order_material_transfer
 erpnext.patches.v16_0.remove_frappe_crm_custom_fields
 erpnext.patches.v16_0.add_batch_split_stock_entry_type
+erpnext.patches.v16_0.add_transaction_roles_to_sms_settings

--- a/erpnext/patches/v16_0/add_transaction_roles_to_sms_settings.py
+++ b/erpnext/patches/v16_0/add_transaction_roles_to_sms_settings.py
@@ -1,0 +1,39 @@
+import frappe
+from frappe import _
+
+STANDARD_TRANSACTION_ROLES = [
+	"Sales User",
+	"Sales Manager",
+	"Purchase User",
+	"Purchase Manager",
+	"Stock User",
+	"Stock Manager",
+	"Accounts User",
+	"Accounts Manager",
+]
+
+
+def execute():
+	"""Seed SMS Settings.allowed_roles with ERPNext's standard transaction roles."""
+	frappe.reload_doctype("SMS Settings")
+
+	if not frappe.get_meta("SMS Settings").has_field("allowed_roles"):
+		frappe.throw(
+			_(
+				"SMS Settings.allowed_roles not found. Update the Frappe Framework app to a "
+				"version that includes this field, then re-run bench migrate."
+			)
+		)
+
+	sms_settings = frappe.get_single("SMS Settings")
+	existing_roles = {d.role for d in sms_settings.get("allowed_roles")}
+
+	added = False
+	for role in STANDARD_TRANSACTION_ROLES:
+		if role not in existing_roles and frappe.db.exists("Role", role):
+			sms_settings.append("allowed_roles", {"role": role})
+			added = True
+
+	if added:
+		sms_settings.flags.ignore_mandatory = True
+		sms_settings.save()


### PR DESCRIPTION
Added a patch to pre-fill roles into SMS Settings Role Table.

related to frappe/frappe#42285

pending backports to v15 & v16 (dependent on frappe)