### PR TITLE
fix: do not map the same row twice in "Get Items From"

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/mapper.py
+++ b/erpnext/accounts/doctype/purchase_invoice/mapper.py
@@ -10,6 +10,7 @@ from frappe.model.mapper import get_mapped_doc
 from frappe.utils import flt
 
 from erpnext.controllers.accounts_controller import merge_taxes
+from erpnext.controllers.mapper import get_qty_already_mapped
 
 
 @frappe.whitelist()
@@ -52,6 +53,11 @@ def make_purchase_receipt(
 		args = {}
 	args = frappe.parse_json(args)
 
+	mapped_qty_by_item = get_qty_already_mapped(target_doc, "purchase_invoice_item")
+
+	def received_and_mapped_qty(obj):
+		return flt(obj.received_qty) + flt(mapped_qty_by_item.get(obj.name, 0))
+
 	def post_parent_process(source_parent, target_parent):
 		remove_items_with_zero_qty(target_parent)
 		set_missing_values(source_parent, target_parent)
@@ -75,15 +81,13 @@ def make_purchase_receipt(
 			or {}
 		)
 
-		target.qty = flt(obj.qty) - flt(obj.received_qty) - flt(returned_qty_map.get("qty"))
-		target.received_qty = flt(obj.qty) - flt(obj.received_qty)
-		target.stock_qty = (flt(obj.qty) - flt(obj.received_qty) - flt(returned_qty_map.get("qty"))) * flt(
-			obj.conversion_factor
-		)
-		target.amount = (flt(obj.qty) - flt(obj.received_qty)) * flt(obj.rate)
-		target.base_amount = (
-			(flt(obj.qty) - flt(obj.received_qty)) * flt(obj.rate) * flt(source_parent.conversion_rate)
-		)
+		pending_qty = flt(obj.qty) - received_and_mapped_qty(obj)
+
+		target.qty = pending_qty - flt(returned_qty_map.get("qty"))
+		target.received_qty = pending_qty
+		target.stock_qty = (pending_qty - flt(returned_qty_map.get("qty"))) * flt(obj.conversion_factor)
+		target.amount = pending_qty * flt(obj.rate)
+		target.base_amount = pending_qty * flt(obj.rate) * flt(source_parent.conversion_rate)
 
 	def select_item(d):
 		filtered_items = args.get("filtered_children", [])
@@ -113,7 +117,8 @@ def make_purchase_receipt(
 					"wip_composite_asset": "wip_composite_asset",
 				},
 				"postprocess": update_item,
-				"condition": lambda doc: abs(doc.received_qty) < abs(doc.qty) and select_item(doc),
+				"condition": lambda doc: abs(received_and_mapped_qty(doc)) < abs(doc.qty)
+				and select_item(doc),
 			},
 			"Purchase Taxes and Charges": {
 				"doctype": "Purchase Taxes and Charges",

--- a/erpnext/buying/doctype/purchase_order/mapper.py
+++ b/erpnext/buying/doctype/purchase_order/mapper.py
@@ -10,6 +10,7 @@ from frappe.model.mapper import get_mapped_doc
 from frappe.utils import flt, get_link_to_form
 
 from erpnext.accounts.party import get_party_account
+from erpnext.controllers.mapper import get_qty_already_mapped
 from erpnext.controllers.status_updater import get_allowance_for
 from erpnext.setup.doctype.item_group.item_group import get_item_group_defaults
 from erpnext.stock.doctype.item.item import get_item_defaults
@@ -34,12 +35,14 @@ def make_purchase_receipt(
 	def is_unit_price_row(source):
 		return has_unit_price_items and source.qty == 0
 
+	mapped_qty_by_item = get_qty_already_mapped(target_doc, "purchase_order_item")
+
 	def get_max_receivable_qty(source):
 		tolerance = flt(get_allowance_for(source.item_code, qty_or_amount="qty")[0])
 		return flt(source.qty) * (100 + tolerance) / 100
 
 	def update_item(obj, target, source_parent):
-		received_qty = flt(obj.received_qty)
+		received_qty = flt(obj.received_qty) + flt(mapped_qty_by_item.get(obj.name, 0))
 		qty = flt(obj.qty)
 		pending_qty = qty - received_qty
 
@@ -84,9 +87,10 @@ def make_purchase_receipt(
 				},
 				"postprocess": update_item,
 				"condition": lambda doc: (
-					True
+					doc.name not in mapped_qty_by_item
 					if is_unit_price_row(doc)
-					else abs(doc.received_qty) < abs(get_max_receivable_qty(doc))
+					else abs(doc.received_qty) + abs(mapped_qty_by_item.get(doc.name, 0))
+					< abs(get_max_receivable_qty(doc))
 				)
 				and doc.delivered_by_supplier != 1
 				and not doc.closed
@@ -149,9 +153,13 @@ def get_mapped_purchase_invoice(source_name, target_doc=None, ignore_permissions
 		)
 		return query.run(pluck="qty")[0] or 0
 
+	mapped_qty_by_item = get_qty_already_mapped(target_doc, "po_detail")
+
+	def get_billed_and_mapped_qty(po_item_name):
+		return flt(get_billed_qty(po_item_name)) + flt(mapped_qty_by_item.get(po_item_name, 0))
+
 	def update_item(obj, target, source_parent):
-		billed_qty = flt(get_billed_qty(obj.name))
-		target.qty = flt(obj.qty) - billed_qty
+		target.qty = flt(obj.qty) - get_billed_and_mapped_qty(obj.name)
 
 		item = get_item_defaults(target.item_code, source_parent.company)
 		item_group = get_item_group_defaults(target.item_code, source_parent.company)
@@ -194,6 +202,7 @@ def get_mapped_purchase_invoice(source_name, target_doc=None, ignore_permissions
 				or abs(doc.billed_amt) < abs(doc.amount)
 				or doc.qty > flt(get_billed_qty(doc.name))
 			)
+			and (doc.name not in mapped_qty_by_item or doc.qty > get_billed_and_mapped_qty(doc.name))
 			and not doc.closed
 			and select_item(doc),
 		},

--- a/erpnext/buying/doctype/supplier_quotation/mapper.py
+++ b/erpnext/buying/doctype/supplier_quotation/mapper.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import flt
 
+from erpnext.controllers.mapper import get_qty_already_mapped
+
 
 @frappe.whitelist()
 def make_purchase_order(
@@ -16,6 +18,8 @@ def make_purchase_order(
 	if args is None:
 		args = {}
 	args = frappe.parse_json(args)
+
+	mapped_items = get_qty_already_mapped(target_doc, "supplier_quotation_item")
 
 	def set_missing_values(source, target):
 		target.run_method("set_missing_values")
@@ -51,7 +55,8 @@ def make_purchase_order(
 					["sales_order", "sales_order"],
 				],
 				"postprocess": update_item,
-				"condition": select_item,
+				# no qty tracking between the two, so dedupe on the row reference alone
+				"condition": lambda d: d.name not in mapped_items and select_item(d),
 			},
 			"Purchase Taxes and Charges": {
 				"doctype": "Purchase Taxes and Charges",

--- a/erpnext/controllers/mapper.py
+++ b/erpnext/controllers/mapper.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+from frappe.utils import flt
+
+
+def get_qty_already_mapped(target_doc, ref_field: str, qty_field: str = "qty") -> frappe._dict:
+	"""Return a map: {source row name: qty} of rows already mapped into the target document.
+
+	"Get Items From" passes the in-progress (unsaved) document back as `target_doc`. Its rows
+	are invisible to the pending-qty queries in the mappers, which only count submitted
+	documents -- so without this, selecting the same source document twice maps every row
+	again. Rows are keyed by `ref_field` (dn_detail, so_detail, ...), and a row is present in
+	the map even when its qty is 0, so mappers without qty tracking can dedupe on presence.
+	"""
+	if isinstance(target_doc, str):
+		target_doc = frappe.parse_json(target_doc)
+
+	qty_map = frappe._dict()
+	for row in (target_doc and target_doc.get("items")) or []:
+		if ref := row.get(ref_field):
+			qty_map[ref] = qty_map.get(ref, 0) + flt(row.get(qty_field))
+
+	return qty_map

--- a/erpnext/controllers/tests/test_mapper.py
+++ b/erpnext/controllers/tests/test_mapper.py
@@ -30,6 +30,97 @@ class TestMapper(ERPNextTestSuite):
 		src_items = item_list_1 + item_list_2 + item_list_3
 		self.assertEqual(set(d for d in src_items), set(d.item_code for d in updated_so.items))
 
+	def test_get_items_from_is_idempotent(self):
+		"""Selecting the same source document twice must not duplicate rows in the target.
+
+		"Get Items From" hands the in-progress document back to the mapper as `target_doc`.
+		Its rows are unsaved, so the mappers' pending-qty queries (submitted documents only)
+		cannot see them -- every mapper has to discount them explicitly.
+		"""
+		for label, make_source, method in self.idempotency_cases():
+			with self.subTest(label):
+				source = make_source()
+				target = frappe.get_attr(method)(source.name)
+				mapped_rows = len(target.items)
+				self.assertTrue(mapped_rows, f"{label}: nothing was mapped")
+
+				target = frappe.get_attr(method)(source.name, target)
+				self.assertEqual(len(target.items), mapped_rows, f"{label}: rows were duplicated")
+
+	def idempotency_cases(self):
+		"""(label, source factory, mapper method) for every "Get Items From" button.
+
+		Quotation -> Sales Invoice is absent: Sales Invoice Item keeps no reference to the
+		Quotation row, so there is nothing to deduplicate on.
+		"""
+		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+		from erpnext.selling.doctype.quotation.test_quotation import make_quotation
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
+		from erpnext.stock.doctype.material_request.test_material_request import (
+			make_material_request_for_items,
+		)
+		from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
+
+		self.load_test_records("Supplier Quotation")
+
+		def make_supplier_quotation():
+			return frappe.copy_doc(self.globalTestRecords["Supplier Quotation"][0]).submit()
+
+		return [
+			(
+				"Quotation -> Sales Order",
+				lambda: make_quotation(),
+				"erpnext.selling.doctype.quotation.mapper.make_sales_order",
+			),
+			(
+				"Sales Order -> Sales Invoice",
+				lambda: make_sales_order(),
+				"erpnext.selling.doctype.sales_order.mapper.make_sales_invoice",
+			),
+			(
+				"Sales Order -> Delivery Note",
+				lambda: make_sales_order(),
+				"erpnext.selling.doctype.sales_order.mapper.make_delivery_note",
+			),
+			(
+				"Delivery Note -> Sales Invoice",
+				lambda: create_delivery_note(),
+				"erpnext.stock.doctype.delivery_note.mapper.make_sales_invoice",
+			),
+			(
+				"Material Request -> Purchase Order",
+				lambda: make_material_request_for_items(["_Test Item"]),
+				"erpnext.stock.doctype.material_request.mapper.make_purchase_order",
+			),
+			(
+				"Supplier Quotation -> Purchase Order",
+				make_supplier_quotation,
+				"erpnext.buying.doctype.supplier_quotation.mapper.make_purchase_order",
+			),
+			(
+				"Purchase Order -> Purchase Receipt",
+				lambda: create_purchase_order(),
+				"erpnext.buying.doctype.purchase_order.mapper.make_purchase_receipt",
+			),
+			(
+				"Purchase Order -> Purchase Invoice",
+				lambda: create_purchase_order(),
+				"erpnext.buying.doctype.purchase_order.mapper.make_purchase_invoice",
+			),
+			(
+				"Purchase Receipt -> Purchase Invoice",
+				lambda: make_purchase_receipt(),
+				"erpnext.stock.doctype.purchase_receipt.mapper.make_purchase_invoice",
+			),
+			(
+				"Purchase Invoice -> Purchase Receipt",
+				lambda: make_purchase_invoice(),
+				"erpnext.accounts.doctype.purchase_invoice.mapper.make_purchase_receipt",
+			),
+		]
+
 	def make_quotation(self, item_list, customer):
 		qtn = frappe.get_doc(
 			{

--- a/erpnext/selling/doctype/quotation/mapper.py
+++ b/erpnext/selling/doctype/quotation/mapper.py
@@ -9,6 +9,8 @@ from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import cint, flt, getdate, nowdate
 
+from erpnext.controllers.mapper import get_qty_already_mapped
+
 
 @frappe.whitelist()
 def make_sales_order(
@@ -35,6 +37,9 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False, ar
 
 	customer = _make_customer(source_name, ignore_permissions)
 	ordered_items = get_ordered_items(source_name)
+	mapped_items = get_qty_already_mapped(target_doc, "quotation_item", "stock_qty")
+	for name, stock_qty in mapped_items.items():
+		ordered_items[name] = flt(ordered_items.get(name)) + stock_qty
 
 	selected_rows = [x.get("name") for x in frappe.flags.get("args", {}).get("selected_items", [])]
 
@@ -88,7 +93,10 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False, ar
 		2. If selections: Is Alternative Item/Has Alternative Item: Map if selected and adequate qty
 		3. If no selections: Simple row: Map if adequate qty
 		"""
-		if not ((item.stock_qty > ordered_items.get(item.name, 0.0)) or is_unit_price_row(item)):
+		if not (
+			(item.stock_qty > ordered_items.get(item.name, 0.0))
+			or (is_unit_price_row(item) and item.name not in mapped_items)
+		):
 			return False
 
 		if not selected_rows:

--- a/erpnext/selling/doctype/sales_order/mapper.py
+++ b/erpnext/selling/doctype/sales_order/mapper.py
@@ -14,6 +14,7 @@ from frappe.utils import add_days, cint, flt, nowdate, strip_html
 
 from erpnext.accounts.party import CROSS_PARTY_FIELD_NO_MAP, get_party_account
 from erpnext.controllers.item_close import is_bundle_of_closed_row
+from erpnext.controllers.mapper import get_qty_already_mapped
 from erpnext.manufacturing.doctype.production_plan.production_plan import (
 	get_items_for_material_requests,
 	get_sales_orders,
@@ -247,6 +248,8 @@ def make_delivery_note(
 	if kwargs.for_reserved_stock:
 		sre_details = get_sre_reserved_qty_details_for_voucher("Sales Order", source_name)
 
+	mapped_qty_by_item = get_qty_already_mapped(target_doc, "so_detail")
+
 	mapper = {
 		"Sales Order": {
 			"doctype": "Delivery Note",
@@ -310,17 +313,21 @@ def make_delivery_note(
 				return False
 
 		return (
-			((abs(doc.delivered_qty) < abs(doc.qty)) or is_unit_price_row(doc))
+			(
+				(abs(doc.delivered_qty) + abs(mapped_qty_by_item.get(doc.name, 0)) < abs(doc.qty))
+				or (is_unit_price_row(doc) and doc.name not in mapped_qty_by_item)
+			)
 			and doc.delivered_by_supplier != 1
 			and not cint(doc.skip_delivery)
 		)
 
+	def remaining_qty(source):
+		return flt(source.qty) - flt(source.delivered_qty) - flt(mapped_qty_by_item.get(source.name, 0))
+
 	def update_item(source, target, source_parent):
-		target.base_amount = (flt(source.qty) - flt(source.delivered_qty)) * flt(source.base_rate)
-		target.amount = (flt(source.qty) - flt(source.delivered_qty)) * flt(source.rate)
-		target.qty = (
-			flt(source.qty) if is_unit_price_row(source) else flt(source.qty) - flt(source.delivered_qty)
-		)
+		target.base_amount = remaining_qty(source) * flt(source.base_rate)
+		target.amount = remaining_qty(source) * flt(source.rate)
+		target.qty = flt(source.qty) if is_unit_price_row(source) else remaining_qty(source)
 
 		item = get_item_defaults(target.item_code, source_parent.company)
 		item_group = get_item_group_defaults(target.item_code, source_parent.company)
@@ -448,6 +455,7 @@ def make_sales_invoice(
 	has_unit_price_items = frappe.db.get_value("Sales Order", source_name, "has_unit_price_items")
 	billed_qty_by_item = None
 	pending_qty_by_item = {}
+	mapped_qty_by_item = get_qty_already_mapped(target_doc, "so_detail")
 
 	def is_unit_price_row(source):
 		return has_unit_price_items and source.qty == 0
@@ -476,6 +484,7 @@ def make_sales_invoice(
 			if source.qty and source.billed_amt:
 				billable_qty -= get_billed_qty_by_item().get(source.name, 0)
 
+			billable_qty -= mapped_qty_by_item.get(source.name, 0)
 			pending_qty_by_item[source.name] = max(flt(billable_qty, source.precision("qty")), 0)
 
 		return pending_qty_by_item[source.name]
@@ -608,7 +617,7 @@ def make_sales_invoice(
 				and select_item(doc)
 				and not doc.closed
 				and (
-					True
+					doc.name not in mapped_qty_by_item
 					if is_unit_price_row(doc)
 					else (
 						doc.qty

--- a/erpnext/stock/doctype/delivery_note/mapper.py
+++ b/erpnext/stock/doctype/delivery_note/mapper.py
@@ -16,6 +16,7 @@ from frappe.utils import flt
 from erpnext.accounts.party import CROSS_PARTY_FIELD_NO_MAP, get_due_date
 from erpnext.controllers.accounts_controller import get_taxes_and_charges, merge_taxes
 from erpnext.controllers.item_close import is_bundle_of_closed_row
+from erpnext.controllers.mapper import get_qty_already_mapped
 from erpnext.stock.doctype.packed_item.packed_item import is_product_bundle
 
 
@@ -74,6 +75,8 @@ def make_sales_invoice(
 	to_make_invoice_qty_map = {}
 	returned_qty_map = get_returned_qty_map(source_name)
 	invoiced_qty_map = get_invoiced_qty_map(source_name)
+	for ref, qty in get_qty_already_mapped(target_doc, "dn_detail").items():
+		invoiced_qty_map[ref] = invoiced_qty_map.get(ref, 0) + qty
 
 	def set_missing_values(source, target):
 		target.run_method("set_missing_values")
@@ -148,7 +151,7 @@ def make_sales_invoice(
 				"postprocess": update_item,
 				"filter": lambda d: get_pending_qty(d) <= 0
 				if not doc.get("is_return")
-				else get_pending_qty(d) > 0,
+				else get_pending_qty(d) >= 0,
 				"condition": select_item,
 			},
 			"Sales Taxes and Charges": {

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -1102,6 +1102,25 @@ class TestDeliveryNote(ERPNextTestSuite):
 		self.assertEqual(dn2.per_billed, 100)
 		self.assertEqual(dn2.status, "Completed")
 
+	def test_mapping_same_dn_twice_is_idempotent(self):
+		# "Get Items From > Delivery Note" passes the in-progress invoice back as target_doc.
+		# Selecting the same DN again must not append a second row for the same dn_detail.
+		dn = create_delivery_note(qty=5)
+
+		si = make_sales_invoice(dn.name)
+		self.assertEqual(len(si.items), 1)
+		self.assertEqual(si.items[0].qty, 5)
+
+		si = make_sales_invoice(dn.name, target_doc=si)
+		self.assertEqual(len(si.items), 1)
+		self.assertEqual(si.items[0].qty, 5)
+
+		# a partly reduced draft row still tops up to the delivered qty
+		si.items[0].qty = 2
+		si = make_sales_invoice(dn.name, target_doc=si)
+		self.assertEqual(len(si.items), 2)
+		self.assertEqual([d.qty for d in si.items], [2, 3])
+
 	def test_dn_billing_falls_back_to_qty_when_amount_is_short(self):
 		# SO -> DN (qty 5 @ 100 => amount 500), invoiced fully but at a lower rate.
 		# The invoiced amount (400) stays below the delivery amount (500), so billing

--- a/erpnext/stock/doctype/material_request/mapper.py
+++ b/erpnext/stock/doctype/material_request/mapper.py
@@ -9,6 +9,7 @@ from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import cint, comma_and, flt, get_link_to_form, getdate, nowdate
 
+from erpnext.controllers.mapper import get_qty_already_mapped
 from erpnext.setup.doctype.brand.brand import get_brand_defaults
 from erpnext.setup.doctype.item_group.item_group import get_item_group_defaults
 from erpnext.stock.doctype.item.item import get_item_defaults
@@ -74,6 +75,7 @@ def make_purchase_order(
 	)
 
 	requested_qty = args.get("requested_qty") or {}
+	mapped_qty_by_item = get_qty_already_mapped(target_doc, "material_request_item", "stock_qty")
 
 	def postprocess(source, target_doc):
 		target_doc.is_subcontracted = is_subcontracted
@@ -90,7 +92,7 @@ def make_purchase_order(
 		filtered_items = args.get("filtered_children", [])
 		child_filter = d.name in filtered_items if filtered_items else True
 
-		qty = d.ordered_qty or d.received_qty
+		qty = (d.ordered_qty or d.received_qty) + flt(mapped_qty_by_item.get(d.name, 0))
 
 		return qty < d.stock_qty and child_filter
 

--- a/erpnext/stock/doctype/purchase_receipt/mapper.py
+++ b/erpnext/stock/doctype/purchase_receipt/mapper.py
@@ -11,6 +11,7 @@ from frappe.query_builder.functions import Abs, Sum
 from frappe.utils import flt
 
 from erpnext.controllers.accounts_controller import merge_taxes
+from erpnext.controllers.mapper import get_qty_already_mapped
 from erpnext.stock.doctype.delivery_note.mapper import make_inter_company_transaction
 from erpnext.stock.serial_batch_bundle import (
 	SerialBatchCreation,
@@ -67,6 +68,8 @@ def make_purchase_invoice(
 	doc = frappe.get_doc("Purchase Receipt", source_name)
 	returned_qty_map = get_returned_qty_map(source_name)
 	invoiced_qty_map = get_invoiced_qty_map(source_name)
+	for ref, qty in get_qty_already_mapped(target_doc, "pr_detail").items():
+		invoiced_qty_map[ref] = invoiced_qty_map.get(ref, 0) + qty
 
 	def set_missing_values(source, target):
 		if len(target.get("items")) == 0:
@@ -154,7 +157,7 @@ def make_purchase_invoice(
 				},
 				"postprocess": update_item,
 				"filter": lambda d: (
-					get_pending_qty(d)[0] <= 0 if not doc.get("is_return") else get_pending_qty(d)[0] > 0
+					get_pending_qty(d)[0] <= 0 if not doc.get("is_return") else get_pending_qty(d)[0] >= 0
 				),
 				"condition": select_item,
 			},


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

"Get Items From" is not idempotent. Select the same Delivery Note twice in a Sales Invoice, and the invoice gets a second set of lines for the same Delivery Note rows.

The same happens on every other "Get Items From" button.

## Cause

The button passes the in-progress document back to the mapper as `target_doc`. The rows in it are unsaved. The pending quantity queries in the mappers count submitted documents only, so they cannot see those rows. On the second selection every source row looks fully open again.

The guard in `erpnext.utils.map_current_doc` does not stop this. Its `return` sits inside a `forEach` callback, so the message appears and the mapping runs anyway.

At submit time, over billing validation catches the duplicate in most cases. It does not catch it for users who hold the "role allowed to over bill", or when the tolerance covers the extra amount.

## Fix

`get_qty_already_mapped` in the new `erpnext/controllers/mapper.py` returns the quantity per source row that the target document already holds. Each mapper subtracts that quantity, keyed by the row reference it already stores:

| Source to target | Row reference |
| --- | --- |
| Quotation to Sales Order | `quotation_item` |
| Sales Order to Sales Invoice | `so_detail` |
| Sales Order to Delivery Note | `so_detail` |
| Delivery Note to Sales Invoice | `dn_detail` |
| Material Request to Purchase Order | `material_request_item` |
| Supplier Quotation to Purchase Order | `supplier_quotation_item` |
| Purchase Order to Purchase Receipt | `purchase_order_item` |
| Purchase Order to Purchase Invoice | `po_detail` |
| Purchase Receipt to Purchase Invoice | `pr_detail` |
| Purchase Invoice to Purchase Receipt | `purchase_invoice_item` |

The mappers already think in open quantity, so this reuses that logic instead of adding a separate deduplication pass. A row that the user reduced by hand still tops up to the open quantity. A row that is already complete adds nothing.

Unit price rows carry no meaningful quantity. They are deduplicated on the row reference alone.

Two mappers also needed their return filter changed from `> 0` to `>= 0`. At a pending quantity of zero they mapped a row with quantity zero, which kept credit notes from return documents non-idempotent.

## Not covered

Quotation to Sales Invoice. Sales Invoice Item keeps no reference to the Quotation row, so there is nothing to deduplicate on. This needs a new field.

## Tests

`test_get_items_from_is_idempotent` in `erpnext/controllers/tests/test_mapper.py` covers all ten paths as subtests. It maps a source document, maps it again onto the result, and asserts that the row count does not change. All ten fail without this change.

`test_mapping_same_dn_twice_is_idempotent` in `test_delivery_note.py` also covers the top up case: reduce a mapped row from 5 to 2, select the Delivery Note again, and get one more row of 3.

Full modules pass locally: `sales_order`, `quotation`, `delivery_note`, `supplier_quotation`, `purchase_receipt`, `material_request`, `purchase_invoice`. Two failures in `purchase_order` and `sales_invoice` are unrelated and also fail on a clean tree.

Ref: LAN-903