### PR TITLE
fix(setup): strict permissions for transaction deletion record

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -1203,6 +1203,8 @@ def get_billing_shipping_address(
 @frappe.whitelist(methods=["POST"])
 def create_transaction_deletion_request(company: str):
 	frappe.only_for("System Manager")
+	# User Permission check
+	frappe.has_permission("Company", ptype="delete", doc=company, throw=True)
 
 	from erpnext.setup.doctype.transaction_deletion_record.transaction_deletion_record import (
 		is_deletion_doc_running,
@@ -1211,6 +1213,7 @@ def create_transaction_deletion_request(company: str):
 	is_deletion_doc_running(company)
 
 	tdr = frappe.get_doc({"doctype": "Transaction Deletion Record", "company": company})
+	tdr.flags.ignore_permissions = 1
 	tdr.insert()
 
 	tdr.generate_to_delete_list()

--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.json
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "autoname": "TDL.####",
  "creation": "2021-04-06 20:17:18.404716",
  "doctype": "DocType",
@@ -166,19 +167,18 @@
    "read_only": 1
   }
  ],
+ "in_create": 1,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-18 15:02:46.427695",
+ "modified": "2026-09-02 20:32:19.679290",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Transaction Deletion Record",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
-   "create": 1,
-   "delete": 1,
    "email": 1,
    "export": 1,
    "print": 1,
@@ -186,7 +186,6 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
-   "submit": 1,
    "write": 1
   }
  ],


### PR DESCRIPTION
Changes include:

- Restrict `Transaction Deletion Record` creation.
- User Permission check for System Manager when creating a `Transaction Deletion Record` using the "Delete Transaction" button.