### PR TITLE
fix(stock): assign batch_no only when the first batch covers the full qty

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -336,7 +336,9 @@ def update_stock(ctx, out, doc=None):
 					out.update({"rate": rate, "price_list_rate": rate})
 
 		if out.has_serial_no and out.has_batch_no and has_incorrect_serial_nos(ctx, out):
-			kwargs["batches"] = [ctx.get("batch_no")] if ctx.get("batch_no") else [out.get("batch_no")]
+			batch_no = ctx.get("batch_no") or out.get("batch_no")
+			if batch_no:
+				kwargs["batches"] = [batch_no]
 			serial_nos = get_serial_nos_for_outward(kwargs)
 			serial_nos = get_filtered_serial_nos(serial_nos, doc)
 

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -292,7 +292,6 @@ def set_valuation_rate(out: frappe._dict, ctx: frappe._dict):
 
 
 def update_stock(ctx, out, doc=None):
-	from erpnext.stock.doctype.batch.batch import get_available_batches
 	from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos_for_outward
 
 	if (
@@ -325,27 +324,14 @@ def update_stock(ctx, out, doc=None):
 		if ctx.get("ignore_serial_nos"):
 			kwargs["ignore_serial_nos"] = ctx.get("ignore_serial_nos")
 
-		qty = out.stock_qty
-		batches = []
 		if out.has_batch_no and not ctx.get("batch_no"):
-			batches = get_available_batches(kwargs)
-			if doc:
-				filter_batches(batches, doc)
-
-			for batch_no, batch_qty in batches.items():
+			batch_no = get_batch_no_covering_qty(kwargs, doc, out.stock_qty)
+			if batch_no:
+				out.update({"batch_no": batch_no, "actual_batch_qty": out.stock_qty})
 				rate = get_batch_based_item_price(
 					{"price_list": doc.get("selling_price_list"), "uom": out.uom, "batch_no": batch_no},
 					out.item_code,
 				)
-				if batch_qty >= qty:
-					out.update({"batch_no": batch_no, "actual_batch_qty": qty})
-					if rate:
-						out.update({"rate": rate, "price_list_rate": rate})
-					break
-				else:
-					qty -= batch_qty
-
-				out.update({"batch_no": batch_no, "actual_batch_qty": batch_qty})
 				if rate:
 					out.update({"rate": rate, "price_list_rate": rate})
 
@@ -374,6 +360,20 @@ def has_incorrect_serial_nos(ctx, out):
 		return True
 
 	return False
+
+
+def get_batch_no_covering_qty(kwargs, doc, qty):
+	from erpnext.stock.doctype.batch.batch import get_available_batches
+
+	batches = get_available_batches(frappe._dict(kwargs, qty=0))
+	if doc:
+		filter_batches(batches, doc)
+
+	batch_no = next(iter(batches), None)
+	if batch_no and flt(batches[batch_no]) >= flt(qty):
+		return batch_no
+
+	return None
 
 
 def filter_batches(batches, doc):

--- a/erpnext/stock/tests/test_get_item_details.py
+++ b/erpnext/stock/tests/test_get_item_details.py
@@ -520,3 +520,30 @@ class TestGetItemDetail(ERPNextTestSuite):
 				"Serial and Batch Entry", {"parent": dn.items[0].serial_and_batch_bundle}, ["batch_no", "qty"]
 			)
 			self.assertEqual({d.batch_no: d.qty for d in entries}, {batches[0]: -2, batches[1]: -3})
+
+	def test_serial_nos_picked_across_batches_when_no_batch_covers_qty(self):
+		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
+		from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle import (
+			get_serial_nos_from_bundle,
+		)
+
+		item_code, batches = self.make_batched_item_with_stock(
+			[2, 3], has_serial_no=1, serial_no_series="FBQ-SN-.#####"
+		)
+
+		with self.change_settings(
+			"Stock Settings",
+			{"pick_serial_and_batch_based_on": "FIFO", "auto_create_serial_and_batch_bundle_for_outward": 1},
+		):
+			details = self.get_item_details_for_row(item_code, 5)
+			self.assertIsNone(details.get("batch_no"))
+			serial_nos = details.serial_no.split("\n")
+			self.assertEqual(len(serial_nos), 5)
+
+			dn = create_delivery_note(
+				item_code=item_code, qty=5, use_serial_batch_fields=1, serial_no=details.serial_no
+			)
+			dn.reload()
+			self.assertEqual(
+				get_serial_nos_from_bundle(dn.items[0].serial_and_batch_bundle), sorted(serial_nos)
+			)

--- a/erpnext/stock/tests/test_get_item_details.py
+++ b/erpnext/stock/tests/test_get_item_details.py
@@ -1,5 +1,4 @@
 import frappe
