### PR TITLE
fix(manufacturing): handle duplicate root BOM items

### DIFF
--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
@@ -91,14 +91,10 @@ class BOMCreator(Document):
 
 			key = (row.item_code, row.fg_reference_id)
 			if key in item_map:
-				parent_item_code = next(
-					item.item_code for item in self.items if item.name == row.fg_reference_id
-				)
-
 				frappe.throw(
 					_(
 						"Item {0} added multiple times under the same parent item {1} at rows {2} and {3}"
-					).format(bold(row.item_code), bold(parent_item_code), item_map[key], row.idx),
+					).format(bold(row.item_code), bold(row.fg_item), item_map[key], row.idx),
 					title=_("Duplicate Item Under Same Parent"),
 				)
 			else:

--- a/erpnext/manufacturing/doctype/bom_creator/test_bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/test_bom_creator.py
@@ -110,36 +110,6 @@ class TestBOMCreator(ERPNextTestSuite):
 
 		self.assertEqual(doc.raw_material_cost, fg_valuation_rate)
 
-	def test_duplicate_root_item_raises_validation_error(self):
-		final_product = "Bicycle"
-		make_item(final_product, {"item_group": "Raw Material", "stock_uom": "Nos"})
-
-		doc = make_bom_creator(
-			name="Bicycle BOM with Duplicate Raw Material",
-			company="_Test Company",
-			item_code=final_product,
-			qty=1,
-			rm_cosy_as_per="Valuation Rate",
-			currency="INR",
-			plc_conversion_rate=1,
-			conversion_rate=1,
-		)
-
-		doc.add_item(
-			fg_item=final_product,
-			fg_reference_id=doc.name,
-			item_code="Pedal Assembly",
-			qty=1,
-		)
-
-		with self.assertRaisesRegex(frappe.ValidationError, "Pedal Assembly.*Bicycle"):
-			doc.add_item(
-				fg_item=final_product,
-				fg_reference_id=doc.name,
-				item_code="Pedal Assembly",
-				qty=1,
-			)
-
 	def test_convert_to_sub_assembly(self):
 		final_product = "Bicycle"
 		make_item(

--- a/erpnext/manufacturing/doctype/bom_creator/test_bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/test_bom_creator.py
@@ -110,6 +110,36 @@ class TestBOMCreator(ERPNextTestSuite):
 
 		self.assertEqual(doc.raw_material_cost, fg_valuation_rate)
 
+	def test_duplicate_root_item_raises_validation_error(self):
+		final_product = "Bicycle"
+		make_item(final_product, {"item_group": "Raw Material", "stock_uom": "Nos"})
+
+		doc = make_bom_creator(
+			name="Bicycle BOM with Duplicate Raw Material",
+			company="_Test Company",
+			item_code=final_product,
+			qty=1,
+			rm_cosy_as_per="Valuation Rate",
+			currency="INR",
+			plc_conversion_rate=1,
+			conversion_rate=1,
+		)
+
+		doc.add_item(
+			fg_item=final_product,
+			fg_reference_id=doc.name,
+			item_code="Pedal Assembly",
+			qty=1,
+		)
+
+		with self.assertRaisesRegex(frappe.ValidationError, "Pedal Assembly.*Bicycle"):
+			doc.add_item(
+				fg_item=final_product,
+				fg_reference_id=doc.name,
+				item_code="Pedal Assembly",
+				qty=1,
+			)
+
 	def test_convert_to_sub_assembly(self):
 		final_product = "Bicycle"
 		make_item(


### PR DESCRIPTION
## Problem

Adding the same raw material twice under the root BOM Creator should raise a duplicate validation error. The validator searched child row names with the root document ID. The search had no match and raised `StopIteration`.

## Solution

Use the required `fg_item` field as the parent item code in the validation message. This field works for root materials and sub-assemblies.

## Tests

- `erpnext.manufacturing.doctype.bom_creator.test_bom_creator` (7 tests)
- `pre-commit run --files erpnext/manufacturing/doctype/bom_creator/bom_creator.py erpnext/manufacturing/doctype/bom_creator/test_bom_creator.py`

## Screenshots

Not applicable. This change affects server-side validation.