### PR TITLE
fix: explain missing fields when loading party details or taxes

### DIFF
--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -77,41 +77,28 @@ erpnext.utils.get_party_details = function (frm, method, args, callback) {
 		}
 	}
 
-	const party_field = frappe.meta.get_docfield(frm.doc.doctype, "party_name")
-		? "party_name"
-		: args.party_type === "Customer"
-		? "customer"
-		: "supplier";
-	const party_label = frm.doc.quotation_to
-		? __(frm.doc.quotation_to)
-		: frappe.meta.get_translated_label(frm.doc.doctype, party_field);
+	const field = party_field(frm, args.party_type);
+	const label = party_label(frm, args.party_type);
 
 	if (frappe.meta.get_docfield(frm.doc.doctype, "taxes") && !args.posting_date) {
-		const date_field = frappe.meta.get_docfield(frm.doc.doctype, "posting_date")
-			? "posting_date"
-			: "transaction_date";
-		const date_label = frappe.meta.get_translated_label(frm.doc.doctype, date_field);
-		frm.doc[party_field] = "";
-		refresh_field(party_field);
-		frappe.throw({
-			title: __("Cannot load {0} details", [party_label]),
-			message: __("{0} is required to apply taxes. Set {0}, then select {1} again.", [
-				date_label,
-				party_label,
-			]),
-		});
+		undo_and_throw(
+			frm,
+			field,
+			__("Cannot load {0} details", [label]),
+			__("{0} is required to apply taxes. Set {0}, then select {1} again.", [date_label(frm), label])
+		);
 	}
 
 	if (!frm.doc.company) {
-		frm.doc[party_field] = "";
-		refresh_field(party_field);
-		frappe.throw({
-			title: __("Cannot load {0} details", [party_label]),
-			message: __(
+		undo_and_throw(
+			frm,
+			field,
+			__("Cannot load {0} details", [label]),
+			__(
 				"Company is required to load address, taxes, and payment terms. Set Company, then select {0} again.",
-				[party_label]
-			),
-		});
+				[label]
+			)
+		);
 	}
 
 	args.currency = frm.doc.currency;