-from frappe.utils import add_days
 
 from erpnext.stock.get_item_details import get_item_details
 from erpnext.tests.utils import ERPNextTestSuite
@@ -459,136 +458,65 @@ class TestGetItemDetail(ERPNextTestSuite):
 			frappe.db.set_single_value("Buying Settings", "maintain_same_rate", original)
 			frappe.clear_cache(doctype="Buying Settings")
 
-	def _setup_batch_item_with_stock(self, batches):
+	def make_batched_item_with_stock(self, quantities, uoms=None, **properties):
 		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle import (
+			get_batch_from_bundle,
+		)
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 
-		item = make_item(
-			properties={
-				"is_stock_item": 1,
-				"has_batch_no": 1,
-				"create_new_batch": 1,
-				"batch_number_series": "FEFO-TAP-.#####",
-			},
-		)
-
-		for qty, expiry_date in batches:
+		properties.update({"has_batch_no": 1, "create_new_batch": 1, "batch_number_series": "FBQ-.#####"})
+		item_code = make_item(properties=properties, uoms=uoms).name
+		batches = []
+		for qty in quantities:
 			se = make_stock_entry(
-				item_code=item.name,
-				target="_Test Warehouse - _TC",
-				qty=qty,
-				rate=100,
-				purpose="Material Receipt",
+				item_code=item_code, target="_Test Warehouse - _TC", qty=qty, basic_rate=100
 			)
-			batch_no = se.items[0].batch_no or frappe.db.get_value(
-				"Serial and Batch Entry", {"parent": se.items[0].serial_and_batch_bundle}, "batch_no"
-			)
-			frappe.db.set_value("Batch", batch_no, "expiry_date", expiry_date)
+			batches.append(get_batch_from_bundle(se.items[0].serial_and_batch_bundle))
 
-		return item.name
+		return item_code, batches
 
-	def _get_delivery_note_context(self, item_code, qty):
+	def get_item_details_for_row(self, item_code, qty, items=None):
 		ctx = frappe._dict(
 			{
-				"item_code": item_code,
 				"doctype": "Delivery Note",
-				"warehouse": "_Test Warehouse - _TC",
+				"item_code": item_code,
 				"company": "_Test Company",
+				"warehouse": "_Test Warehouse - _TC",
 				"qty": qty,
-				"stock_qty": qty,
-				"conversion_factor": 1,
 				"use_serial_batch_fields": 1,
-				"update_stock": 1,
+				"price_list": "_Test Price List",
 				"currency": "INR",
 				"conversion_rate": 1.0,
-				"price_list": "_Test Price List",
 				"price_list_currency": "INR",
 				"plc_conversion_rate": 1.0,
-				"transaction_date": None,
-				"name": None,
 				"ignore_pricing_rule": 1,
 			}
 		)
-		return ctx
+		doc = {"doctype": "Delivery Note", "selling_price_list": "_Test Price List", "items": items or []}
+		return get_item_details(ctx, doc=doc)
 
-	def test_expiry_based_pick_spans_multiple_batches(self):
-		original_based_on = frappe.db.get_single_value("Stock Settings", "pick_serial_and_batch_based_on")
-		original_auto_create = frappe.db.get_single_value(
-			"Stock Settings", "auto_create_serial_and_batch_bundle_for_outward"
-		)
-		frappe.db.set_single_value("Stock Settings", "pick_serial_and_batch_based_on", "Expiry")
-		frappe.db.set_single_value("Stock Settings", "auto_create_serial_and_batch_bundle_for_outward", 1)
+	def get_picked_batch_no(self, item_code, qty, items=None):
+		return self.get_item_details_for_row(item_code, qty, items).get("batch_no")
 
-		try:
-			item_code = self._setup_batch_item_with_stock(
-				[(2, add_days(None, 3)), (3, add_days(None, 9)), (14, add_days(None, 30))]
-			)
+	def test_batch_no_set_only_when_first_batch_covers_qty(self):
+		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
 
-			single_batch_details = get_item_details(
-				self._get_delivery_note_context(item_code, 2),
-				doc={"doctype": "Delivery Note", "selling_price_list": "_Test Price List", "items": []},
-			)
-			self.assertIsNotNone(single_batch_details.get("batch_no"))
+		item_code, batches = self.make_batched_item_with_stock([2, 3, 14])
+		first_batch_row = [{"batch_no": batches[0], "qty": 2, "stock_qty": 2}]
 
