### PR TITLE
fix: compare quotation quantity in stock uom

### DIFF
--- a/erpnext/accounts/services/child_item_update.py
+++ b/erpnext/accounts/services/child_item_update.py
@@ -72,6 +72,10 @@ class ChildItemUpdater:
 				self._check_permissions("write")
 				child_item = frappe.get_doc(self.parent_doctype + " Item", d.get("docname"))
 
+			if self.parent_doctype == "Quotation":
+				self._set_quotation_conversion_factor(child_item, d)
+
+			if not new_child_flag:
 				change_state = get_child_item_change_state(self.parent_doctype, child_item, d)
 				rate_unchanged = change_state.rate_unchanged
 				any_conversion_factor_changed |= not change_state.conversion_factor_unchanged
@@ -251,6 +255,12 @@ class ChildItemUpdater:
 			item_row,
 		)
 
+	def _set_quotation_conversion_factor(self, child_item, new_data: dict) -> None:
+		uom = new_data.get("uom") or child_item.uom
+		new_data["conversion_factor"] = flt(
+			get_conversion_factor(child_item.item_code, uom).get("conversion_factor")
+		)
+
 	def _validate_quantity_and_rate(self, child_item, new_data: dict, rate_unchanged: bool | None) -> None:
 		if not flt(new_data.get("qty")) and not self.allow_zero_qty:
 			frappe.throw(
@@ -291,7 +301,11 @@ class ChildItemUpdater:
 				).format(frappe.bold(new_data.get("item_code")))
 			)
 
-		if flt(new_data.get("qty")) < qty_to_check:
+		new_qty = flt(new_data.get("qty"))
+		if self.parent_doctype == "Quotation":
+			new_qty *= flt(new_data.get("conversion_factor"))
+
+		if new_qty < qty_to_check:
 			frappe.throw(_("Cannot reduce quantity than ordered or purchased quantity"))
 
 	def _validate_fg_item_for_subcontracting(self, new_data: dict, is_new: bool) -> None:
@@ -591,11 +605,8 @@ def update_child_item_uom_and_weight(child_item, new_data) -> None:
 
 	if new_data.get("uom"):
 		child_item.uom = new_data.get("uom")
-		conversion_factor = flt(
+		child_item.conversion_factor = flt(new_data.get("conversion_factor"), conv_fac_precision) or flt(
 			get_conversion_factor(child_item.item_code, child_item.uom).get("conversion_factor")
-		)
-		child_item.conversion_factor = (
-			flt(new_data.get("conversion_factor"), conv_fac_precision) or conversion_factor
 		)
 
 	if child_item.get("weight_per_unit"):

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -156,6 +156,58 @@ class TestQuotation(ERPNextTestSuite):
 		qo.reload()
 		self.assertEqual(len(qo.get("items")), 1)
 
+	def test_update_child_qty_with_uom_conversion_factor(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		item = make_item(uoms=[{"uom": "Box", "conversion_factor": 5}])
+
+		qo = make_quotation(item_code=item.item_code, qty=6, uom="Box", do_not_submit=1)
+		self.assertEqual(qo.items[0].conversion_factor, 5)
+		qo.submit()
+
+		sales_order = make_sales_order(qo.name)
+		sales_order.delivery_date = nowdate()
+		sales_order.items[0].qty = 2
+		sales_order.save()
+		sales_order.submit()
+
+		qo.reload()
+		self.assertEqual(qo.status, "Partially Ordered")
+		self.assertEqual(qo.items[0].ordered_qty, 10)
+
+		trans_item = json.dumps(
+			[
+				{
+					"item_code": qo.items[0].item_code,
+					"rate": qo.items[0].rate,
+					"qty": 6,
+					"uom": "Box",
+					"conversion_factor": 100,
+					"docname": qo.items[0].name,
+				}
+			]
+		)
+		update_child_qty_rate("Quotation", trans_item, qo.name)
+
+		qo.reload()
+		self.assertEqual(qo.items[0].qty, 6)
+		self.assertEqual(qo.items[0].conversion_factor, 5)
+		self.assertEqual(qo.items[0].stock_qty, 30)
+
+		trans_item = json.dumps(
+			[
+				{
+					"item_code": qo.items[0].item_code,
+					"rate": qo.items[0].rate,
+					"qty": 1,
+					"uom": "Box",
+					"conversion_factor": 100,
+					"docname": qo.items[0].name,
+				}
+			]
+		)
+		self.assertRaises(frappe.ValidationError, update_child_qty_rate, "Quotation", trans_item, qo.name)
+
 	def test_quotation_qty(self):
 		qo = make_quotation(qty=0, do_not_save=True)
 		with self.assertRaises(InvalidQtyError):


### PR DESCRIPTION
 ### Issue
 - Quotation Update Items compares the edited quantity in the line UOM with the ordered quantity in the stock UOM. This incorrectly blocks valid updates for items using a conversion factor.

  Closes #58578.

  ### Steps to reproduce

  1. Create a UOM named `Box`.
  2. Create an Item with:
     - Stock UOM: `Nos`
     - UOM conversion: `1 Box = 5 Nos`
  3. Create a Quotation for a customer.
  4. Add the Item with:
     - Quantity: `6`
     - UOM: `Box`
     - Conversion Factor: `5`

     The Stock Quantity should be `30 Nos`.
  5. Submit the Quotation.
  6. From the submitted Quotation, click **Create → Sales Order**.
  7. Change the Sales Order quantity to `2 Box` and submit it.

     The Quotation is now **Partially Ordered**, with `10 Nos` ordered.
  8. Return to the Quotation and reload it.
  9. Click **Update Items**.
  10. Keep or set the quantity to `6 Box`, then click **Update**.

  ### Actual behaviour

  The update is rejected with:

  `Cannot reduce quantity than ordered or purchased quantity`

  The validation incorrectly compares `6 Box` directly with `10 Nos`, resulting in `6 < 10`.

  ### Expected behaviour

  The quotation quantity should first be converted to Stock UOM:

  `6 Box × 5 = 30 Nos`

  Since `30 Nos` is greater than the already ordered `10 Nos`, the update should be accepted.

  As a boundary check, changing the quotation quantity to `1 Box` should still be rejected because `1 Box = 5 Nos`, which is below the ordered quantity of `10 Nos`.

  ### Backport needed for V16 and V15.