### PR TITLE
test: prevent update_doctypes from exporting files

### DIFF
--- a/erpnext/utilities/test_utilities_init.py
+++ b/erpnext/utilities/test_utilities_init.py
@@ -1,4 +1,7 @@
+from unittest.mock import patch
+
 import frappe
+from frappe.core.doctype.doctype.doctype import DocType
 
 from erpnext.tests.utils import ERPNextTestSuite
 from erpnext.utilities import update_doctypes
@@ -57,7 +60,5 @@ class TestUtilitiesInit(ERPNextTestSuite):
 		"""update_doctypes() is the public entry point exercising the converted
 		query; ensure it imports and runs without error against real schema."""
 		self.assertTrue(callable(update_doctypes))
-		# Run it: it should only ever upgrade Text/Small Text description fields to
-		# Text Editor; core fixtures used above are already Text Editor, so this is
-		# effectively a no-op but must not raise.
-		update_doctypes()
+		with patch.object(DocType, "save", autospec=True):
+			update_doctypes()


### PR DESCRIPTION
## Problem

The utility test added in #56134 calls update_doctypes against the real schema. The function saves standard child DocTypes.

A developer-mode test site exports each saved DocType into the shared app checkout. This changes Frappe files such as DocField and can make a later site migration fail during schema sync. Database rollback does not restore these files.

## Fix

Mock DocType.save while the test runs update_doctypes. The test still executes the converted query against the real schema, but it does not change the database, schema, or filesystem.

## Tests

- bench --site erpnext-ci-3.localhost run-tests --module erpnext.utilities.test_utilities_init
- pre-commit run --files erpnext/utilities/test_utilities_init.py
- Migrated postgres.localhost after restoring the files generated by the old test