### PR TITLE
fix(subcontracting): add condition to exclude tax withholding accounts in purchase receipt mapping

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/mapper.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/mapper.py
@@ -113,6 +113,8 @@ def make_purchase_receipt(
 			"Purchase Taxes and Charges": {
 				"doctype": "Purchase Taxes and Charges",
 				"reset_value": True,
+				# for POs created in earlier version with tax_withholding_row
+				"condition": lambda doc: not doc.is_tax_withholding_account,
 			},
 		},
 		postprocess=post_process,

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -1592,6 +1592,73 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 		self.assertEqual(pr_details[0]["total_taxes_and_charges"], 60)
 
 	@ERPNextTestSuite.change_settings("Buying Settings", {"auto_create_purchase_receipt": 1})
+	def test_auto_create_purchase_receipt_with_tax_withholding_row(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+
+		fg_item = "Subcontracted Item SA1"
+		service_items = [
+			{
+				"warehouse": "_Test Warehouse - _TC",
+				"item_code": "Subcontracted Service Item 1",
+				"qty": 10,
+				"rate": 100,
+				"fg_item": fg_item,
+				"fg_item_qty": 5,
+			},
+		]
+
+		po = create_purchase_order(
+			rm_items=service_items,
+			is_subcontracted=1,
+			supplier_warehouse="_Test Warehouse 1 - _TC",
+			do_not_submit=True,
+		)
+		# withheld against the full PO value, and not recomputed on a partial receipt
+		po.append(
+			"taxes",
+			{
+				"account_head": "_Test Account Excise Duty - _TC",
+				"charge_type": "Actual",
+				"add_deduct_tax": "Deduct",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "TDS on Contract",
+				"doctype": "Purchase Taxes and Charges",
+				"tax_amount": 800,
+				"is_tax_withholding_account": 1,
+			},
+		)
+		po.save()
+		po.submit()
+		self.assertEqual(po.grand_total, 200)
+
+		sco = get_subcontracting_order(po_name=po.name)
+
+		rm_items = get_rm_items(sco.supplied_items)
+		itemwise_details = make_stock_in_entry(rm_items=rm_items)
+		make_stock_transfer_entry(
+			sco_no=sco.name,
+			rm_items=rm_items,
+			itemwise_details=copy.deepcopy(itemwise_details),
+		)
+
+		scr = make_subcontracting_receipt(sco.name)
+		scr.items[0].qty = 3
+		scr.save()
+
+		# carrying the withholding row over would deduct 800 from a 600 receipt,
+		# and Purchase Receipt rejects the resulting negative Grand Total
+		scr.submit()
+
+		pr_name = frappe.db.get_value("Purchase Receipt", {"subcontracting_receipt": scr.name})
+		self.assertTrue(pr_name)
+
+		pr = frappe.get_doc("Purchase Receipt", pr_name)
+		self.assertEqual(pr.items[0].qty, 6)
+		self.assertEqual(pr.net_total, 600)
+		self.assertFalse([row for row in pr.taxes if row.is_tax_withholding_account])
+		self.assertEqual(pr.grand_total, 600)
+
+	@ERPNextTestSuite.change_settings("Buying Settings", {"auto_create_purchase_receipt": 1})
 	def test_auto_create_purchase_receipt_with_no_reference_of_po_item(self):
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
 


### PR DESCRIPTION
Issue: #51099  breaks Subcontracting Receipt submission when the linked Purchase Order carries a tax withholding row; it removed a condition from the Subcontracting Receipt to Purchase Receipt mapping that had been added by #44095.

TDS feature is removed from PO, but POs created in earlier versions may contain TDS row.


Frappe Support Issue: https://support.frappe.io/helpdesk/tickets/77104?view=VIEW-HD+Ticket-771