### PR TITLE
fix: handle BOM price list currency update

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -699,7 +699,9 @@ erpnext.bom.BomController = class BomController extends erpnext.TransactionContr
 		get_bom_material_detail(doc, cdt, cdn, secondary_items);
 	}
 
-	buying_price_list(doc) {
+	buying_price_list() {
+		const doc = this.frm.doc;
+
 		if (doc.rm_cost_as_per !== "Price List" && doc.buying_price_list) {
 			this.frm.set_value("buying_price_list", "");
 			return;
@@ -710,8 +712,8 @@ erpnext.bom.BomController = class BomController extends erpnext.TransactionContr
 		}
 	}
 
-	plc_conversion_rate(doc) {
-		if (!this.in_apply_price_list && doc.rm_cost_as_per === "Price List") {
+	plc_conversion_rate() {
+		if (!this.in_apply_price_list && this.frm.doc.rm_cost_as_per === "Price List") {
 			this.apply_price_list(null, true);
 		}
 	}


### PR DESCRIPTION
### Issue

  Creating a new BOM triggers a browser console error because the BOM controller expects a document argument when handling price list currency updates.

  Closes #58635

  ### Steps to reproduce

  1. Go to Manufacturing > BOM.
  2. Create a new BOM.
  3. Select an Item to Manufacture.
  4. Check the browser console.


**Before:** 

<img width="1280" height="640" alt="image" src="https://github.com/user-attachments/assets/85d01f7f-be1d-4b44-8350-1fbdc760b1a1" />


**After:**

<img width="1857" height="929" alt="image" src="https://github.com/user-attachments/assets/bc885e79-ae02-47a3-bd20-71ee14716227" />


  ### Actual behaviour

  The following error appears:

  `TypeError: Cannot read properties of undefined (reading 'rm_cost_as_per')`

  The BOM can still be created and saved.

  ### Expected behaviour

  Selecting an item should update the BOM without producing a browser console error.

  ### Backport needed for V16
