### PR TITLE
fix(gross-profit): include item_name in export

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -180,13 +180,15 @@ def get_data_when_grouped_by_invoice(columns, gross_profit_data, filters, group_
 	columns[0]["fieldname"] = "sales_invoice"
 	columns[0]["options"] = "Item"
 	columns[0]["width"] = 300
-	# removing Item Code and Item Name columns
+	# removing the duplicate Item Code column and moving Item Name before Customer
 	supplier_master_name = frappe.db.get_single_value("Buying Settings", "supp_master_name")
 	customer_master_name = frappe.db.get_single_value("Selling Settings", "cust_master_name")
 	if supplier_master_name == "Supplier Name" and customer_master_name == "Customer Name":
-		del columns[4:6]
+		del columns[4]
+		columns.insert(1, columns.pop(4))
 	else:
-		del columns[5:7]
+		del columns[5]
+		columns.insert(1, columns.pop(5))
 
 	total_base_amount = 0
 	total_buying_amount = 0


### PR DESCRIPTION
**Issue Statement:**

In the Gross Profit Report, the Item Name is displayed together with the Item Code in the report view, but when the report is exported, only the Item Code is included. Adding a custom Item Name column resolves the issue when Group By = Invoice, but causes blank columns when other Group By views are selected.

**Steps to Replicate the issue:**

1. Open the Gross Profit Report.
2. Set Group By to Invoice.
3. Verify that the report displays the item information as Item Code: Item Name.
4. Export the report.
5. Open the exported file and verify that Item Code is included but Item Name is missing.

**Ref:** [#76959](https://support.frappe.io/helpdesk/tickets/76959?view=VIEW-HD+Ticket-745)

**Before:**

<img width="1246" height="246" alt="Screenshot from 2026-09-01 09-54-42" src="https://github.com/user-attachments/assets/cb139091-1bf5-4ccd-9645-b91172ccf409" />


**After:**
<img width="1246" height="246" alt="image" src="https://github.com/user-attachments/assets/44595359-1f18-4744-9f0d-e04cb0f55767" />


