### PR TITLE
 feat(accounts): allow filtering reports by blank accounting dimensions

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -311,11 +311,16 @@ def get_dimension_with_children(doctype, dimensions):
 def get_dimension_filter_values(values, dimension_doctype=None):
 	if isinstance(values, str):
 		try:
-			values = json.loads(values)
+			parsed_values = json.loads(values)
 		except json.JSONDecodeError:
-			values = [values]
+			pass
+		else:
+			if isinstance(parsed_values, list):
+				values = parsed_values
 
-	if not isinstance(values, list | tuple):
+	if values is None:
+		values = []
+	elif not isinstance(values, list | tuple):
 		values = [values]
 
 	include_blank = BLANK_ACCOUNTING_DIMENSION in values

--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -16,6 +16,9 @@ from erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger 
 	get_allowed_types_from_settings,
 )
 
+# Document names cannot contain ">", so this cannot collide with a dimension value.
+BLANK_ACCOUNTING_DIMENSION = "__blank__>"
+
 
 class AccountingDimension(Document):
 	# begin: auto-generated types
@@ -303,6 +306,49 @@ def get_dimension_with_children(doctype, dimensions):
 		all_dimensions += [c.name for c in children]
 
 	return all_dimensions
+
+
+def get_dimension_filter_values(values, dimension_doctype=None):
+	if isinstance(values, str):
+		try:
+			values = json.loads(values)
+		except json.JSONDecodeError:
+			values = [values]
+
+	if not isinstance(values, list | tuple):
+		values = [values]
+
+	include_blank = BLANK_ACCOUNTING_DIMENSION in values
+	values = [value for value in values if value != BLANK_ACCOUNTING_DIMENSION]
+
+	if values and dimension_doctype and frappe.get_cached_value("DocType", dimension_doctype, "is_tree"):
+		values = get_dimension_with_children(dimension_doctype, values)
+
+	return values, include_blank
+
+
+def get_dimension_filter_condition(field, values, dimension_doctype=None):
+	values, include_blank = get_dimension_filter_values(values, dimension_doctype)
+	condition = field.isin(values) if values else None
+
+	if include_blank:
+		blank_condition = field.isnull() | (field == "")
+		condition = condition | blank_condition if condition else blank_condition
+
+	return condition
+
+
+def get_dimension_filter_sql_condition(fieldname, values, dimension_doctype=None):
+	values, include_blank = get_dimension_filter_values(values, dimension_doctype)
+	parts = []
+
+	if values:
+		parts.append(f"{fieldname} IN ({', '.join(['?'] * len(values))})")
+
+	if include_blank:
+		parts.append(f"({fieldname} IS NULL OR {fieldname} = '')")
+
+	return f"({' OR '.join(parts)})" if parts else None, values
 
 
 @frappe.whitelist()

--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -6,6 +6,7 @@ import frappe
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	BLANK_ACCOUNTING_DIMENSION,
 	get_dimension_filter_sql_condition,
+	get_dimension_filter_values,
 )
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
@@ -24,6 +25,17 @@ class TestAccountingDimension(ERPNextTestSuite):
 			"(department IN (?) OR (department IS NULL OR department = ''))",
 		)
 		self.assertEqual(values, ["_Test Department - _TC"])
+
+	def test_dimension_filter_values_preserve_plain_string_names(self):
+		values, include_blank = get_dimension_filter_values("null")
+
+		self.assertEqual(values, ["null"])
+		self.assertFalse(include_blank)
+
+		values, include_blank = get_dimension_filter_values("__blank__")
+
+		self.assertEqual(values, ["__blank__"])
+		self.assertFalse(include_blank)
 
 	def test_dimension_against_sales_invoice(self):
 		si = create_sales_invoice(do_not_save=1)

--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -3,12 +3,28 @@
 
 import frappe
 
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+	BLANK_ACCOUNTING_DIMENSION,
+	get_dimension_filter_sql_condition,
+)
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestAccountingDimension(ERPNextTestSuite):
+	def test_blank_dimension_filter_sql_condition(self):
+		condition, values = get_dimension_filter_sql_condition(
+			"department",
+			f'["_Test Department - _TC", "{BLANK_ACCOUNTING_DIMENSION}"]',
+		)
+
+		self.assertEqual(
+			condition,
+			"(department IN (?) OR (department IS NULL OR department = ''))",
+		)
+		self.assertEqual(values, ["_Test Department - _TC"])
+
 	def test_dimension_against_sales_invoice(self):
 		si = create_sales_invoice(do_not_save=1)
 

--- a/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
+++ b/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
@@ -22,7 +22,7 @@ from pypika.terms import Bracket, LiteralValue
 from erpnext import get_company_currency
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
-	get_dimension_with_children,
+	get_dimension_filter_condition,
 )
 from erpnext.accounts.doctype.financial_report_row.financial_report_row import FinancialReportRow
 from erpnext.accounts.doctype.financial_report_template.financial_report_template import (
@@ -35,7 +35,6 @@ from erpnext.accounts.doctype.financial_report_template.financial_report_validat
 )
 from erpnext.accounts.report.financial_statements import (
 	get_columns,
-	get_cost_centers_with_children,
 	get_period_list,
 )
 from erpnext.accounts.utils import get_children, get_currency_precision
@@ -743,14 +742,14 @@ class FinancialQueryBuilder:
 		query = query.where(~is_pcv | table.account.isin(closing_heads))
 
 		if self.filters.get("project"):
-			projects = self.filters.get("project")
-			if isinstance(projects, str):
-				projects = [projects]
-			query = query.where(table.project.isin(projects))
+			query = query.where(
+				get_dimension_filter_condition(table.project, self.filters.project, "Project")
+			)
 
 		if self.filters.get("cost_center"):
-			self.filters.cost_center = get_cost_centers_with_children(self.filters.cost_center)
-			query = query.where(table.cost_center.isin(self.filters.cost_center))
+			query = query.where(
+				get_dimension_filter_condition(table.cost_center, self.filters.cost_center, "Cost Center")
+			)
 
 		finance_book = self.filters.get("finance_book")
 		if self.filters.get("include_default_book_entries"):
