### PR TITLE
fix: restore isolated loyalty and subcontracting tests

### DIFF
--- a/erpnext/accounts/doctype/loyalty_program/test_loyalty_program.py
+++ b/erpnext/accounts/doctype/loyalty_program/test_loyalty_program.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-import unittest
+from unittest.mock import patch
 
 import frappe
 from frappe.query_builder.functions import Sum
@@ -196,7 +196,7 @@ class TestLoyaltyProgram(ERPNextTestSuite):
 		for d in company_wise_info:
 			self.assertTrue(d.get("loyalty_points"))
 
-	@unittest.mock.patch("erpnext.accounts.doctype.loyalty_program.loyalty_program.get_loyalty_details")
+	@patch("erpnext.accounts.doctype.loyalty_program.loyalty_program.get_loyalty_details")
 	def test_tier_selection(self, mock_get_loyalty_details):
 		# Create a new loyalty program with multiple tiers
 		loyalty_program = frappe.get_doc(

--- a/erpnext/stock/doctype/stock_entry/services/manufacturing.py
+++ b/erpnext/stock/doctype/stock_entry/services/manufacturing.py
@@ -597,6 +597,8 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 		self.doc.append("items", item_args)
 
 	def _resolve_rm_warehouse(self, row):
+		if self.wo_doc and self.wo_doc.skip_transfer and not self.wo_doc.from_wip_warehouse:
+			return row.get("source_warehouse")
 		if self.doc.from_warehouse:
 			return self.doc.from_warehouse
 		if self.wo_doc and self.wo_doc.from_wip_warehouse:

--- a/erpnext/subcontracting/doctype/subcontracting_inward_order/test_subcontracting_inward_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_inward_order/test_subcontracting_inward_order.py
@@ -169,6 +169,10 @@ class IntegrationTestSubcontractingInwardOrder(ERPNextTestSuite):
 		wo.submit()
 
 		manufacture = frappe.new_doc("Stock Entry").update(make_stock_entry_from_wo(wo.name, "Manufacture"))
+		self.assertEqual(
+			next(item.s_warehouse for item in manufacture.items if item.item_code == "Self RM"),
+			"Stores - _TC",
+		)
 		manufacture.save()
 		frappe.new_doc(
 			"Stock Entry Detail",


### PR DESCRIPTION
## Problem

The Loyalty Program test module fails in an isolated Python process because it does not import unittest.mock.

Skip-transfer Manufacture Stock Entries also replace Work Order item warehouses with the Work Order header warehouse. This makes subcontracting consume self-supplied raw materials from the customer warehouse.

## Solution

- Import patch directly from unittest.mock.
- Use each Work Order item source warehouse for direct material consumption.
- Add an assertion for the self-supplied raw material warehouse.

## Tests

- pilot -b postgres frappe --site erpnext-ci-2.localhost run-tests --module erpnext.accounts.doctype.loyalty_program.test_loyalty_program
- pilot -b postgres frappe --site erpnext-ci-3.localhost run-tests --module erpnext.subcontracting.doctype.subcontracting_inward_order.test_subcontracting_inward_order
- pre-commit run --files erpnext/accounts/doctype/loyalty_program/test_loyalty_program.py erpnext/stock/doctype/stock_entry/services/manufacturing.py erpnext/subcontracting/doctype/subcontracting_inward_order/test_subcontracting_inward_order.py