### PR TITLE
fix(stock): subtract stock qty of same-document rows from batch availability

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -381,7 +381,7 @@ def get_batch_no_covering_qty(kwargs, doc, qty):
 def filter_batches(batches, doc):
 	for row in doc.get("items"):
 		if row.get("batch_no") in batches:
-			batches[row.get("batch_no")] -= row.get("qty")
+			batches[row.get("batch_no")] -= flt(row.get("stock_qty"))
 			if batches[row.get("batch_no")] <= 0:
 				del batches[row.get("batch_no")]
 

--- a/erpnext/stock/tests/test_get_item_details.py
+++ b/erpnext/stock/tests/test_get_item_details.py
@@ -547,3 +547,16 @@ class TestGetItemDetail(ERPNextTestSuite):
 			self.assertEqual(
 				get_serial_nos_from_bundle(dn.items[0].serial_and_batch_bundle), sorted(serial_nos)
 			)
+
+	def test_same_document_rows_reduce_batch_by_stock_qty(self):
+		item_code, batches = self.make_batched_item_with_stock(
+			[10], uoms=[{"uom": "Box", "conversion_factor": 5}]
+		)
+		box_row = [{"batch_no": batches[0], "uom": "Box", "qty": 1, "stock_qty": 5}]
+
+		with self.change_settings(
+			"Stock Settings",
+			{"pick_serial_and_batch_based_on": "FIFO", "auto_create_serial_and_batch_bundle_for_outward": 1},
+		):
+			self.assertEqual(self.get_picked_batch_no(item_code, 5, items=box_row), batches[0])
+			self.assertIsNone(self.get_picked_batch_no(item_code, 6, items=box_row))


### PR DESCRIPTION
`filter_batches` subtracted a row's transaction-UOM `qty` from batch quantities that are in the stock UOM, so a row in an alternate UOM freed less of the batch than it consumes and the auto-pick could assign a batch that cannot cover the new row.

Subtract `stock_qty` instead. Flagged in the review of the PR below this one.