-			next_batch_details = get_item_details(
-				self._get_delivery_note_context(item_code, 3),
-				doc={
-					"doctype": "Delivery Note",
-					"selling_price_list": "_Test Price List",
-					"items": [{"batch_no": single_batch_details.batch_no, "qty": 2}],
-				},
-			)
-			self.assertIsNotNone(next_batch_details.get("batch_no"))
-			self.assertNotEqual(
-				next_batch_details.batch_no,
-				single_batch_details.batch_no,
-			)
+		with self.change_settings(
+			"Stock Settings",
+			{"pick_serial_and_batch_based_on": "FIFO", "auto_create_serial_and_batch_bundle_for_outward": 1},
+		):
+			self.assertEqual(self.get_picked_batch_no(item_code, 2), batches[0])
+			self.assertEqual(self.get_picked_batch_no(item_code, 3, items=first_batch_row), batches[1])
+			self.assertIsNone(self.get_picked_batch_no(item_code, 5))
+			self.assertIsNone(self.get_picked_batch_no(item_code, 20))
 
-			multiple_batch_details = get_item_details(
-				self._get_delivery_note_context(item_code, 5),
-				doc={"doctype": "Delivery Note", "selling_price_list": "_Test Price List", "items": []},
-			)
-			self.assertIsNone(multiple_batch_details.get("batch_no"))
-
-			insufficient_details = get_item_details(
-				self._get_delivery_note_context(item_code, 20),
-				doc={"doctype": "Delivery Note", "selling_price_list": "_Test Price List", "items": []},
-			)
-			self.assertIsNone(insufficient_details.get("batch_no"))
-
-			dn = frappe.get_doc(
-				{
-					"doctype": "Delivery Note",
-					"customer": "_Test Customer",
-					"company": "_Test Company",
-					"selling_price_list": "_Test Price List",
-					"currency": "INR",
-					"items": [
-						{
-							"item_code": item_code,
-							"qty": 5,
-							"rate": 100,
-							"warehouse": "_Test Warehouse - _TC",
-							"use_serial_batch_fields": 1,
-						}
-					],
-				}
-			)
-			dn.insert()
-			dn.submit()
+			dn = create_delivery_note(item_code=item_code, qty=5, use_serial_batch_fields=1)
 			dn.reload()
-
 			entries = frappe.get_all(
-				"Serial and Batch Entry",
-				filters={"parent": dn.items[0].serial_and_batch_bundle},
-				fields=["batch_no", "qty"],
-				order_by="idx",
+				"Serial and Batch Entry", {"parent": dn.items[0].serial_and_batch_bundle}, ["batch_no", "qty"]
 			)
-			self.assertEqual(len(entries), 2)
-			self.assertEqual(abs(entries[0].qty), 2)
-			self.assertEqual(abs(entries[1].qty), 3)
-		finally:
-			frappe.db.set_single_value("Stock Settings", "pick_serial_and_batch_based_on", original_based_on)
-			frappe.db.set_single_value(
-				"Stock Settings", "auto_create_serial_and_batch_bundle_for_outward", original_auto_create
-			)
+			self.assertEqual({d.batch_no: d.qty for d in entries}, {batches[0]: -2, batches[1]: -3})

--- a/erpnext/stock/tests/test_get_item_details.py
+++ b/erpnext/stock/tests/test_get_item_details.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.utils import add_days
 
 from erpnext.stock.get_item_details import get_item_details
 from erpnext.tests.utils import ERPNextTestSuite
@@ -457,3 +458,137 @@ class TestGetItemDetail(ERPNextTestSuite):
 			frappe.set_user("Administrator")
 			frappe.db.set_single_value("Buying Settings", "maintain_same_rate", original)
 			frappe.clear_cache(doctype="Buying Settings")