@@ -195,37 +182,27 @@ erpnext.utils.set_taxes_from_address = function (
 	const trigger_label = frappe.meta.get_translated_label(frm.doc.doctype, triggered_from_field);
 
 	if (!(frm.doc.customer || frm.doc.supplier || frm.doc.lead || frm.doc.party_name)) {
-		const party_field = ["customer", "supplier", "lead", "party_name"].find((field) =>
-			frappe.meta.get_docfield(frm.doc.doctype, field)
-		);
-		const party_label = frm.doc.quotation_to
-			? __(frm.doc.quotation_to)
-			: frappe.meta.get_translated_label(frm.doc.doctype, party_field);
-		frm.doc[triggered_from_field] = "";
-		refresh_field(triggered_from_field);
-		frappe.throw({
-			title: __("Cannot apply taxes from this address"),
-			message: __("{0} is required to apply taxes. Set {0}, then select {1} again.", [
-				party_label,
+		undo_and_throw(
+			frm,
+			triggered_from_field,
+			__("Cannot apply taxes from this address"),
+			__("{0} is required to apply taxes. Set {0}, then select {1} again.", [
+				party_label(frm),
 				trigger_label,
-			]),
-		});
+			])
+		);
 	}
 
 	if (!(frm.doc.posting_date || frm.doc.transaction_date)) {
-		const date_field = frappe.meta.get_docfield(frm.doc.doctype, "posting_date")
-			? "posting_date"
-			: "transaction_date";
-		const date_label = frappe.meta.get_translated_label(frm.doc.doctype, date_field);
-		frm.doc[triggered_from_field] = "";
-		refresh_field(triggered_from_field);
-		frappe.throw({
-			title: __("Cannot apply taxes from this address"),
-			message: __("{0} is required to apply taxes. Set {0}, then select {1} again.", [
-				date_label,
+		undo_and_throw(
+			frm,
+			triggered_from_field,
+			__("Cannot apply taxes from this address"),
+			__("{0} is required to apply taxes. Set {0}, then select {1} again.", [
+				date_label(frm),
 				trigger_label,
-			]),
-		});
+			])
+		);
 	}
 
 	frappe.call({
@@ -255,48 +232,36 @@ erpnext.utils.set_taxes = function (frm, triggered_from_field) {
 	const trigger_label = frappe.meta.get_translated_label(frm.doc.doctype, triggered_from_field);
 
 	if (!frm.doc.company) {
-		frm.doc[triggered_from_field] = "";
-		refresh_field(triggered_from_field);
-		frappe.throw({
-			title: __("Cannot apply taxes"),
-			message: __("Company is required to apply taxes. Set Company, then select {0} again.", [
-				trigger_label,
-			]),
-		});
+		undo_and_throw(
+			frm,
+			triggered_from_field,
+			__("Cannot apply taxes"),
+			__("Company is required to apply taxes. Set Company, then select {0} again.", [trigger_label])
+		);
 	}
 
 	if (!(frm.doc.customer || frm.doc.supplier || frm.doc.lead || frm.doc.party_name)) {
-		const party_field = ["customer", "supplier", "lead", "party_name"].find((field) =>
-			frappe.meta.get_docfield(frm.doc.doctype, field)
-		);
-		const party_label = frm.doc.quotation_to
-			? __(frm.doc.quotation_to)
-			: frappe.meta.get_translated_label(frm.doc.doctype, party_field);
-		frm.doc[triggered_from_field] = "";
-		refresh_field(triggered_from_field);
-		frappe.throw({
-			title: __("Cannot apply taxes"),
-			message: __("{0} is required to apply taxes. Set {0}, then select {1} again.", [
-				party_label,
+		undo_and_throw(
+			frm,
+			triggered_from_field,
+			__("Cannot apply taxes"),
+			__("{0} is required to apply taxes. Set {0}, then select {1} again.", [
+				party_label(frm),
 				trigger_label,
-			]),
-		});
+			])
+		);
 	}
 
 	if (!(frm.doc.posting_date || frm.doc.transaction_date)) {
-		const date_field = frappe.meta.get_docfield(frm.doc.doctype, "posting_date")
-			? "posting_date"
-			: "transaction_date";
-		const date_label = frappe.meta.get_translated_label(frm.doc.doctype, date_field);
-		frm.doc[triggered_from_field] = "";
-		refresh_field(triggered_from_field);
-		frappe.throw({
-			title: __("Cannot apply taxes"),
-			message: __("{0} is required to apply taxes. Set {0}, then select {1} again.", [
-				date_label,
+		undo_and_throw(
+			frm,
+			triggered_from_field,
+			__("Cannot apply taxes"),
+			__("{0} is required to apply taxes. Set {0}, then select {1} again.", [
+				date_label(frm),
 				trigger_label,
-			]),
-		});
+			])
+		);
 	}
 
 	var party_type, party;
@@ -414,3 +379,39 @@ erpnext.utils.get_shipping_address = function (frm, callback) {
 		frappe.msgprint(__("Select company first"));
 	}
 };
+
+function party_field(frm, party_type) {
+	if (frappe.meta.get_docfield(frm.doc.doctype, "party_name")) {
+		return "party_name";
+	}
+	if (party_type === "Customer") {
+		return "customer";
+	}
+	if (party_type === "Supplier") {
+		return "supplier";
+	}
+	if (party_type === "Lead") {
+		return "lead";
+	}
+	return ["customer", "supplier", "lead"].find((field) => frappe.meta.get_docfield(frm.doc.doctype, field));
+}
+
+function party_label(frm, party_type) {
+	if (frm.doc.quotation_to) {
+		return __(frm.doc.quotation_to);
+	}
+	return frappe.meta.get_translated_label(frm.doc.doctype, party_field(frm, party_type));
+}
+
+function date_label(frm) {
+	const field = frappe.meta.get_docfield(frm.doc.doctype, "posting_date")
+		? "posting_date"
+		: "transaction_date";
+	return frappe.meta.get_translated_label(frm.doc.doctype, field);
+}
+
+function undo_and_throw(frm, field, title, message) {
+	frm.doc[field] = "";
+	refresh_field(field);
+	frappe.throw({ title, message });
+}

--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -77,27 +77,41 @@ erpnext.utils.get_party_details = function (frm, method, args, callback) {
 		}
 	}
 
-	if (frappe.meta.get_docfield(frm.doc.doctype, "taxes")) {
-		if (
-			!erpnext.utils.validate_mandatory(
-				frm,
-				__("Posting / Transaction Date"),
-				args.posting_date,
-				args.party_type == "Customer" ? "customer" : "supplier"
-			)
-		)
-			return;
+	const party_field = frappe.meta.get_docfield(frm.doc.doctype, "party_name")
+		? "party_name"
+		: args.party_type === "Customer"
+		? "customer"
+		: "supplier";
+	const party_label = frm.doc.quotation_to
+		? __(frm.doc.quotation_to)
+		: frappe.meta.get_translated_label(frm.doc.doctype, party_field);
+
+	if (frappe.meta.get_docfield(frm.doc.doctype, "taxes") && !args.posting_date) {
+		const date_field = frappe.meta.get_docfield(frm.doc.doctype, "posting_date")
+			? "posting_date"
+			: "transaction_date";
+		const date_label = frappe.meta.get_translated_label(frm.doc.doctype, date_field);
+		frm.doc[party_field] = "";
+		refresh_field(party_field);
+		frappe.throw({
+			title: __("Cannot load {0} details", [party_label]),
+			message: __("{0} is required to apply taxes. Set {0}, then select {1} again.", [
+				date_label,
+				party_label,
+			]),
+		});
 	}
 
-	if (
-		!erpnext.utils.validate_mandatory(
-			frm,
-			__("Company"),
-			frm.doc.company,
-			args.party_type == "Customer" ? "customer" : "supplier"
-		)
-	) {
-		return;
+	if (!frm.doc.company) {
+		frm.doc[party_field] = "";
+		refresh_field(party_field);
+		frappe.throw({
+			title: __("Cannot load {0} details", [party_label]),
+			message: __(
+				"Company is required to load address, taxes, and payment terms. Set Company, then select {0} again.",
+				[party_label]
+			),
+		});
 	}
 
 	args.currency = frm.doc.currency;
@@ -174,30 +188,44 @@ erpnext.utils.set_taxes_from_address = function (
 ) {
 	if (frm.updating_party_details) return;
 
-	if (frappe.meta.get_docfield(frm.doc.doctype, "taxes")) {
-		if (
-			!erpnext.utils.validate_mandatory(
-				frm,
-				__("Lead / Customer / Supplier"),
-				frm.doc.customer || frm.doc.supplier || frm.doc.lead || frm.doc.party_name,
-				triggered_from_field
-			)
-		) {
-			return;
-		}
-
-		if (
-			!erpnext.utils.validate_mandatory(
-				frm,
-				__("Posting / Transaction Date"),
-				frm.doc.posting_date || frm.doc.transaction_date,
-				triggered_from_field
-			)
-		) {
-			return;
-		}
-	} else {
+	if (!frappe.meta.get_docfield(frm.doc.doctype, "taxes")) {
 		return;
+	}
+
+	const trigger_label = frappe.meta.get_translated_label(frm.doc.doctype, triggered_from_field);
+
+	if (!(frm.doc.customer || frm.doc.supplier || frm.doc.lead || frm.doc.party_name)) {
+		const party_field = ["customer", "supplier", "lead", "party_name"].find((field) =>
+			frappe.meta.get_docfield(frm.doc.doctype, field)
+		);
+		const party_label = frm.doc.quotation_to
+			? __(frm.doc.quotation_to)
+			: frappe.meta.get_translated_label(frm.doc.doctype, party_field);
+		frm.doc[triggered_from_field] = "";
+		refresh_field(triggered_from_field);
+		frappe.throw({
+			title: __("Cannot apply taxes from this address"),
+			message: __("{0} is required to apply taxes. Set {0}, then select {1} again.", [
+				party_label,
+				trigger_label,
+			]),
+		});
+	}
+
+	if (!(frm.doc.posting_date || frm.doc.transaction_date)) {
+		const date_field = frappe.meta.get_docfield(frm.doc.doctype, "posting_date")
+			? "posting_date"
+			: "transaction_date";
+		const date_label = frappe.meta.get_translated_label(frm.doc.doctype, date_field);
+		frm.doc[triggered_from_field] = "";
+		refresh_field(triggered_from_field);
+		frappe.throw({
+			title: __("Cannot apply taxes from this address"),
+			message: __("{0} is required to apply taxes. Set {0}, then select {1} again.", [
+				date_label,
+				trigger_label,
+			]),
+		});
 	}
 
 	frappe.call({
@@ -220,34 +248,55 @@ erpnext.utils.set_taxes_from_address = function (
 };
 
 erpnext.utils.set_taxes = function (frm, triggered_from_field) {
-	if (frappe.meta.get_docfield(frm.doc.doctype, "taxes")) {
-		if (!erpnext.utils.validate_mandatory(frm, __("Company"), frm.doc.company, triggered_from_field)) {
-			return;
-		}
-
-		if (
-			!erpnext.utils.validate_mandatory(
-				frm,
-				__("Lead / Customer / Supplier"),
-				frm.doc.customer || frm.doc.supplier || frm.doc.lead || frm.doc.party_name,
-				triggered_from_field
-			)
-		) {
-			return;
-		}
-
-		if (
-			!erpnext.utils.validate_mandatory(
-				frm,
-				__("Posting / Transaction Date"),
-				frm.doc.posting_date || frm.doc.transaction_date,
-				triggered_from_field
-			)
-		) {
-			return;
-		}
-	} else {
+	if (!frappe.meta.get_docfield(frm.doc.doctype, "taxes")) {
 		return;
+	}
+
+	const trigger_label = frappe.meta.get_translated_label(frm.doc.doctype, triggered_from_field);
+
+	if (!frm.doc.company) {
+		frm.doc[triggered_from_field] = "";
+		refresh_field(triggered_from_field);
+		frappe.throw({
+			title: __("Cannot apply taxes"),
+			message: __("Company is required to apply taxes. Set Company, then select {0} again.", [
+				trigger_label,
+			]),
+		});
+	}
+
+	if (!(frm.doc.customer || frm.doc.supplier || frm.doc.lead || frm.doc.party_name)) {
+		const party_field = ["customer", "supplier", "lead", "party_name"].find((field) =>
+			frappe.meta.get_docfield(frm.doc.doctype, field)
+		);
+		const party_label = frm.doc.quotation_to
+			? __(frm.doc.quotation_to)
+			: frappe.meta.get_translated_label(frm.doc.doctype, party_field);
+		frm.doc[triggered_from_field] = "";
+		refresh_field(triggered_from_field);
+		frappe.throw({
+			title: __("Cannot apply taxes"),
+			message: __("{0} is required to apply taxes. Set {0}, then select {1} again.", [
+				party_label,
+				trigger_label,
+			]),
+		});
+	}
+
+	if (!(frm.doc.posting_date || frm.doc.transaction_date)) {
+		const date_field = frappe.meta.get_docfield(frm.doc.doctype, "posting_date")
+			? "posting_date"
+			: "transaction_date";
+		const date_label = frappe.meta.get_translated_label(frm.doc.doctype, date_field);
+		frm.doc[triggered_from_field] = "";
+		refresh_field(triggered_from_field);
+		frappe.throw({
+			title: __("Cannot apply taxes"),
+			message: __("{0} is required to apply taxes. Set {0}, then select {1} again.", [
+				date_label,
+				trigger_label,
+			]),
+		});
 	}
 
 	var party_type, party;
@@ -263,10 +312,6 @@ erpnext.utils.set_taxes = function (frm, triggered_from_field) {
 	} else if (frm.doc.quotation_to) {
 		party_type = frm.doc.quotation_to;
 		party = frm.doc.party_name;
-	}
-
-	if (!frm.doc.company) {
-		frappe.throw(__("Kindly select the company first"));
 	}
 
 	frappe.call({
@@ -336,16 +381,6 @@ function reset_contact_fields(frm) {
 		contact_department: "",
 	});
 }
-
-erpnext.utils.validate_mandatory = function (frm, label, value, trigger_on) {
-	if (!value) {
-		frm.doc[trigger_on] = "";
-		refresh_field(trigger_on);
-		frappe.throw({ message: __("Please enter {0} first", [label]), title: __("Mandatory") });
-		return false;
-	}
-	return true;
-};
 
 erpnext.utils.get_shipping_address = function (frm, callback) {
 	if (frm.doc.company) {

--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -415,3 +415,12 @@ function undo_and_throw(frm, field, title, message) {
 	refresh_field(field);
 	frappe.throw({ title, message });
 }
+
+// Kept for custom client scripts that call this public helper.
+erpnext.utils.validate_mandatory = function (frm, label, value, trigger_on) {
+	if (value) {
+		return true;
+	}
+	undo_and_throw(frm, trigger_on, __("Mandatory"), __("Please enter {0} first", [label]));
+	return false;
+};


### PR DESCRIPTION
## Problem
When **Company**, a party, or a date is missing, the form still tries to load party details or apply taxes. The old helper then clears the field the user just set and throws "Please enter {0} first" with the title "Mandatory".
The message does not say what the user tried to do, why it failed, or that the field was cleared and must be set again. It also used vague labels such as "Posting / Transaction Date" and "Lead / Customer / Supplier". On **Quotation**, it cleared `customer` or `supplier` instead of `party_name`.

## Change
Remove `erpnext.utils.validate_mandatory`. Each call site now throws its own message.
The title names the action: load party details, apply taxes from an address, or apply taxes. The body names the missing field and tells the user to set it, then select the cleared field again.
Labels come from the form: _Posting Date_ or _Transaction Date_, _Customer_ or _Supplier_, and the trigger field.
This also removes the extra "Kindly select the company first" throw in `set_taxes`.
