### PR TITLE
fix: filter cancelled BOMs in BOM Stock Analysis

### DIFF
--- a/erpnext/manufacturing/report/bom_stock_analysis/bom_stock_analysis.js
+++ b/erpnext/manufacturing/report/bom_stock_analysis/bom_stock_analysis.js
@@ -9,6 +9,7 @@ frappe.query_reports["BOM Stock Analysis"] = {
 			fieldtype: "Link",
 			options: "BOM",
 			reqd: 1,
+			get_query: () => ({ filters: { docstatus: 1 } }),
 		},
 		{
 			fieldname: "warehouse",


### PR DESCRIPTION
Filters the BOM Stock Analysis selector to submitted active BOMs only. 
Ref: https://support.frappe.io/helpdesk/tickets/77459?view=VIEW-HD+Ticket-70178