+
+	def _setup_batch_item_with_stock(self, batches):
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+
+		item = make_item(
+			properties={
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "FEFO-TAP-.#####",
+			},
+		)
+
+		for qty, expiry_date in batches:
+			se = make_stock_entry(
+				item_code=item.name,
+				target="_Test Warehouse - _TC",
+				qty=qty,
+				rate=100,
+				purpose="Material Receipt",
+			)
+			batch_no = se.items[0].batch_no or frappe.db.get_value(
+				"Serial and Batch Entry", {"parent": se.items[0].serial_and_batch_bundle}, "batch_no"
+			)
+			frappe.db.set_value("Batch", batch_no, "expiry_date", expiry_date)
+
+		return item.name
+
+	def _get_delivery_note_context(self, item_code, qty):
+		ctx = frappe._dict(
+			{
+				"item_code": item_code,
+				"doctype": "Delivery Note",
+				"warehouse": "_Test Warehouse - _TC",
+				"company": "_Test Company",
+				"qty": qty,
+				"stock_qty": qty,
+				"conversion_factor": 1,
+				"use_serial_batch_fields": 1,
+				"update_stock": 1,
+				"currency": "INR",
+				"conversion_rate": 1.0,
+				"price_list": "_Test Price List",
+				"price_list_currency": "INR",
+				"plc_conversion_rate": 1.0,
+				"transaction_date": None,
+				"name": None,
+				"ignore_pricing_rule": 1,
+			}
+		)
+		return ctx
+
+	def test_expiry_based_pick_spans_multiple_batches(self):
+		original_based_on = frappe.db.get_single_value("Stock Settings", "pick_serial_and_batch_based_on")
+		original_auto_create = frappe.db.get_single_value(
+			"Stock Settings", "auto_create_serial_and_batch_bundle_for_outward"
+		)
+		frappe.db.set_single_value("Stock Settings", "pick_serial_and_batch_based_on", "Expiry")
+		frappe.db.set_single_value("Stock Settings", "auto_create_serial_and_batch_bundle_for_outward", 1)
+
+		try:
+			item_code = self._setup_batch_item_with_stock(
+				[(2, add_days(None, 3)), (3, add_days(None, 9)), (14, add_days(None, 30))]
+			)
+
+			single_batch_details = get_item_details(
+				self._get_delivery_note_context(item_code, 2),
+				doc={"doctype": "Delivery Note", "selling_price_list": "_Test Price List", "items": []},
+			)
+			self.assertIsNotNone(single_batch_details.get("batch_no"))
+
+			next_batch_details = get_item_details(
+				self._get_delivery_note_context(item_code, 3),
+				doc={
+					"doctype": "Delivery Note",
+					"selling_price_list": "_Test Price List",
+					"items": [{"batch_no": single_batch_details.batch_no, "qty": 2}],
+				},
+			)
+			self.assertIsNotNone(next_batch_details.get("batch_no"))
+			self.assertNotEqual(
+				next_batch_details.batch_no,
+				single_batch_details.batch_no,
+			)
+
+			multiple_batch_details = get_item_details(
+				self._get_delivery_note_context(item_code, 5),
+				doc={"doctype": "Delivery Note", "selling_price_list": "_Test Price List", "items": []},
+			)
+			self.assertIsNone(multiple_batch_details.get("batch_no"))
+
+			insufficient_details = get_item_details(
+				self._get_delivery_note_context(item_code, 20),
+				doc={"doctype": "Delivery Note", "selling_price_list": "_Test Price List", "items": []},
+			)
+			self.assertIsNone(insufficient_details.get("batch_no"))
+
+			dn = frappe.get_doc(
+				{
+					"doctype": "Delivery Note",
+					"customer": "_Test Customer",
+					"company": "_Test Company",
+					"selling_price_list": "_Test Price List",
+					"currency": "INR",
+					"items": [
+						{
+							"item_code": item_code,
+							"qty": 5,
+							"rate": 100,
+							"warehouse": "_Test Warehouse - _TC",
+							"use_serial_batch_fields": 1,
+						}
+					],
+				}
+			)
+			dn.insert()
+			dn.submit()
+			dn.reload()
+
+			entries = frappe.get_all(
+				"Serial and Batch Entry",
+				filters={"parent": dn.items[0].serial_and_batch_bundle},
+				fields=["batch_no", "qty"],
+				order_by="idx",
+			)
+			self.assertEqual(len(entries), 2)
+			self.assertEqual(abs(entries[0].qty), 2)
+			self.assertEqual(abs(entries[1].qty), 3)
+		finally:
+			frappe.db.set_single_value("Stock Settings", "pick_serial_and_batch_based_on", original_based_on)
+			frappe.db.set_single_value(
+				"Stock Settings", "auto_create_serial_and_batch_bundle_for_outward", original_auto_create
+			)


### PR DESCRIPTION
When automatic outward Serial and Batch Bundle creation is enabled, the auto-pick loop reduced the requested qty per batch and left the last visited batch on the row. A qty spanning batches got a batch that could not fulfil it and submit failed with a misleading negative-stock error.

Assign the first batch in pick order only when it alone covers the qty. Otherwise leave `batch_no` empty so the auto-created bundle splits the qty across batches at submit.

Batches are queried without `qty` so `filter_batches` subtracts same-document rows from uncapped quantities. Querying a copy also stops `get_auto_batch_nos` from clearing `warehouse` on the kwargs later used to pick serial nos.

For serialised and batched items, an empty `batch_no` used to make the serial pick filter on `[None]` and return nothing. The serial pick now skips the batch filter when no batch is set, so serial nos are picked in the configured order across batches and the bundle built at submit derives each serial's batch.

POS Invoice requires `batch_no` on rows with `use_serial_batch_fields`, so there a qty spanning batches now fails at save with "Please select Batch No" instead of negative stock at submit.

Alternative to #58661. Supersedes #58664 (moved to an origin branch so a stack can build on it). Needs backport to version-16-hotfix.

Fixes #58640