### PR TITLE
fix: use account currency in Bank Reconciliation Statement print

### DIFF
--- a/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html
+++ b/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html
@@ -28,16 +28,16 @@
 						<br>{%= __("Clearance Date") %}: {%= frappe.datetime.str_to_user(data[i]["clearance_date"]) %}
 					{% } %}
 				</td>
-				<td style="text-align: right">{%= format_currency(data[i]["debit"]) %}</td>
-				<td style="text-align: right">{%= format_currency(data[i]["credit"]) %}</td>
+				<td style="text-align: right">{%= format_currency(data[i]["debit"], data[i]["account_currency"]) %}</td>
+				<td style="text-align: right">{%= format_currency(data[i]["credit"], data[i]["account_currency"]) %}</td>
 			</tr>
 			{% } else { %}
 			<tr>
 				<td></td>
 				<td></td>
 				<td>{%= data[i]["payment_entry"] %}</td>
-				<td style="text-align: right">{%= format_currency(data[i]["debit"]) %}</td>
-				<td style="text-align: right">{%= format_currency(data[i]["credit"]) %}</td>
+				<td style="text-align: right">{%= format_currency(data[i]["debit"], data[i]["account_currency"]) %}</td>
+				<td style="text-align: right">{%= format_currency(data[i]["credit"], data[i]["account_currency"]) %}</td>
 			</tr>
 			{% } %}
 		{% } %}


### PR DESCRIPTION
Uses each row’s account currency in Bank Reconciliation Statement print/PDF output instead of the system default currency.

Support: https://support.frappe.io/helpdesk/tickets/77582?view=VIEW-HD+Ticket-70178

v15 fix: https://github.com/frappe/erpnext/pull/57278