### PR TITLE
ci: allow shallow fetch when fast-forwarding the cached bench

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -188,7 +188,7 @@ restore_warm_bench() {
         # Phase 1 already fetched ~/frappe to the exact live develop SHA. Fetch that commit
         # straight from it (bench init names the remote 'upstream', not 'origin', and points
         # it at this local clone — so a plain `git fetch origin` does not work).
-        git fetch --no-tags "$HOME/frappe" HEAD || exit 1
+        git fetch --no-tags --update-shallow "$HOME/frappe" HEAD || exit 1
         git checkout --force FETCH_HEAD || exit 1
     ); then
         echo "Fast-forward to ${frappe_sha} failed; falling back to full init"

--- a/erpnext/controllers/subcontracting_inward_controller.py
+++ b/erpnext/controllers/subcontracting_inward_controller.py
@@ -4,7 +4,6 @@ import frappe
 from frappe import _, bold
 from frappe.query_builder import Case
 from frappe.utils import flt, get_link_to_form
-from pypika.terms import ValueWrapper
 
 from erpnext.stock.serial_batch_bundle import get_serial_batch_list_from_item
 
@@ -509,21 +508,13 @@ class SubcontractingInwardController:
 				)
 
 			table = frappe.qb.DocType("Subcontracting Inward Order Item")
+			allowed_qty = table.produced_qty
+			if not allow_delivery_of_overproduced_qty:
+				allowed_qty = Case().when(table.produced_qty < table.qty, table.produced_qty).else_(table.qty)
+
 			query = (
 				frappe.qb.from_(table)
-				.select(
-					(
-						Case()
-						.when(
-							# bool() so the literal renders as true/false; postgres rejects `OR <integer>`
-							(table.produced_qty < table.qty)
-							| ValueWrapper(bool(allow_delivery_of_overproduced_qty)),
-							table.produced_qty,
-						)
-						.else_(table.qty)
-						- table.delivered_qty
-					).as_("max_allowed_qty")
-				)
+				.select((allowed_qty - table.delivered_qty).as_("max_allowed_qty"))
 				.where((table.name == item.scio_detail) & (table.docstatus == 1))
 			)
 			max_allowed_qty = query.run(pluck="max_allowed_qty")


### PR DESCRIPTION
Both `~/frappe` (fetched with `--depth 1`) and the cached bench's `apps/frappe` are shallow. Once frappe develop moves past the baked base SHA, git rejects the fetch with "shallow roots are not allowed to be updated", `FETCH_HEAD` is never written and the checkout fails. The warm path then falls back to a full init, which also died because `rm -rf` could not empty `apps/frappe` ("Directory not empty") and `bench init` refused the leftover directory.

`--update-shallow` lets the fetch extend the shallow boundary so the warm bench fast-forwards as intended.

Second commit fixes the Postgres failure the repaired job then surfaced: `validate_delivery_on_save` built `produced_qty < qty OR <literal>` from the Selling Settings flag, and frappe's value wrapper renders a Python bool as `0`, so Postgres rejected it with "argument of OR must be type boolean". The query now branches in Python instead of embedding a literal. Same values on MariaDB.

Seen on #58664 (Server (Postgres), Build & reinstall) and in the nightly Postgres run.