### PR TITLE
fix: check write permission in whitelisted document methods

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -236,6 +236,8 @@ class Lead(SellingController, CRMNote):
 
 	@frappe.whitelist()
 	def create_prospect_and_contact(self, data: dict):
+		self.check_permission("write")
+
 		data = frappe._dict(data)
 		if data.create_contact:
 			self.create_contact()

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -373,6 +373,8 @@ class ProductionPlan(Document):
 
 	@frappe.whitelist()
 	def set_status(self, close: bool | None = None, update_bin: bool = False):
+		self.check_permission("write")
+
 		self.status = {0: "Draft", 1: "Submitted", 2: "Cancelled"}.get(self.docstatus)
 
 		if close:

--- a/erpnext/manufacturing/doctype/work_order/services/status.py
+++ b/erpnext/manufacturing/doctype/work_order/services/status.py
@@ -386,6 +386,7 @@ class StatusService:
 			frappe.db.set_value("Production Plan Sub Assembly Item", field, "ordered_qty", qty)
 
 		doc = frappe.get_doc("Production Plan", self.doc.production_plan)
+		doc.flags.ignore_permissions = True
 		doc.set_status()
 		doc.db_set("status", doc.status)
 

--- a/erpnext/manufacturing/doctype/work_order/services/status.py
+++ b/erpnext/manufacturing/doctype/work_order/services/status.py
@@ -308,6 +308,7 @@ class StatusService:
 
 	def update_production_plan_status(self):
 		production_plan = frappe.get_doc("Production Plan", self.doc.production_plan)
+		production_plan.flags.ignore_permissions = True
 		produced_qty = 0
 		if self.doc.production_plan_item:
 			total_qty = frappe.get_all(

--- a/erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.py
+++ b/erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.py
@@ -168,6 +168,8 @@ class ImportSupplierInvoice(Document):
 
 	@frappe.whitelist()
 	def process_file_data(self):
+		self.check_permission("write")
+
 		self.db_set("status", "Processing File Data", notify=True, commit=True)
 		frappe.enqueue_doc(self.doctype, self.name, "import_xml_data", queue="long", timeout=3600)
 

--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -158,6 +158,8 @@ class Batch(Document):
 
 	@frappe.whitelist()
 	def recalculate_batch_qty(self):
+		self.check_permission("write")
+
 		batches = get_batch_qty(
 			batch_no=self.name,
 			item_code=self.item,

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -502,6 +502,7 @@ class MaterialRequest(BuyingController):
 
 		for production_plan in production_plans:
 			doc = frappe.get_doc("Production Plan", production_plan)
+			doc.flags.ignore_permissions = True
 			doc.set_status()
 			doc.db_set("status", doc.status)
 

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -286,6 +286,8 @@ class RepostItemValuation(Document):
 
 	@frappe.whitelist()
 	def restart_reposting(self):
+		self.check_permission("write")
+
 		self.set_status("Queued", write=False)
 		self.current_index = 0
 		self.distinct_item_and_warehouse = None

--- a/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
+++ b/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
@@ -151,6 +151,8 @@ class StockClosingEntry(Document):
 
 	@frappe.whitelist(methods=["POST"])
 	def enqueue_job(self):
+		self.check_permission("write")
+
 		self.db_set("status", "In Progress")
 		enqueue(prepare_closing_stock_balance, name=self.name, queue="long", timeout=1500)
 		frappe.msgprint(
@@ -161,6 +163,8 @@ class StockClosingEntry(Document):
 
 	@frappe.whitelist(methods=["POST"])
 	def regenerate_closing_balance(self):
+		self.check_permission("write")
+
 		self.validate_closed_period_lock()
 		self.remove_stock_closing()
 		self.enqueue_job()

--- a/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.py
+++ b/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.py
@@ -73,6 +73,8 @@ class StockRepostingSettings(Document):
 	def convert_to_item_wh_reposting(self):
 		"""Convert Transaction reposting to Item Warehouse based reposting if Item Based Reposting has enabled."""
 
+		self.check_permission("write")
+
 		reposting_data = get_reposting_entries()
 
 		vouchers = [d.voucher_no for d in reposting_data]


### PR DESCRIPTION
`run_doc_method` loads the document with a **read** permission check only. `save()`, `insert()` and `submit()` re-check write permission themselves, but `db_set()`, `db_update()`, `frappe.db.set_value()`, `frappe.qb` writes and `insert(ignore_permissions=True)` do not — so a whitelisted controller method that writes through those APIs is callable by anyone with read access on the doctype.

Added `self.check_permission("write")` to the whitelisted methods that write directly:

| Method | What it writes |
| --- | --- |
| `ProductionPlan.set_status` | closes/reopens the plan, updates Bin qty |
| `Batch.recalculate_batch_qty` | `db_set("batch_qty")` on a submitted Batch |
| `RepostItemValuation.restart_reposting` | resets a submitted repost to Queued, deletes its attachments |
| `StockClosingEntry.enqueue_job` / `regenerate_closing_balance` | sets status, deletes Stock Closing Balance rows, enqueues a long job |
| `StockRepostingSettings.convert_to_item_wh_reposting` | marks queued Repost Item Valuations as Skipped, flips `item_based_reposting` |
| `ImportSupplierInvoice.process_file_data` | `db_set(..., commit=True)` and enqueues the import |
| `Lead.create_prospect_and_contact` | inserts Contact / Prospect with `ignore_permissions=True` |

### Callers checked

- `ProductionPlan.set_status` is also called server side from Work Order via `update_produced_pending_qty`. That is a system-driven status sync, so `update_production_plan_status` now sets `flags.ignore_permissions` on the plan document. The `validate()` path is unaffected — the saving user already holds write.
- `StockClosingEntry.enqueue_job` is called from `on_submit`, which runs after `save()` has already checked write permission.
- `RepostItemValuation.restart_reposting` is also reached from the list-view action `bulk_restart_reposting`, which had no check of its own; that path is now covered as well.

Methods that write directly but then call `self.save()` in the same request (`BisectAccountingStatements.build_tree`, `POSInvoice.update_payments`, `Bin.recalculate_values`) are left as they are — the failing write check rolls the transaction back.
