### PR TITLE
fix: skip zero quantity items in production plan material requests

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -887,6 +887,9 @@ class ProductionPlan(Document):
 		material_request_map = {}
 
 		for item in self.mr_items:
+			if not item.quantity:
+				continue
+
 			item_doc = frappe.get_cached_doc("Item", item.item_code)
 
 			material_request_type = item.material_request_type or item_doc.default_material_request_type

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -107,6 +107,19 @@ class TestProductionPlan(FrappeTestCase):
 		pln = frappe.get_doc("Production Plan", pln.name)
 		pln.cancel()
 
+	def test_production_plan_mr_creation_skips_zero_qty(self):
+		pln = create_production_plan(item_code="Test Production Item 1", do_not_submit=1)
+		pln.mr_items[0].quantity = 0
+		pln.save().submit()
+
+		pln.make_material_request()
+
+		quantities = frappe.get_all(
+			"Material Request Item", filters={"production_plan": pln.name}, pluck="qty"
+		)
+		self.assertEqual(len(quantities), len(pln.mr_items) - 1)
+		self.assertNotIn(0, quantities)
+
 	def test_production_plan_start_date(self):
 		"Test if Work Order has same Planned Start Date as Prod Plan."
 		planned_date = add_to_date(date=None, days=3)


### PR DESCRIPTION
Backports the v16/develop behavior to v15. Zero-quantity rows remain in the Production Plan for bin reservation but are skipped when creating Material Requests.

Support ticket: https://support.frappe.io/helpdesk/tickets/77386?view=VIEW-HD+Ticket-70178