### PR TITLE
Fix/pos partial payment validation scope

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -326,10 +326,10 @@ class SalesInvoice(SellingController):
 
 		if cint(self.is_pos):
 			self.validate_pos()
+			POSService(self).validate_full_payment()
 
 		if cint(self.is_created_using_pos):
 			POSService(self).validate_created_using_pos()
-			POSService(self).validate_full_payment()
 
 		self.validate_dropship_item()
 

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -21,6 +21,7 @@ from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import (
 )
 from erpnext.accounts.doctype.sales_invoice.mapper import make_inter_company_transaction
 from erpnext.accounts.doctype.sales_invoice.services.pos import (
+	PartialPaymentValidationError,
 	POSService,
 	get_all_mode_of_payments,
 	get_mode_of_payment_info,
@@ -5213,6 +5214,22 @@ class TestSalesInvoice(ERPNextTestSuite):
 
 			pos.append("payments", {"mode_of_payment": "Cash", "amount": 1000})
 			self.assertRaises(frappe.ValidationError, pos.insert)
+
+	def test_pos_sales_invoice_partial_payment_not_allowed_without_pos_screen(self):
+		frappe.db.delete("POS Opening Entry")
+
+		pos_profile = make_pos_profile()
+		pos_profile.payments = []
+		pos_profile.append("payments", {"default": 1, "mode_of_payment": "Cash"})
+		pos_profile.save()
+
+		pos = create_sales_invoice(qty=1, rate=100, do_not_save=True)
+		pos.is_pos = 1
+		pos.pos_profile = pos_profile.name
+		pos.append("payments", {"mode_of_payment": "Cash", "amount": 99})
+		pos.insert()
+
+		self.assertRaises(PartialPaymentValidationError, pos.submit)
 
 	def test_stand_alone_credit_note_valuation(self):
 		item_code = "_Test Item for Credit Note Valuation"


### PR DESCRIPTION
**Issue:**
Sales Invoice with "Include Payment (POS)" can be submitted underpaid when not created via the POS screen, silently hiding the shortfall in low-value currencies

 **Steps to reproduce:**
  1. Enable the CDF currency (Congolese Franc) if disabled, and use a Company whose default currency is a "strong" 2-decimal currency (e.g. EUR/USD).
  2. Create a POS Profile for that company with "Allow Partial Payment" unchecked (the default). the POS screen, so is_created_using_pos stays 0), set Currency to CDF.
  3. Add one item with Rate = 9,210,000 (Grand Total FC 9,210,000.00; base/EUR total will be a few thousand at a small conversion rate).
  4. On the Payments tab, enter Cash = 9,209,999.00 — 1 CDF short of the grand total.
  5. Save and Submit.
  


**Ref:**[#77055](https://support.frappe.io/helpdesk/tickets/77055?view=VIEW-HD+Ticket-745)

<img width="1295" height="605" alt="image" src="https://github.com/user-attachments/assets/49431b58-624b-412a-929f-07c48bcaea42" />

<img width="1295" height="605" alt="image" src="https://github.com/user-attachments/assets/56a79a7e-c025-49a3-bd90-e93bceb18db8" />