@@ -773,12 +772,13 @@ class FinancialQueryBuilder:
 		dimensions = get_accounting_dimensions(as_list=False)
 		for dimension in dimensions:
 			if self.filters.get(dimension.fieldname):
-				if frappe.get_cached_value("DocType", dimension.document_type, "is_tree"):
-					self.filters[dimension.fieldname] = get_dimension_with_children(
-						dimension.document_type, self.filters.get(dimension.fieldname)
+				query = query.where(
+					get_dimension_filter_condition(
+						table[dimension.fieldname],
+						self.filters[dimension.fieldname],
+						dimension.document_type,
 					)
-
-				query = query.where(table[dimension.fieldname].isin(self.filters.get(dimension.fieldname)))
+				)
 
 		return query
 

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -13,9 +13,8 @@ from frappe.utils import cint, cstr, flt, getdate, nowdate
 
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
-	get_dimension_with_children,
+	get_dimension_filter_condition,
 )
-from erpnext.accounts.report.financial_statements import get_cost_centers_with_children
 from erpnext.accounts.utils import (
 	build_qb_match_conditions,
 	get_advance_payment_doctypes,
@@ -980,7 +979,9 @@ class ReceivablePayableReport:
 			self.get_cost_center_conditions()
 
 		if self.filters.project:
-			self.qb_selection_filter.append(self.ple.project.isin(self.filters.project))
+			self.qb_selection_filter.append(
+				get_dimension_filter_condition(self.ple.project, self.filters.project, "Project")
+			)
 
 		self.add_user_permission_filters()
 
@@ -1005,8 +1006,9 @@ class ReceivablePayableReport:
 			)
 
 	def get_cost_center_conditions(self):
-		cost_center_list = get_cost_centers_with_children(self.filters.cost_center)
-		self.qb_selection_filter.append(self.ple.cost_center.isin(cost_center_list))
+		self.qb_selection_filter.append(
+			get_dimension_filter_condition(self.ple.cost_center, self.filters.cost_center, "Cost Center")
+		)
 
 	def add_common_filters(self):
 		if self.filters.company:
@@ -1123,8 +1125,11 @@ class ReceivablePayableReport:
 			ptt = ptt.where((voucher_type[party.lower()]).isin(self.filters.party))
 
 		if self.filters.cost_center:
-			cost_centers = get_cost_centers_with_children(self.filters.cost_center)
-			ptt = ptt.where(voucher_type.cost_center.isin(cost_centers))
+			ptt = ptt.where(
+				get_dimension_filter_condition(
+					voucher_type.cost_center, self.filters.cost_center, "Cost Center"
+				)
+			)
 
 		if self.filters.party_account:
 			ptt = ptt.where(voucher_type[acc_type] == self.filters.party_account)
@@ -1137,17 +1142,13 @@ class ReceivablePayableReport:
 		if accounting_dimensions:
 			for dimension in accounting_dimensions:
 				if self.filters.get(dimension.fieldname):
