### PR TITLE
fix(crm): validate contact email before saving an email campaign

### DIFF
--- a/erpnext/crm/doctype/email_campaign/email_campaign.py
+++ b/erpnext/crm/doctype/email_campaign/email_campaign.py
@@ -29,11 +29,18 @@ class EmailCampaign(Document):
 
 	def validate(self):
 		self.set_date()
-		# checking if email is set for lead. Not checking for contact as email is a mandatory field for contact.
-		if self.email_campaign_for == "Lead":
-			self.validate_lead()
+		self.validate_recipient_email()
 		self.validate_email_campaign_already_exists()
 		self.update_status()
+
+	def validate_recipient_email(self):
+		if not self.recipient:
+			return
+
+		if self.email_campaign_for == "Lead":
+			self.validate_lead()
+		elif self.email_campaign_for == "Contact":
+			self.validate_contact()
 
 	def set_date(self):
 		if getdate(self.start_date) < getdate(today()):
@@ -55,6 +62,12 @@ class EmailCampaign(Document):
 		if not lead_email_id:
 			lead_name = frappe.db.get_value("Lead", self.recipient, "lead_name")
 			frappe.throw(_("Please set an email id for the Lead {0}").format(lead_name))
+
+	def validate_contact(self):
+		contact_email_id = frappe.db.get_value("Contact", self.recipient, "email_id")
+		if not contact_email_id:
+			full_name = frappe.db.get_value("Contact", self.recipient, "full_name")
+			frappe.throw(_("Please set a primary email id for the Contact {0}").format(full_name))
 
 	def validate_email_campaign_already_exists(self):
 		email_campaign_exists = frappe.db.exists(

--- a/erpnext/crm/doctype/email_campaign/email_campaign.py
+++ b/erpnext/crm/doctype/email_campaign/email_campaign.py
@@ -64,10 +64,11 @@ class EmailCampaign(Document):
 			frappe.throw(_("Please set an email id for the Lead {0}").format(lead_name))
 
 	def validate_contact(self):
-		contact_email_id = frappe.db.get_value("Contact", self.recipient, "email_id")
-		if not contact_email_id:
-			full_name = frappe.db.get_value("Contact", self.recipient, "full_name")
-			frappe.throw(_("Please set a primary email id for the Contact {0}").format(full_name))
+		contact = frappe.db.get_value("Contact", self.recipient, ["email_id", "full_name"], as_dict=True)
+		if contact and not contact.email_id:
+			frappe.throw(
+				_("Please set a primary email ID for the Contact {0}").format(frappe.bold(contact.full_name))
+			)
 
 	def validate_email_campaign_already_exists(self):
 		email_campaign_exists = frappe.db.exists(

--- a/erpnext/crm/doctype/email_campaign/test_email_campaign.py
+++ b/erpnext/crm/doctype/email_campaign/test_email_campaign.py
@@ -59,3 +59,26 @@ class TestEmailCampaign(ERPNextTestSuite):
 		doc.email_campaign_for = "Lead"
 		doc.recipient = lead.name
 		self.assertRaises(frappe.ValidationError, doc.validate_lead)
+
+	def test_contact_without_an_email_is_rejected(self):
+		contact = frappe.get_doc({"doctype": "Contact", "first_name": "_Test Contact No Email"}).insert()
+		campaign = self.make_campaign(schedules=[0])
+		doc = self.make_email_campaign(campaign.name)
+		doc.email_campaign_for = "Contact"
+		doc.recipient = contact.name
+		self.assertRaisesRegex(frappe.ValidationError, "primary email id", doc.insert)
+
+	def test_contact_with_an_email_is_accepted(self):
+		contact = frappe.get_doc(
+			{
+				"doctype": "Contact",
+				"first_name": "_Test Contact With Email",
+				"email_ids": [{"email_id": "_test_email_campaign@example.com", "is_primary": 1}],
+			}
+		).insert()
+		campaign = self.make_campaign(schedules=[0])
+		doc = self.make_email_campaign(campaign.name)
+		doc.email_campaign_for = "Contact"
+		doc.recipient = contact.name
+		doc.insert()
+		self.assertEqual(doc.status, "In Progress")

--- a/erpnext/crm/doctype/email_campaign/test_email_campaign.py
+++ b/erpnext/crm/doctype/email_campaign/test_email_campaign.py
@@ -66,7 +66,7 @@ class TestEmailCampaign(ERPNextTestSuite):
 		doc = self.make_email_campaign(campaign.name)
 		doc.email_campaign_for = "Contact"
 		doc.recipient = contact.name
-		self.assertRaisesRegex(frappe.ValidationError, "primary email id", doc.insert)
+		self.assertRaisesRegex(frappe.ValidationError, "primary email ID", doc.insert)
 
 	def test_contact_with_an_email_is_accepted(self):
 		contact = frappe.get_doc(


### PR DESCRIPTION
Email Campaign validates the recipient's email address only when the recipient is a Lead. Contact was skipped on the assumption written into the comment there, that email is mandatory on Contact. It isn't; `Contact.email_id` is read only and derived from the `email_ids` child table by `set_primary_email`, so it stays empty when the contact has no email rows at all, and also when it has several and none is marked primary.

A campaign for such a contact saves and moves to In Progress, then silently does nothing. The daily job reads that same empty `email_id` in `send_mail`, writes an Error Log and returns, so no Communication and no Email Queue entry is created and the campaign sits In Progress until its end date passes. Contact recipients now get the same save time check Leads already had, where the problem is still fixable by the person creating the campaign.

The recipient guard moved into `validate_recipient_email` so that saving with no recipient reports the mandatory field error rather than an email message naming nothing.

---

Ref: https://support.frappe.io/helpdesk/tickets/76704