### PR TITLE
fix(stock): ignore cancelled batch entries in valuation

### DIFF
--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -947,6 +947,7 @@ class BatchNoValuation(DeprecatedBatchNoValuation):
 			& (child.warehouse == self.sle.warehouse)
 			& (child.batch_no.isin(self.batchwise_valuation_batches))
 			& (child.docstatus == 1)
+			& (child.is_cancelled == 0)
 			& (child.type_of_transaction.isin(["Inward", "Outward"]))
 		)
 


### PR DESCRIPTION
  ### Issue

  Cancelled Serial and Batch Entry rows are included while calculating the available batch quantity during Manufacture submission.

  Closes #58650

  ### Steps to reproduce

  1. Receive 12 units of a batch item.
  2. Create a Manufacture Stock Entry consuming 4 units.
  3. Submit and cancel that Stock Entry.
  4. Create another Manufacture Stock Entry consuming 10 units from the same batch.
  5. Submit the new Stock Entry.

  ### Actual behaviour

  The cancelled outward quantity is counted again. ERPNext calculates the remaining quantity as `12 - 4 - 10 = -2` and throws a negative batch stock error.

  ### Expected behaviour

  Cancelled entries should be ignored. ERPNext should calculate the remaining quantity as `12 - 10 = 2` and allow the Stock Entry to be submitted.

**Backport Needed For V16**