-					if frappe.get_cached_value("DocType", dimension.document_type, "is_tree"):
-						self.filters[dimension.fieldname] = get_dimension_with_children(
-							dimension.document_type, self.filters.get(dimension.fieldname)
+					self.qb_selection_filter.append(
+						get_dimension_filter_condition(
+							self.ple[dimension.fieldname],
+							self.filters[dimension.fieldname],
+							dimension.document_type,
 						)
-						self.qb_selection_filter.append(
-							self.ple[dimension.fieldname].isin(self.filters[dimension.fieldname])
-						)
-					else:
-						self.qb_selection_filter.append(
-							self.ple[dimension.fieldname].isin(self.filters[dimension.fieldname])
-						)
+					)
 
 	def is_invoice(self, ple):
 		if ple.voucher_type in ("Sales Invoice", "Purchase Invoice"):

--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -14,7 +14,7 @@ from pypika.terms import Bracket, LiteralValue
 
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
-	get_dimension_with_children,
+	get_dimension_filter_condition,
 )
 from erpnext.accounts.doctype.financial_report_template.financial_report_engine import (
 	FinancialReportEngine,
@@ -23,7 +23,6 @@ from erpnext.accounts.doctype.financial_report_template.financial_report_engine 
 from erpnext.accounts.report.financial_statements import (
 	build_period_list,
 	get_columns,
-	get_cost_centers_with_children,
 	get_data,
 	get_filtered_list_for_consolidated_report,
 	is_dimension_grouped,
@@ -269,15 +268,13 @@ def get_account_type_based_gl_data(company, filters=None):
 
 	# cost center (with children)
 	if filters.get("cost_center"):
-		cost_centers = get_cost_centers_with_children(filters.cost_center)
-		query = query.where(gl.cost_center.isin(cost_centers))
+		query = query.where(
+			get_dimension_filter_condition(gl.cost_center, filters.cost_center, "Cost Center")
+		)
 
 	# project
 	if filters.get("project"):
-		projects = filters.project
-		if not isinstance(projects, list):
-			projects = frappe.parse_json(projects)
-		query = query.where(gl.project.isin(projects))
+		query = query.where(get_dimension_filter_condition(gl.project, filters.project, "Project"))
 
 	# per-period group-by-dimension filter (always a single exact value)
 	if filters.get("dimension_field") and filters.get("dimension_value"):
@@ -286,10 +283,11 @@ def get_account_type_based_gl_data(company, filters=None):
 	# accounting dimension filters selected in the filter bar
 	for dimension in get_accounting_dimensions(as_list=False):
 		if filters.get(dimension.fieldname):
-			values = filters[dimension.fieldname]
-			if frappe.get_cached_value("DocType", dimension.document_type, "is_tree"):
-				values = get_dimension_with_children(dimension.document_type, values)
-			query = query.where(gl[dimension.fieldname].isin(values))
+			query = query.where(
+				get_dimension_filter_condition(
+					gl[dimension.fieldname], filters[dimension.fieldname], dimension.document_type
+				)
+			)
 
 	# apply permission filters
 	from frappe.desk.reportview import build_match_conditions

--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -278,7 +278,9 @@ def get_account_type_based_gl_data(company, filters=None):
 
 	# per-period group-by-dimension filter (always a single exact value)
 	if filters.get("dimension_field") and filters.get("dimension_value"):
-		query = query.where(gl[filters.dimension_field] == filters.dimension_value)
+		query = query.where(
+			get_dimension_filter_condition(gl[filters.dimension_field], [filters.dimension_value])
+		)
 
 	# accounting dimension filters selected in the filter bar
 	for dimension in get_accounting_dimensions(as_list=False):

--- a/erpnext/accounts/report/cash_flow/test_cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/test_cash_flow.py
@@ -4,6 +4,9 @@
 import frappe
 from frappe.utils import getdate, today
 
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+	BLANK_ACCOUNTING_DIMENSION,
+)
 from erpnext.accounts.report.cash_flow.cash_flow import execute
 from erpnext.accounts.report.financial_statements import build_period_list, is_dimension_grouped
 from erpnext.accounts.utils import get_fiscal_year
@@ -111,3 +114,42 @@ class TestCashFlow(ERPNextTestSuite):
 		self.assertEqual(after.get(key_for(cc1), 0) - before.get(key_for(cc1), 0), 400)
 		self.assertEqual(after.get(key_for(cc2), 0) - before.get(key_for(cc2), 0), 200)
 		self.assertEqual(after.get("total", 0) - before.get("total", 0), 600)
+
+	def test_group_by_blank_dimension(self):
+		from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+
+		filters = frappe._dict(
+			company=self.company,
+			period_start_date=getdate(),
+			period_end_date=getdate(),
+			filter_based_on="Date Range",
+			periodicity="Yearly",
+			accumulated_values=False,
+			group_by_dimension="Cost Center",
+			cost_center=[BLANK_ACCOUNTING_DIMENSION],
+		)
+
+		period_list = build_period_list(filters)
+		self.assertEqual(
+			{period.dimension_value for period in period_list},
+			{BLANK_ACCOUNTING_DIMENSION},
+		)
+		blank_period_key = period_list[0].key
+
+		def net_change_row():
+			return next(row for row in execute(filters)[1] if row.get("section") == "'Net Change in Cash'")
+
+		before = net_change_row()
+		journal_entry = make_journal_entry(
+			"Cash - _TC", "Sales - _TC", 350, posting_date=today(), submit=True
+		)
+		frappe.db.set_value(
+			"GL Entry",
+			{"voucher_no": journal_entry.name},
+			"cost_center",
+			None,
+		)
+		after = net_change_row()
+
+		self.assertEqual(after.get(blank_period_key, 0) - before.get(blank_period_key, 0), 350)
+		self.assertEqual(after.get("total", 0) - before.get("total", 0), 350)

--- a/erpnext/accounts/report/custom_financial_statement/test_custom_financial_statement.py
+++ b/erpnext/accounts/report/custom_financial_statement/test_custom_financial_statement.py
@@ -4,6 +4,9 @@
 import frappe
 from frappe.utils import flt
 
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+	BLANK_ACCOUNTING_DIMENSION,
+)
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 from erpnext.accounts.report.custom_financial_statement.custom_financial_statement import execute
 from erpnext.tests.utils import ERPNextTestSuite
@@ -88,6 +91,37 @@ class TestCustomFinancialStatement(ERPNextTestSuite):
 		# the account-data row picks up the posted expense; the calculated row doubles it
 		self.assertEqual(flt(rows["Test Expense"][period_key]), 2000.0)
 		self.assertEqual(flt(rows["Expense Doubled"][period_key]), 4000.0)
+
+	def test_blank_cost_center_filter(self):
+		blank_je = make_journal_entry(
+			self.expense_account,
+			self.cash_account,
+			700,
+			posting_date="2024-06-15",
+			company=self.company,
+			submit=True,
+		)
+		make_journal_entry(
+			self.expense_account,
+			self.cash_account,
+			300,
+			posting_date="2024-06-15",
+			company=self.company,
+			submit=True,
+		)
+		frappe.db.set_value(
+			"GL Entry",
+			{"voucher_no": blank_je.name},
+			{"cost_center": None},
+		)
+
+		template = self._make_template()
+		filters = self._filters(template.template_name)
+		filters.cost_center = [BLANK_ACCOUNTING_DIMENSION]
+		rows = {row.get("account_name"): row for row in execute(filters)[1]}
+		period_key = rows["Test Expense"].get("_segment_info", {}).get("period_keys", [])[0]
+
+		self.assertEqual(flt(rows["Test Expense"][period_key]), 700.0)
 
 	def test_no_template_returns_nothing(self):
 		"""Without a report_template the report short-circuits and returns None."""

