### PR TITLE
fix(manufacturing): use item warehouses in production plan work orders

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/services/work_order_planning.py
+++ b/erpnext/manufacturing/doctype/production_plan/services/work_order_planning.py
@@ -232,8 +232,6 @@ class WorkOrderCreationService:
 	def _new_work_order(self, item):
 		wo = frappe.new_doc("Work Order")
 		wo.update(item)
-		if not wo.source_warehouse:
-			wo.source_warehouse = item.get("fg_warehouse")
 
 		wo.reserve_stock = self.doc.reserve_stock
 		wo.planned_start_date = item.get("planned_start_date") or item.get("schedule_date")
@@ -241,7 +239,7 @@ class WorkOrderCreationService:
 			wo.fg_warehouse = item.get("warehouse")
 
 		wo.set_work_order_operations()
-		wo.set_required_items(reset_source_warehouse=True)
+		wo.set_required_items()
 		return wo
 
 

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -128,6 +128,57 @@ class TestProductionPlan(ERPNextTestSuite):
 		plan.reload()
 		plan.cancel()
 
+	def test_subassembly_work_order_uses_raw_material_default_warehouses(self):
+		raw_material_warehouses = {
+			make_item(
+				properties={
+					"is_stock_item": 1,
+					"item_defaults": [
+						{"company": "_Test Company", "default_warehouse": "_Test Warehouse - _TC"}
+					],
+				}
+			).name: "_Test Warehouse - _TC",
+			make_item(
+				properties={
+					"is_stock_item": 1,
+					"item_defaults": [
+						{"company": "_Test Company", "default_warehouse": "_Test Warehouse 1 - _TC"}
+					],
+				}
+			).name: "_Test Warehouse 1 - _TC",
+		}
+		subassembly_item = make_item(properties={"is_stock_item": 1}).name
+		finished_item = make_item(properties={"is_stock_item": 1}).name
+
+		make_bom(item=subassembly_item, raw_materials=raw_material_warehouses)
+		make_bom(item=finished_item, raw_materials=[subassembly_item])
+
+		plan = create_production_plan(
+			item_code=finished_item,
+			warehouse="Finished Goods - _TC",
+			sub_assembly_warehouse="Finished Goods - _TC",
+			skip_available_sub_assembly_item=1,
+			skip_getting_mr_items=1,
+			do_not_submit=1,
+		)
+		plan.get_sub_assembly_items()
+		plan.save()
+		plan.submit()
+		plan.make_work_order()
+
+		work_order_name = frappe.db.get_value(
+			"Work Order",
+			{"production_plan": plan.name, "production_item": subassembly_item},
+		)
+		work_order = frappe.get_doc("Work Order", work_order_name)
+
+		self.assertFalse(work_order.source_warehouse)
+		self.assertEqual(work_order.fg_warehouse, plan.sub_assembly_warehouse)
+		self.assertEqual(
+			{row.item_code: row.source_warehouse for row in work_order.required_items},
+			raw_material_warehouses,
+		)
+
 	def test_production_plan_for_existing_ordered_qty(self):
 		"""
 		- Enable 'ignore_existing_ordered_qty'.


### PR DESCRIPTION
  ### Issue

-  Work Orders created from a Production Plan use the sub-assembly Target Warehouse as the Source Warehouse when the BOM has no Default Source Warehouse.

-  This also assigns the same Source Warehouse to every Required Item, even when the raw materials have different default warehouses.

  Closes #58658

  ### Steps to reproduce

  1. Create two raw material items with different default warehouses.
  2. Create a sub-assembly BOM containing both raw materials.
  3. Add the sub-assembly to a finished-goods BOM.
  4. Create a Production Plan and set a Sub-assembly Warehouse.
  5. Create Work Orders from the Production Plan.
  6. Check the Source Warehouse of each Required Item in the sub-assembly Work Order.

  ### Actual behaviour

 - The sub-assembly Target Warehouse is copied to the Work Order Source Warehouse. Consequently, every Required Item uses the same warehouse and its own configured default is ignored.

  ### Expected behaviour

 - When the BOM has no Default Source Warehouse, each Required Item should independently resolve its Source Warehouse from its BOM row, Item Default, or Item Group Default.

 - This allows raw materials belonging to different warehouses to be handled correctly. The Production Plan's Sub-assembly Warehouse should continue to be used as
  the Work Order Target Warehouse.

**Backport Needed For V16** 