### PR TITLE
perf(stock): improve warehouse account mapping and rebuild tree only if necessary

### DIFF
--- a/erpnext/stock/__init__.py
+++ b/erpnext/stock/__init__.py
@@ -30,14 +30,34 @@ def get_warehouse_account_map(company=None):
 			filters["company"] = company
 			frappe.flags.setdefault("warehouse_account_map", {}).setdefault(company, {})
 
-		for d in frappe.get_all(
+		warehouses = frappe.get_all(
 			"Warehouse",
 			fields=["name", "account", "parent_warehouse", "company", "is_group"],
 			filters=filters,
 			order_by="lft, rgt",
-		):
+		)
+		warehouse_names = {d.name for d in warehouses}
+		walked_warehouses = set()
+
+		for d in warehouses:
+			if (
+				d.parent_warehouse in warehouse_names
+				and d.parent_warehouse not in walked_warehouses
+				and not frappe.flags.warehouse_tree_rebuilt
+			):
+				# lft, rgt must order a parent before its children: repair the tree and
+				# build the map again against the corrected order, at most once per request
+				from frappe.utils.nestedset import rebuild_tree
+
+				rebuild_tree("Warehouse")
+				frappe.flags.warehouse_tree_rebuilt = True
+
+				return get_warehouse_account_map(company)
+
 			if not d.account:
 				d.account = get_warehouse_account(d, warehouse_account, raise_error=False)
+
+			walked_warehouses.add(d.name)
 
 			if d.account:
 				d.account_currency = frappe.db.get_value("Account", d.account, "account_currency", cache=True)
@@ -59,10 +79,6 @@ def get_warehouse_account(warehouse, warehouse_account=None, *, raise_error=True
 		if warehouse_account:
 			if warehouse_account.get(warehouse.parent_warehouse):
 				account = warehouse_account.get(warehouse.parent_warehouse).account
-			else:
-				from frappe.utils.nestedset import rebuild_tree
-
-				rebuild_tree("Warehouse")
 		else:
 			account = frappe.get_all(
 				"Warehouse",
@@ -83,9 +99,7 @@ def get_warehouse_account(warehouse, warehouse_account=None, *, raise_error=True
 		account = get_company_default_inventory_account(warehouse.company)
 
 	if not account and warehouse.company:
-		inventory_accounts = frappe.get_all(
-			"Account", {"account_type": "Stock", "is_group": 0, "company": warehouse.company}, pluck="name"
-		)
+		inventory_accounts = get_company_stock_accounts(warehouse.company)
 
 		if len(inventory_accounts) == 1:
 			account = inventory_accounts[0]
@@ -101,3 +115,10 @@ def get_warehouse_account(warehouse, warehouse_account=None, *, raise_error=True
 
 def get_company_default_inventory_account(company):
 	return frappe.get_cached_value("Company", company, "default_inventory_account")
+
+
+@frappe.request_cache
+def get_company_stock_accounts(company):
+	return frappe.get_all(
+		"Account", {"account_type": "Stock", "is_group": 0, "company": company}, pluck="name"
+	)

--- a/erpnext/stock/__init__.py
+++ b/erpnext/stock/__init__.py
@@ -39,6 +39,15 @@ def get_warehouse_account_map(company=None):
 		warehouse_names = {d.name for d in warehouses}
 		walked_warehouses = set()
 
+		# the fallback is company wide and cannot change while this map is built
+		company_inventory_accounts = frappe._dict()
+		for account in frappe.get_all(
+			"Account",
+			fields=["name", "company"],
+			filters={"account_type": "Stock", "is_group": 0, **filters},
+		):
+			company_inventory_accounts.setdefault(account.company, []).append(account.name)
+
 		for d in warehouses:
 			if (
 				d.parent_warehouse in warehouse_names
@@ -55,7 +64,12 @@ def get_warehouse_account_map(company=None):
 				return get_warehouse_account_map(company)
 
 			if not d.account:
-				d.account = get_warehouse_account(d, warehouse_account, raise_error=False)
+				d.account = get_warehouse_account(
+					d,
+					warehouse_account,
+					raise_error=False,
+					inventory_accounts=company_inventory_accounts.get(d.company, []),
+				)
 
 			walked_warehouses.add(d.name)
 
@@ -73,7 +87,7 @@ def get_warehouse_account_map(company=None):
 	return frappe.flags.warehouse_account_map
 
 
-def get_warehouse_account(warehouse, warehouse_account=None, *, raise_error=True):
+def get_warehouse_account(warehouse, warehouse_account=None, *, raise_error=True, inventory_accounts=None):
 	account = warehouse.account
 	if not account and warehouse.parent_warehouse:
 		if warehouse_account:
@@ -99,7 +113,12 @@ def get_warehouse_account(warehouse, warehouse_account=None, *, raise_error=True
 		account = get_company_default_inventory_account(warehouse.company)
 
 	if not account and warehouse.company:
-		inventory_accounts = get_company_stock_accounts(warehouse.company)
+		if inventory_accounts is None:
+			inventory_accounts = frappe.get_all(
+				"Account",
+				{"account_type": "Stock", "is_group": 0, "company": warehouse.company},
+				pluck="name",
+			)
 
 		if len(inventory_accounts) == 1:
 			account = inventory_accounts[0]
@@ -115,10 +134,3 @@ def get_warehouse_account(warehouse, warehouse_account=None, *, raise_error=True
 
 def get_company_default_inventory_account(company):
 	return frappe.get_cached_value("Company", company, "default_inventory_account")
-
-
-@frappe.request_cache
-def get_company_stock_accounts(company):
-	return frappe.get_all(
-		"Account", {"account_type": "Stock", "is_group": 0, "company": company}, pluck="name"
-	)


### PR DESCRIPTION
Issue: For a site where the default_inventory_account is not set in Company, and there are multiple warehouses and the account is not set in the parent warehouse, then rebuild_tree is called multiple times, causing severe performance degradation. 

Frappe Support Issue: https://support.frappe.io/helpdesk/tickets/77070

The user site has 600 warehouses and no company default inventory account and multiple stock accounts.