### PR TITLE
fix: skip non-positive production plan material requests

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/services/material_request.py
+++ b/erpnext/manufacturing/doctype/production_plan/services/material_request.py
@@ -57,14 +57,14 @@ class MaterialRequestService:
 		"""Create Material Requests grouped by Sales Order and Material Request Type"""
 		self.validate_mr_subcontracted()
 
-		if all(item.requested_qty == item.quantity for item in self.doc.mr_items):
+		if all(item.requested_qty >= item.quantity for item in self.doc.mr_items):
 			msgprint(_("All items are already requested"))
 			return
 
 		material_request_map = {}
 		material_request_list = []
 		for item in self.doc.mr_items:
-			if item.quantity == item.requested_qty:
+			if item.quantity <= item.requested_qty:
 				continue
 			self._add_item_to_material_request(item, material_request_map, material_request_list)
 

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -177,6 +177,7 @@ class TestProductionPlan(ERPNextTestSuite):
 				"posting_date": nowdate(),
 				"get_items_from": "Sales Order",
 				"ignore_existing_ordered_qty": 1,
+				"for_warehouse": "_Test Warehouse - _TC",
 			}
 		)
 		pln.append(
@@ -212,6 +213,15 @@ class TestProductionPlan(ERPNextTestSuite):
 			[0, 1],
 			"Cascading failed: first item should consume stock (qty=0), second should need procurement (qty=1)",
 		)
+
+		pln.extend("mr_items", mr_items)
+		pln.submit()
+		pln.make_material_request()
+		material_request_name = frappe.db.get_value(
+			"Material Request Item", {"production_plan": pln.name}, "parent"
+		)
+		material_request = frappe.get_doc("Material Request", material_request_name)
+		self.assertEqual([item.qty for item in material_request.items], [1])
 
 		sr.cancel()
 


### PR DESCRIPTION
Skip non-positive Production Plan rows when creating Material Requests.

Ticket: https://support.frappe.io/helpdesk/tickets/77386?view=VIEW-HD+Ticket-70178