--- a/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
+++ b/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
@@ -12,7 +12,7 @@ from pypika.terms import Bracket, LiteralValue
 
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
-	get_dimension_with_children,
+	get_dimension_filter_condition,
 )
 
 TREE_DOCTYPES = frozenset(
@@ -385,27 +385,23 @@ class PartyLedgerSummaryReport:
 			query = query.where(IfNull(gle.finance_book, "") == self.filters.finance_book)
 
 		if self.filters.cost_center:
-			query = query.where((gle.cost_center).isin(self.filters.cost_center))
+			query = query.where(get_dimension_filter_condition(gle.cost_center, self.filters.cost_center))
 
 		if self.filters.project:
-			query = query.where((gle.project).isin(self.filters.project))
+			query = query.where(get_dimension_filter_condition(gle.project, self.filters.project, "Project"))
 
 		accounting_dimensions = get_accounting_dimensions(as_list=False)
 
 		if accounting_dimensions:
 			for dimension in accounting_dimensions:
 				if self.filters.get(dimension.fieldname):
-					if frappe.get_cached_value("DocType", dimension.document_type, "is_tree"):
-						self.filters[dimension.fieldname] = get_dimension_with_children(
-							dimension.document_type, self.filters.get(dimension.fieldname)
+					query = query.where(
+						get_dimension_filter_condition(
+							gle[dimension.fieldname],
+							self.filters[dimension.fieldname],
+							dimension.document_type,
 						)
-						query = query.where(
-							(gle[dimension.fieldname]).isin(self.filters.get(dimension.fieldname))
-						)
-					else:
-						query = query.where(
-							(gle[dimension.fieldname]).isin(self.filters.get(dimension.fieldname))
-						)
+					)
 
 		return query
 

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -17,6 +17,7 @@ from pypika.terms import Bracket, ExistsCriterion, LiteralValue
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
 	get_dimension_fieldname,
+	get_dimension_filter_condition,
 	get_dimension_with_children,
 	get_doctypes_with_dimensions,
 )
@@ -809,14 +810,12 @@ def apply_additional_conditions(doctype, query, from_date, ignore_closing_entrie
 
 	if filters:
 		if filters.get("project"):
-			if not isinstance(filters.get("project"), list):
-				filters.project = frappe.parse_json(filters.get("project"))
-
-			query = query.where(gl_entry.project.isin(filters.project))
+			query = query.where(get_dimension_filter_condition(gl_entry.project, filters.project, "Project"))
 
 		if filters.get("cost_center"):
-			filters.cost_center = get_cost_centers_with_children(filters.cost_center)
-			query = query.where(gl_entry.cost_center.isin(filters.cost_center))
+			query = query.where(
+				get_dimension_filter_condition(gl_entry.cost_center, filters.cost_center, "Cost Center")
+			)
 
 		if filters.get("include_default_book_entries"):
 			company_fb = frappe.get_cached_value("Company", filters.company, "default_finance_book")
@@ -839,12 +838,13 @@ def apply_additional_conditions(doctype, query, from_date, ignore_closing_entrie
 	if accounting_dimensions:
 		for dimension in accounting_dimensions:
 			if filters.get(dimension.fieldname):
-				if frappe.get_cached_value("DocType", dimension.document_type, "is_tree"):
-					filters[dimension.fieldname] = get_dimension_with_children(
-						dimension.document_type, filters.get(dimension.fieldname)
+				query = query.where(
+					get_dimension_filter_condition(
+						gl_entry[dimension.fieldname],
+						filters[dimension.fieldname],
+						dimension.document_type,
 					)
-
-				query = query.where(gl_entry[dimension.fieldname].isin(filters[dimension.fieldname]))
+				)
 
 	return query
 

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -15,10 +15,11 @@ from frappe.utils import add_days, add_months, cint, cstr, flt, formatdate, get_
 from pypika.terms import Bracket, ExistsCriterion, LiteralValue
 
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+	BLANK_ACCOUNTING_DIMENSION,
 	get_accounting_dimensions,
 	get_dimension_fieldname,
 	get_dimension_filter_condition,
-	get_dimension_with_children,
+	get_dimension_filter_values,
 	get_doctypes_with_dimensions,
 )
 from erpnext.accounts.report.utils import convert_to_presentation_currency, get_currency
@@ -49,13 +50,14 @@ def get_dimension_values(filters: frappe._dict) -> tuple[str | None, list]:
 	if meta.has_field("company"):
 		query = query.where(dim.company == filters.company)
 
+	include_blank = False
+	selected_values = []
+
 	# Self-filter: narrow to values the user picked for this same dimension.
 	if selected := filters.get(fieldname):
-		if isinstance(selected, str):
-			selected = frappe.parse_json(selected)
-		if is_tree:
-			selected = get_dimension_with_children(dim_doctype, selected)
-		query = query.where(dim.name.isin(selected))
+		selected_values, include_blank = get_dimension_filter_values(selected, dim_doctype)
+		if selected_values:
+			query = query.where(dim.name.isin(selected_values))
 
 	from frappe.desk.reportview import build_match_conditions
 
@@ -65,7 +67,11 @@ def get_dimension_values(filters: frappe._dict) -> tuple[str | None, list]:
 	# order by name
 	query = query.orderby(dim.name)
 
-	return fieldname, query.run(pluck=True)
+	dimensions = [] if include_blank and not selected_values else query.run(pluck=True)
+	if include_blank:
+		dimensions.append(BLANK_ACCOUNTING_DIMENSION)
+
+	return fieldname, dimensions
 
 
 def get_dimension_period_list(filters: frappe._dict) -> list[dict]:
@@ -113,6 +119,7 @@ def get_dimension_period_list(filters: frappe._dict) -> list[dict]:
 
 	for dimension in dimensions:
 		dim_key_base = frappe.scrub(dimension)
+		dimension_label = _("Blank") if dimension == BLANK_ACCOUNTING_DIMENSION else dimension
 		for period in period_buckets:
 			key = f"{dim_key_base}_{period.key}"
 
@@ -124,7 +131,7 @@ def get_dimension_period_list(filters: frappe._dict) -> list[dict]:
 			cell.update(
 				{
 					"key": key,
-					"label": f"{dimension} - {period.label}",
+					"label": f"{dimension_label} - {period.label}",
 					"dimension_field": fieldname,
 					"dimension_value": dimension,
 					"period": period.key,
@@ -164,6 +171,13 @@ def is_dimension_grouped(period_list: list[dict]) -> bool:
 		return False
 
 	return bool(period_list[0].get("dimension_field"))
+
+
+def _matches_dimension_value(entry_value, dimension_value):
+	if dimension_value == BLANK_ACCOUNTING_DIMENSION:
+		return entry_value in (None, "")
+
+	return entry_value == dimension_value
 
 
 def get_period_keys_for_total(
@@ -423,7 +437,9 @@ def calculate_values(
 					raise_exception=1,
 				)
 			for period in period_list:
-				if grouped_by_dimension and entry.get(period.dimension_field) != period.dimension_value:
+				if grouped_by_dimension and not _matches_dimension_value(
+					entry.get(period.dimension_field), period.dimension_value
+				):
 					continue
 
 				if entry.posting_date <= period.to_date:

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -10,9 +10,9 @@ from frappe.utils import cstr, getdate
 from erpnext import get_company_currency, get_default_company
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
-	get_dimension_with_children,
+	get_dimension_filter_sql_condition,
+	get_dimension_filter_values,
 )
-from erpnext.accounts.report.financial_statements import get_cost_centers_with_children
 from erpnext.accounts.report.utils import convert_to_presentation_currency, get_currency
 from erpnext.accounts.utils import get_account_currency
 
@@ -233,8 +233,7 @@ def get_conditions(filters):
 			conditions.append("account in %(account)s")
 
 	if filters.get("cost_center"):
-		filters.cost_center = get_cost_centers_with_children(filters.cost_center)
-		conditions.append("cost_center in %(cost_center)s")
+		append_named_dimension_condition(conditions, filters, "cost_center", "Cost Center")
 
 	if filters.get("voucher_no"):
 		conditions.append("voucher_no=%(voucher_no)s")
@@ -308,7 +307,7 @@ def get_conditions(filters):
 		conditions.append("posting_date <=%(to_date)s")
 
 	if filters.get("project"):
-		conditions.append("project in %(project)s")
+		append_named_dimension_condition(conditions, filters, "project", "Project")
 
 	if filters.get("include_default_book_entries"):
 		if filters.get("finance_book"):
@@ -343,15 +342,27 @@ def get_conditions(filters):
 			# Ignore 'Finance Book' set up as dimension in below logic, as it is already handled in above section
 			if not dimension.disabled and dimension.document_type != "Finance Book":
 				if filters.get(dimension.fieldname):
-					if frappe.get_cached_value("DocType", dimension.document_type, "is_tree"):
-						filters[dimension.fieldname] = get_dimension_with_children(
-							dimension.document_type, filters.get(dimension.fieldname)
-						)
-						conditions.append(f"{dimension.fieldname} in %({dimension.fieldname})s")
-					else:
-						conditions.append(f"{dimension.fieldname} in %({dimension.fieldname})s")
+					append_named_dimension_condition(
+						conditions, filters, dimension.fieldname, dimension.document_type
+					)
 
 	return "and {}".format(" and ".join(conditions)) if conditions else ""
+
+
+def append_named_dimension_condition(conditions, filters, fieldname, dimension_doctype):
+	values, include_blank = get_dimension_filter_values(filters[fieldname], dimension_doctype)
+	parts = []
+
+	if values:
+		parameter = f"_selected_{fieldname}"
+		filters[parameter] = values
+		parts.append(f"{fieldname} in %({parameter})s")
+
+	if include_blank:
+		parts.append(f"({fieldname} is null or {fieldname} = '')")
+
+	if parts:
+		conditions.append(f"({' or '.join(parts)})")
 
 
 def get_party_name_map():
@@ -977,9 +988,9 @@ def _build_gl_conditions_duckdb(filters):
 			params.extend(filters.account)
 
 	if filters.get("cost_center"):
-		filters.cost_center = get_cost_centers_with_children(filters.cost_center)
-		conditions.append(f"cost_center IN ({', '.join(['?'] * len(filters.cost_center))})")
-		params.extend(filters.cost_center)
+		append_positional_dimension_condition(
+			conditions, params, "cost_center", filters.cost_center, "Cost Center"
+		)
 
 	if filters.get("voucher_no"):
 		conditions.append("voucher_no = ?")
@@ -1058,8 +1069,7 @@ def _build_gl_conditions_duckdb(filters):
 	params.append(filters.to_date)
 
 	if filters.get("project"):
-		conditions.append(f"project IN ({', '.join(['?'] * len(filters.project))})")
-		params.extend(filters.project)
+		append_positional_dimension_condition(conditions, params, "project", filters.project, "Project")
 
 	company_fb = filters.get("company_fb") or frappe.get_cached_value(
 		"Company", filters.company, "default_finance_book"
@@ -1090,16 +1100,19 @@ def _build_gl_conditions_duckdb(filters):
 		for dimension in accounting_dimensions_list:
 			if not dimension.disabled and dimension.document_type != "Finance Book":
 				if filters.get(dimension.fieldname):
-					if frappe.get_cached_value("DocType", dimension.document_type, "is_tree"):
-						filters[dimension.fieldname] = get_dimension_with_children(
-							dimension.document_type, filters.get(dimension.fieldname)
-						)
-					vals = (
-						filters[dimension.fieldname]
-						if isinstance(filters[dimension.fieldname], list)
-						else [filters[dimension.fieldname]]
+					append_positional_dimension_condition(
+						conditions,
+						params,
+						dimension.fieldname,
+						filters[dimension.fieldname],
+						dimension.document_type,
 					)
-					conditions.append(f"{dimension.fieldname} IN ({', '.join(['?'] * len(vals))})")
-					params.extend(vals)
 
 	return conditions, params
+
+
+def append_positional_dimension_condition(conditions, params, fieldname, selected_values, dimension_doctype):
+	condition, values = get_dimension_filter_sql_condition(fieldname, selected_values, dimension_doctype)
+	if condition:
+		conditions.append(condition)
+		params.extend(values)

--- a/erpnext/accounts/report/general_ledger/test_general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/test_general_ledger.py
@@ -5,6 +5,10 @@ import frappe
 from frappe import qb
 from frappe.utils import add_days, flt, today
 
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+	BLANK_ACCOUNTING_DIMENSION,
+	get_dimension_filter_condition,
+)
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.report.general_ledger.general_ledger import execute
 from erpnext.controllers.sales_and_purchase_return import make_return_doc
@@ -39,6 +43,96 @@ class TestGeneralLedger(ERPNextTestSuite):
 		self.assertTrue(columns)
 		self.assertTrue(data)
 		self.assertTrue(any("remarks" in row for row in data))
+
+	def test_blank_accounting_dimension_filter(self):
+		from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+
+		blank_dimension_je = make_journal_entry("_Test Bank - _TC", "_Test Cash - _TC", 100, save=False)
+		for account in blank_dimension_je.accounts:
+			account.cost_center = None
+			account.department = None
+		blank_dimension_je.insert()
+		blank_dimension_je.submit()
+		frappe.db.set_value(
+			"GL Entry",
+			{"voucher_no": blank_dimension_je.name},
+			{"cost_center": None, "department": None},
+		)
+
+		dimensioned_je = make_journal_entry("_Test Bank - _TC", "_Test Cash - _TC", 200, save=False)
+		for account in dimensioned_je.accounts:
+			account.department = "_Test Department - _TC"
+		dimensioned_je.insert()
+		dimensioned_je.submit()
+
+		filters = frappe._dict(
+			company=self.company,
+			from_date=today(),
+			to_date=today(),
+			categorize_by="Categorize by Voucher",
+		)
+
+		def get_vouchers(**dimension_filters):
+			report_filters = filters.copy()
+			report_filters.update(dimension_filters)
+			return {row.voucher_no for row in execute(report_filters)[1] if row.get("voucher_no")}
+
+		all_vouchers = get_vouchers()
+		self.assertLessEqual({blank_dimension_je.name, dimensioned_je.name}, all_vouchers)
+
+		blank_cost_center_vouchers = get_vouchers(cost_center=[BLANK_ACCOUNTING_DIMENSION])
+		self.assertIn(blank_dimension_je.name, blank_cost_center_vouchers)
+		self.assertNotIn(dimensioned_je.name, blank_cost_center_vouchers)
+
+		blank_department_vouchers = get_vouchers(department=[BLANK_ACCOUNTING_DIMENSION])
+		self.assertIn(blank_dimension_je.name, blank_department_vouchers)
+		self.assertNotIn(dimensioned_je.name, blank_department_vouchers)
+
+		department_vouchers = get_vouchers(department=["_Test Department - _TC"])
+		self.assertNotIn(blank_dimension_je.name, department_vouchers)
+		self.assertIn(dimensioned_je.name, department_vouchers)
+
+		all_department_vouchers = get_vouchers(
+			department=[BLANK_ACCOUNTING_DIMENSION, "_Test Department - _TC"]
+		)
+		self.assertLessEqual({blank_dimension_je.name, dimensioned_je.name}, all_department_vouchers)
+
+		gl_entry = frappe.qb.DocType("GL Entry")
+		blank_department_condition = get_dimension_filter_condition(
+			gl_entry.department, [BLANK_ACCOUNTING_DIMENSION]
+		)
+		query_builder_vouchers = set(
+			frappe.qb.from_(gl_entry)
+			.select(gl_entry.voucher_no)
+			.where(gl_entry.voucher_no.isin([blank_dimension_je.name, dimensioned_je.name]))
+			.where(blank_department_condition)
+			.run(pluck=True)
+		)
+		self.assertEqual(query_builder_vouchers, {blank_dimension_je.name})
+
+	def test_blank_dimension_filter_keeps_party_and_voucher(self):
+		sales_invoice = create_sales_invoice(
+			company=self.company,
+			customer="_Test Customer",
+			debit_to="Debtors - _TC",
+		)
+		frappe.db.set_value(
+			"GL Entry",
+			{"voucher_no": sales_invoice.name},
+			{"department": None},
+		)
+
+		filters = frappe._dict(
+			company=self.company,
+			from_date=sales_invoice.posting_date,
+			to_date=sales_invoice.posting_date,
+			categorize_by="Categorize by Voucher (Consolidated)",
+			department=[BLANK_ACCOUNTING_DIMENSION],
+		)
+		invoice_rows = [row for row in execute(filters)[1] if row.get("voucher_no") == sales_invoice.name]
+
+		self.assertTrue(invoice_rows)
+		self.assertIn("_Test Customer", {row.get("party") for row in invoice_rows})
 
 	def clear_old_entries(self):
 		doctype_list = [

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -12,9 +12,8 @@ from pypika.terms import ExistsCriterion
 
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
-	get_dimension_with_children,
+	get_dimension_filter_condition,
 )
-from erpnext.accounts.report.financial_statements import get_cost_centers_with_children
 from erpnext.stock.report.stock_ledger.stock_ledger import get_item_group_condition
 from erpnext.stock.utils import get_incoming_rate
 
@@ -1146,21 +1145,26 @@ class GrossProfitGenerator:
 			query = query.where(SalesInvoiceItem.item_code == self.filters.item_code)
 
 		if self.filters.cost_center:
-			self.filters.cost_center = frappe.parse_json(self.filters.get("cost_center"))
-			self.filters.cost_center = get_cost_centers_with_children(self.filters.cost_center)
-			query = query.where(SalesInvoiceItem.cost_center.isin(self.filters.cost_center))
+			query = query.where(
+				get_dimension_filter_condition(
+					SalesInvoiceItem.cost_center, self.filters.cost_center, "Cost Center"
+				)
+			)
 
 		if self.filters.project:
-			self.filters.project = frappe.parse_json(self.filters.get("project"))
-			query = query.where(SalesInvoiceItem.project.isin(self.filters.project))
+			query = query.where(
+				get_dimension_filter_condition(SalesInvoiceItem.project, self.filters.project, "Project")
+			)
 
 		for dim in get_accounting_dimensions(as_list=False) or []:
 			if self.filters.get(dim.fieldname):
-				if frappe.get_cached_value("DocType", dim.document_type, "is_tree"):
-					self.filters[dim.fieldname] = get_dimension_with_children(
-						dim.document_type, self.filters.get(dim.fieldname)
+				query = query.where(
+					get_dimension_filter_condition(
+						SalesInvoiceItem[dim.fieldname],
+						self.filters[dim.fieldname],
+						dim.document_type,
 					)
-				query = query.where(SalesInvoiceItem[dim.fieldname].isin(self.filters[dim.fieldname]))
+				)
 
 		if self.filters.warehouse:
 			lft, rgt = frappe.db.get_value("Warehouse", self.filters.warehouse, ["lft", "rgt"])

--- a/erpnext/accounts/report/profit_and_loss_statement/test_profit_and_loss_statement.py
+++ b/erpnext/accounts/report/profit_and_loss_statement/test_profit_and_loss_statement.py
@@ -5,6 +5,9 @@ import frappe
 from frappe.desk.query_report import export_query
 from frappe.utils import add_days, getdate, today
 
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+	BLANK_ACCOUNTING_DIMENSION,
+)
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.report.financial_statements import (
 	build_period_list,
@@ -132,6 +135,35 @@ class TestProfitAndLossStatement(ERPNextTestSuite, AccountsTestMixin):
 		data = execute(filters)[1]
 		income_row = next(r for r in data if r.get("account") == income_account)
 		self.assertEqual(income_row["total"], 300.0)
+
+	def test_group_by_dimension_with_blank_filter(self):
+		sales_invoice = self.create_sales_invoice(rate=125)
+		frappe.db.set_value(
+			"GL Entry",
+			{"voucher_no": sales_invoice.name},
+			"cost_center",
+			None,
+		)
+
+		filters = self.get_report_filters()
+		filters.group_by_dimension = "Cost Center"
+		filters.cost_center = [BLANK_ACCOUNTING_DIMENSION]
+		period_list = build_period_list(filters)
+
+		self.assertEqual(
+			{period.dimension_value for period in period_list},
+			{BLANK_ACCOUNTING_DIMENSION},
+		)
+
+		posting_date = getdate()
+		blank_period_key = next(
+			period.key for period in period_list if period.from_date <= posting_date <= period.to_date
+		)
+		income_account = frappe.db.get_value("Company", self.company, "default_income_account")
+		income_row = next(row for row in execute(filters)[1] if row.get("account") == income_account)
+
+		self.assertEqual(income_row[blank_period_key], 125)
+		self.assertEqual(income_row["total"], 125)
 
 	def test_profit_and_loss_output_and_summary(self):
 		self.create_sales_invoice(qty=1, rate=150)

--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -10,12 +10,12 @@ from frappe.utils import add_days, cstr, flt, formatdate, getdate
 import erpnext
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
-	get_dimension_with_children,
+	get_dimension_filter_condition,
+	get_dimension_filter_sql_condition,
 )
 from erpnext.accounts.report.financial_statements import (
 	filter_accounts,
 	filter_out_zero_value_rows,
-	get_cost_centers_with_children,
 	set_gl_entries_by_account,
 )
 from erpnext.accounts.report.utils import convert_to_presentation_currency, get_currency
@@ -305,11 +305,15 @@ def get_opening_balance(
 
 	if filters.cost_center:
 		opening_balance = opening_balance.where(
-			closing_balance.cost_center.isin(get_cost_centers_with_children(filters.get("cost_center")))
+			get_dimension_filter_condition(
+				closing_balance.cost_center, filters.get("cost_center"), "Cost Center"
+			)
 		)
 
 	if filters.project:
-		opening_balance = opening_balance.where(closing_balance.project.isin(filters.project))
+		opening_balance = opening_balance.where(
+			get_dimension_filter_condition(closing_balance.project, filters.project, "Project")
+		)
 
 	if frappe.db.count("Finance Book"):
 		if filters.get("include_default_book_entries"):
@@ -333,17 +337,13 @@ def get_opening_balance(
 	if accounting_dimensions:
 		for dimension in accounting_dimensions:
 			if filters.get(dimension.fieldname):
-				if frappe.get_cached_value("DocType", dimension.document_type, "is_tree"):
-					filters[dimension.fieldname] = get_dimension_with_children(
-						dimension.document_type, filters.get(dimension.fieldname)
+				opening_balance = opening_balance.where(
+					get_dimension_filter_condition(
+						closing_balance[dimension.fieldname],
+						filters[dimension.fieldname],
+						dimension.document_type,
 					)
-					opening_balance = opening_balance.where(
-						closing_balance[dimension.fieldname].isin(filters[dimension.fieldname])
-					)
-				else:
-					opening_balance = opening_balance.where(
-						closing_balance[dimension.fieldname].isin(filters[dimension.fieldname])
-					)
+				)
 
 	gle = opening_balance.run(as_dict=1)
 
@@ -643,14 +643,12 @@ def _extra_gl_conditions(filters):
 	conditions, params = [], []
 
 	if filters.get("cost_center"):
-		cc = get_cost_centers_with_children(filters.get("cost_center"))
-		conditions.append(f"cost_center IN ({', '.join(['?'] * len(cc))})")
-		params.extend(cc)
+		append_dimension_condition(
+			conditions, params, "cost_center", filters.get("cost_center"), "Cost Center"
+		)
 
 	if filters.get("project"):
-		proj = filters.project if isinstance(filters.project, list) else [filters.project]
-		conditions.append(f"project IN ({', '.join(['?'] * len(proj))})")
-		params.extend(proj)
+		append_dimension_condition(conditions, params, "project", filters.project, "Project")
 
 	if frappe.db.count("Finance Book"):
 		company_fb = frappe.get_cached_value("Company", filters.company, "default_finance_book")
@@ -667,19 +665,22 @@ def _extra_gl_conditions(filters):
 
 	for dim in get_accounting_dimensions(as_list=False):
 		if filters.get(dim.fieldname):
-			if frappe.get_cached_value("DocType", dim.document_type, "is_tree"):
-				filters[dim.fieldname] = get_dimension_with_children(
-					dim.document_type, filters.get(dim.fieldname)
-				)
-			vals = (
-				filters[dim.fieldname]
-				if isinstance(filters[dim.fieldname], list)
-				else [filters[dim.fieldname]]
+			append_dimension_condition(
+				conditions,
+				params,
+				dim.fieldname,
+				filters[dim.fieldname],
+				dim.document_type,
 			)
-			conditions.append(f"{dim.fieldname} IN ({', '.join(['?'] * len(vals))})")
-			params.extend(vals)
 
 	return conditions, params
+
+
+def append_dimension_condition(conditions, params, fieldname, selected_values, dimension_doctype):
+	condition, values = get_dimension_filter_sql_condition(fieldname, selected_values, dimension_doctype)
+	if condition:
+		conditions.append(condition)
+		params.extend(values)
 
 
 def _fetch_gl_rows_duckdb(conn, conditions, params):

--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -8,7 +8,7 @@ from pypika import Order
 from erpnext import get_company_currency, get_default_company
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
-	get_dimension_with_children,
+	get_dimension_filter_condition,
 )
 from erpnext.accounts.doctype.fiscal_year.fiscal_year import get_from_and_to_date
 from erpnext.accounts.party import get_party_account
@@ -338,12 +338,12 @@ def apply_common_conditions(filters, query, doctype, child_doctype=None, payment
 
 	if payments:
 		if doctype == "Journal Entry" and filters.get("cost_center"):
-			query = query.where(child_doc.cost_center == filters.cost_center)
+			query = query.where(get_dimension_filter_condition(child_doc.cost_center, filters.cost_center))
 		elif filters.get("cost_center"):
-			query = query.where(parent_doc.cost_center == filters.cost_center)
+			query = query.where(get_dimension_filter_condition(parent_doc.cost_center, filters.cost_center))
 	else:
 		if filters.get("cost_center"):
-			query = query.where(child_doc.cost_center == filters.cost_center)
+			query = query.where(get_dimension_filter_condition(child_doc.cost_center, filters.cost_center))
 			join_required = True
 		if filters.get("warehouse"):
 			query = query.where(child_doc.warehouse == filters.warehouse)
@@ -395,12 +395,12 @@ def filter_invoices_based_on_dimensions(filters, query, parent_doc):
 	if accounting_dimensions:
 		for dimension in accounting_dimensions:
 			if filters.get(dimension.fieldname):
-				if frappe.get_cached_value("DocType", dimension.document_type, "is_tree"):
-					filters[dimension.fieldname] = get_dimension_with_children(
-						dimension.document_type, filters.get(dimension.fieldname)
-					)
 				fieldname = dimension.fieldname
-				query = query.where(parent_doc[fieldname].isin(filters[fieldname]))
+				query = query.where(
+					get_dimension_filter_condition(
+						parent_doc[fieldname], filters[fieldname], dimension.document_type
+					)
+				)
 	return query
 
 

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -327,26 +327,64 @@ $.extend(erpnext.utils, {
 		});
 	},
 
+	add_blank_option_to_dimension_filter: function (filter) {
+		if (filter.has_blank_option) {
+			return;
+		}
+
+		const blank_option = {
+			// Document names cannot contain ">", so this cannot collide with a dimension value.
+			value: "__blank__>",
+			label: __("Blank"),
+			description: __("Not Set"),
+		};
+		const get_data =
+			filter.get_data?.bind(filter) ||
+			((txt) => {
+				const query = filter.get_query?.call(filter) || {};
+				return frappe.db.get_link_options(filter.options, txt, query.filters);
+			});
+		const on_make = filter.on_make;
+
+		filter.fieldtype = "MultiSelectList";
+		filter.on_make = function (control) {
+			on_make?.call(this, control);
+			control._options = [
+				blank_option,
+				...(control._options || []).filter((option) => option.value !== blank_option.value),
+			];
+		};
+		filter.get_data = (txt) =>
+			Promise.resolve(get_data(txt)).then((options) => [blank_option, ...(options || [])]);
+		filter.has_blank_option = true;
+	},
+
 	add_dimensions: function (report_name, index) {
 		let filters = frappe.query_reports[report_name].filters;
+		filters
+			.filter((filter) => ["cost_center", "project"].includes(filter.fieldname))
+			.forEach((filter) => erpnext.utils.add_blank_option_to_dimension_filter(filter));
 
 		frappe.call({
 			method: "erpnext.accounts.doctype.accounting_dimension.accounting_dimension.get_dimensions",
 			callback: function (r) {
 				let accounting_dimensions = r.message[0];
 				accounting_dimensions.forEach((dimension) => {
-					let found = filters.some((el) => el.fieldname === dimension["fieldname"]);
+					let filter = filters.find((el) => el.fieldname === dimension["fieldname"]);
 
-					if (!found) {
-						filters.splice(index, 0, {
+					if (!filter) {
+						filter = {
 							fieldname: dimension["fieldname"],
 							label: __(dimension["label"]),
 							fieldtype: "MultiSelectList",
 							get_data: function (txt) {
 								return frappe.db.get_link_options(dimension["document_type"], txt);
 							},
-						});
+						};
+						filters.splice(index, 0, filter);
 					}
+
+					erpnext.utils.add_blank_option_to_dimension_filter(filter);
 				});
 			},
 		});


### PR DESCRIPTION
### Issue
  Accounting reports allow filtering by specific Accounting Dimension values, but users cannot filter transactions where Cost Center, Project, or another configured dimension is not set.


  Closes #58488

  ### Steps to reproduce

  1. Create two accounting transactions.
  2. Set an Accounting Dimension on one transaction and leave it blank on the other.
  3. Open a report such as General Ledger, Trial Balance, or Accounts Receivable.
  4. Open the corresponding Accounting Dimension filter.
  5. Try to display only the transactions where the dimension is not set.

  ### Actual behaviour

  Leaving the filter empty includes both dimensioned and non-dimensioned entries. There is no way to explicitly request only entries where the dimension is blank.

  ### Expected behaviour

[Screencast from 2026-09-02 13-15-05.webm](https://github.com/user-attachments/assets/b94c58a5-bb1e-44e8-b946-2099f4de7f20)


  Accounting Dimension filters should provide a `Blank` option.

  - No selection should continue to include all entries.
  - Selecting a specific value should continue to include only that value.
  - Selecting `Blank` should include entries where the dimension is `NULL` or empty.
  - Selecting `Blank` together with specific values should include both.
  - The behaviour should work across supported reports, configured dimensions, report templates, and grouped financial statements.

No-docs