### PR TITLE
fix(pos): use company-currency change amount when netting pos gl entries

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/services/gl_composer.py
+++ b/erpnext/accounts/doctype/sales_invoice/services/gl_composer.py
@@ -476,7 +476,7 @@ class SalesInvoiceGLComposer(BaseGLComposer):
 
 			for payment_mode in doc.payments:
 				if skip_change_gl_entries and payment_mode.account == doc.account_for_change_amount:
-					payment_mode.base_amount -= flt(doc.change_amount)
+					payment_mode.base_amount -= flt(doc.base_change_amount)
 
 				if payment_mode.base_amount:
 					# POS, make payment entries

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -1583,6 +1583,35 @@ class TestSalesInvoice(ERPNextTestSuite):
 
 		frappe.db.set_single_value("POS Settings", "post_change_gl_entries", 1)
 
+	def test_pos_change_amount_multi_currency_gl_entry(self):
+		from erpnext.accounts.doctype.sales_invoice.services.gl_composer import SalesInvoiceGLComposer
+
+		frappe.db.set_single_value("POS Settings", "post_change_gl_entries", 0)
+
+		si = create_sales_invoice(do_not_save=True)
+		si.is_pos = 1
+		si.currency = "USD"
+		si.conversion_rate = 50
+		si.party_account_currency = "USD"
+		si.account_for_change_amount = "Cash - _TC"
+		si.change_amount = 50
+		si.base_change_amount = 2500
+		si.append(
+			"payments",
+			{"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 150, "base_amount": 7500},
+		)
+
+		gl_entries = []
+		SalesInvoiceGLComposer(si).make_pos_gl_entries(gl_entries)
+
+		debtors_entry = next(entry for entry in gl_entries if entry["account"] == si.debit_to)
+		cash_entry = next(entry for entry in gl_entries if entry["account"] == "Cash - _TC")
+
+		self.assertEqual(flt(debtors_entry["credit"]), 5000.0)
+		self.assertEqual(flt(cash_entry["debit"]), 5000.0)
+
+		frappe.db.set_single_value("POS Settings", "post_change_gl_entries", 1)
+
 	def test_stock_delivered_but_not_billed_gl_on_invoice(self):
 		company = "_Test SDBNB Company"
 		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note


### PR DESCRIPTION
 **Bug description**
POS change amount is netted in the wrong currency, resulting in incorrect GL entries for multi-currency Sales Invoices
When **Create Ledger Entries for Change Amount** is disabled in POS Settings, the change amount is netted against the payment entry.
For a multi-currency Sales Invoice, the system incorrectly deducts `change_amount`, which is expressed in the invoice currency, from a value expressed in the company currency. It should deduct `base_change_amount` instead.
This produces incorrect GL entries and leaves an outstanding balance even though the invoice has been paid in full.

### Steps to reproduce

1. Create or use a Company whose default currency differs from the customer’s invoice currency—for example:
   * Company currency: EUR
   * Invoice currency: USD
2. In POS Settings, disable **Create Ledger Entries for Change Amount**.
3. Create a Sales Invoice from the desk form.
4. Enable **Include Payment (POS)**.
5. Set the invoice currency to USD and use a conversion rate of approximately `0.86`.
6. Add one item with a rate of USD 100.
   The resulting totals should be approximately:
   * Grand Total: USD 100.00
   * Base Grand Total: EUR 85.89
7. On the Payments tab, enter a Cash payment of USD 150.00.
   The change values should be approximately:
   * Change Amount: USD 50.00
   * Base Change Amount: EUR 42.95
8. Set **Account for Change Amount** to the same Cash account used for the payment.
9. Save and submit the invoice.
10. Open the General Ledger for the Sales Invoice.

**Observed behavior**

Debtors is credited by only EUR 78.84:

<img width="1295" height="605" alt="image" src="https://github.com/user-attachments/assets/14a84738-b20b-468b-b525-e94f06869aab" />

<img width="1295" height="605" alt="image" src="https://github.com/user-attachments/assets/e910ba28-9b0a-4d54-bcf2-e9a7d245f48f" />

<img width="1295" height="605" alt="image" src="https://github.com/user-attachments/assets/0f5b9260-d671-4931-8f40-f15ed854aa81" />



