### PR TITLE
fix(selling): fetch pending sales order qty within over billing allowance

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -225,7 +225,8 @@
    "description": "The percentage you are allowed to bill more against the amount ordered. For example, if the order value is $100 for an item and tolerance is set as 10%, then you are allowed to bill up to $110 ",
    "fieldname": "over_billing_allowance",
    "fieldtype": "Currency",
-   "label": "Over Billing Allowance (%)"
+   "label": "Over Billing Allowance (%)",
+   "non_negative": 1
   },
   {
    "default": "1",
@@ -805,7 +806,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-08-14 15:26:49.070889",
+ "modified": "2026-09-04 10:08:30.115003",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -166,7 +166,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 						get_query_filters: {
 							docstatus: 1,
 							status: ["not in", ["Closed", "On Hold"]],
-							per_billed: ["<", 99.99],
+							per_billed: ["<", 99.99 + flt(frappe.boot.sysdefaults.over_billing_allowance)],
 							company: me.frm.doc.company,
 						},
 						allow_child_item_selection: true,

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -368,7 +368,6 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 		let filters = {
 			docstatus: 1,
 			status: ["not in", ["Closed", "On Hold"]],
-			per_billed: ["<", 99.99],
 			company: me.frm.doc.company,
 		};
 
@@ -387,6 +386,8 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 						customer: me.frm.doc.customer || undefined,
 					},
 					get_query_filters: filters,
+					get_query_method:
+						"erpnext.selling.doctype.sales_order.sales_order.get_billable_sales_orders",
 					allow_child_item_selection: true,
 					child_fieldname: "items",
 					child_columns: ["item_code", "item_name", "qty", "amount", "billed_amt"],

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -383,7 +383,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 						}
 					}
 					// Please do not add precision in the below flt function
-					if (flt(doc.per_billed) < 100)
+					if (flt(doc.per_billed) < 100 + flt(frappe.boot.sysdefaults.over_billing_allowance))
 						this.frm.add_custom_button(
 							__("Purchase Invoice"),
 							() => {

--- a/erpnext/selling/doctype/sales_order/mapper.py
+++ b/erpnext/selling/doctype/sales_order/mapper.py
@@ -455,10 +455,24 @@ def make_sales_invoice(
 	has_unit_price_items = frappe.db.get_value("Sales Order", source_name, "has_unit_price_items")
 	billed_qty_by_item = None
 	pending_qty_by_item = {}
+	amount_allowance_by_item = {}
 	mapped_qty_by_item = get_qty_already_mapped(target_doc, "so_detail")
 
 	def is_unit_price_row(source):
 		return has_unit_price_items and source.qty == 0
+
+	def is_amount_billable(source):
+		"""Billing is tracked on amount, so a row invoiced at a higher rate than ordered can hit
+		100% billed while qty is still pending. Allow it upto the item's over billing allowance."""
+		from erpnext.controllers.status_updater import get_allowance_for
+
+		if source.item_code not in amount_allowance_by_item:
+			amount_allowance_by_item[source.item_code] = flt(
+				get_allowance_for(source.item_code, qty_or_amount="amount")[0]
+			)
+
+		allowance = amount_allowance_by_item[source.item_code]
+		return abs(flt(source.billed_amt)) < abs(flt(source.amount)) * (1 + allowance / 100.0)
 
 	def get_billed_qty_by_item():
 		nonlocal billed_qty_by_item
@@ -621,7 +635,7 @@ def make_sales_invoice(
 					if is_unit_price_row(doc)
 					else (
 						doc.qty
-						and (doc.base_amount == 0 or abs(doc.billed_amt) < abs(doc.amount))
+						and (doc.base_amount == 0 or is_amount_billable(doc))
 						and get_pending_qty(doc) > 0
 					)
 				),

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1120,7 +1120,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 
 					// sales invoice
 					if (
-						(flt(doc.per_billed) < 100 && frappe.model.can_create("Sales Invoice")) ||
+						(doc.__onload?.has_billable_items && frappe.model.can_create("Sales Invoice")) ||
 						doc.is_subcontracted
 					) {
 						this.frm.add_custom_button(

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -9,8 +9,10 @@ import frappe
 import frappe.utils
 from frappe import _, qb
 from frappe.model.document import Document
-from frappe.query_builder.functions import Sum
+from frappe.query_builder import Case, Criterion
+from frappe.query_builder.functions import Abs, IfNull, Sum
 from frappe.utils import cint, flt, get_link_to_form, getdate
+from pypika import Order
 
 from erpnext.accounts.doctype.sales_invoice.sales_invoice import (
 	unlink_inter_company_doc,
@@ -29,8 +31,22 @@ from erpnext.selling.doctype.sales_order.services.subcontracting import Subcontr
 from erpnext.stock.doctype.packed_item.packed_item import make_packing_list
 from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import has_reserved_stock
 from erpnext.stock.get_item_details import get_default_bom
+from erpnext.utilities.query import get_filter_conditions_qb, get_match_conditions_qb
 
 form_grid_templates = {"items": "templates/form_grid/item_grid.html"}
+
+# fieldtypes frappe's link search runs a LIKE against, see frappe.desk.search.search_widget
+TEXT_SEARCH_FIELDTYPES = {
+	"Autocomplete",
+	"Data",
+	"Link",
+	"Long Text",
+	"Read Only",
+	"Select",
+	"Small Text",
+	"Text",
+	"Text Editor",
+}
 
 
 class WarehouseRequired(frappe.ValidationError):
@@ -212,6 +228,9 @@ class SalesOrder(SellingController):
 
 		if has_reserved_stock(self.doctype, self.name):
 			self.set_onload("has_reserved_stock", True)
+
+		if self.docstatus == 1:
+			self.set_onload("has_billable_items", has_billable_items(self.name))
 
 	def can_update_items(self) -> bool:
 		return SubcontractingService(self).can_update_items()
@@ -930,3 +949,123 @@ def get_work_order_items(sales_order: str, for_raw_material_request: int = 0):
 @frappe.whitelist()
 def get_stock_reservation_status():
 	return frappe.get_single_value("Stock Settings", "enable_stock_reservation")
+
+
+def get_pending_qty_expr(so_item):
+	"""`get_pending_qty` from the mapper, as a query-builder expression."""
+	invoice_item = qb.DocType("Sales Invoice Item")
+	billed_qty = (
+		qb.from_(invoice_item)
+		.select(IfNull(Sum(invoice_item.qty), 0))
+		.where((invoice_item.docstatus == 1) & (invoice_item.so_detail == so_item.name))
+	)
+
+	# get_qty_net_of_returns: min(qty, max(qty - returned_qty, delivered_qty))
+	after_returns = (
+		Case()
+		.when(so_item.qty - so_item.returned_qty > so_item.delivered_qty, so_item.qty - so_item.returned_qty)
+		.else_(so_item.delivered_qty)
+	)
+	net_qty = Case().when(so_item.qty < after_returns, so_item.qty).else_(after_returns)
+
+	# like the mapper, only net off the invoiced qty once the row has been billed
+	return net_qty - Case().when((so_item.qty != 0) & (so_item.billed_amt != 0), billed_qty).else_(0)
+
+
+def get_billable_item_criterion(so, so_item, item):
+	"""Criterion for a Sales Order Item that can still be invoiced.
+
+	Mirrors the mapper's condition. Billing is tracked on amount, so a row stays billable while
+	its billed amount is within the item's over billing allowance, falling back to the global one,
+	and while there is qty left for the mapper to carry over.
+	"""
+	global_allowance = flt(frappe.get_cached_value("Accounts Settings", None, "over_billing_allowance"))
+	allowance = (
+		Case().when(item.over_billing_allowance > 0, item.over_billing_allowance).else_(global_allowance)
+	)
+
+	within_allowance = (so_item.base_amount == 0) | (
+		Abs(so_item.billed_amt) < Abs(so_item.amount) * (1 + allowance / 100)
+	)
+	# 0 qty rows of a unit price order are mapped as they are, so they never run out of qty
+	is_unit_price_row = (so.has_unit_price_items == 1) & (so_item.qty == 0)
+
+	return (so_item.closed == 0) & (
+		is_unit_price_row | ((so_item.qty != 0) & within_allowance & (get_pending_qty_expr(so_item) > 0))
+	)
+
+
+def has_billable_items(sales_order: str) -> bool:
+	so = qb.DocType("Sales Order")
+	so_item = qb.DocType("Sales Order Item")
+	item = qb.DocType("Item")
+
+	return bool(
+		qb.from_(so_item)
+		.inner_join(so)
+		.on(so.name == so_item.parent)
+		.left_join(item)
+		.on(item.name == so_item.item_code)
+		.select(so_item.name)
+		.where((so_item.parent == sales_order) & get_billable_item_criterion(so, so_item, item))
+		.limit(1)
+		.run()
+	)
+
+
+@frappe.whitelist()
+def get_billable_sales_orders(
+	doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: dict
+):
+	"""Sales Orders with at least one item that can still be invoiced.
+
+	A plain `per_billed` filter cannot see item level over billing allowances, so it hides orders
+	the mapper would still map rows from.
+	"""
+	frappe.has_permission("Sales Order", throw=True)
+
+	so = qb.DocType("Sales Order")
+	so_item = qb.DocType("Sales Order Item")
+	item = qb.DocType("Item")
+
+	query = (
+		qb.from_(so)
+		.inner_join(so_item)
+		.on(so_item.parent == so.name)
+		.left_join(item)
+		.on(item.name == so_item.item_code)
+		.select(so.name, so.customer, so.transaction_date)
+		.where(get_billable_item_criterion(so, so_item, item))
+		# customer and transaction_date are plain selects under GROUP BY, so Postgres needs them
+		# grouped as well; they are functionally dependent on the order, so this is a no-op.
+		.groupby(so.name, so.customer, so.transaction_date)
+		.orderby(so.transaction_date, order=Order.desc)
+		.limit(cint(page_len))
+		.offset(cint(start))
+	)
+
+	for condition in get_match_conditions_qb("Sales Order", table=so) + get_filter_conditions_qb(
+		"Sales Order", filters
+	):
+		query = query.where(condition)
+
+	if txt:
+		meta = frappe.get_meta("Sales Order")
+
+		def is_searchable(fieldname):
+			# like frappe's own link search, only text like fields can take a LIKE. postgres
+			# refuses one on a Date column, and `transaction_date` is a search field here.
+			if fieldname == "name":
+				return True
+
+			df = meta.get_field(fieldname)
+			return df and df.fieldtype in TEXT_SEARCH_FIELDTYPES
+
+		txt = f"%{txt}%"
+		query = query.where(
+			Criterion.any(
+				so[fieldname].like(txt) for fieldname in meta.get_search_fields() if is_searchable(fieldname)
+			)
+		)
+
+	return query.run(as_dict=True)

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -33,6 +33,8 @@ from erpnext.selling.doctype.sales_order.mapper import (
 )
 from erpnext.selling.doctype.sales_order.sales_order import (
 	WarehouseRequired,
+	get_billable_sales_orders,
+	has_billable_items,
 )
 from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
@@ -381,6 +383,82 @@ class TestSalesOrder(ERPNextTestSuite):
 
 		si1 = make_sales_invoice(so.name)
 		self.assertEqual(len(si1.get("items")), 0)
+
+	def test_make_sales_invoice_for_pending_qty_within_over_billing_allowance(self):
+		item = make_item("_Test Over Billed Pending Qty Item", {"is_stock_item": 1}).name
+		so = make_sales_order(item_code=item, qty=390, rate=100)
+
+		# invoiced above the ordered rate, so 240 of 390 qty already bills 100% of the amount
+		for _ in range(2):
+			si = make_sales_invoice(so.name)
+			si.get("items")[0].qty = 120
+			si.get("items")[0].rate = 162.50
+			si.insert()
+			si.submit()
+
+		so.load_from_db()
+		self.assertEqual(flt(so.per_billed), 100.0)
+		self.assertEqual(so.get("items")[0].billed_amt, so.get("items")[0].amount)
+
+		with change_settings("Accounts Settings", {"over_billing_allowance": 0}):
+			self.assertEqual(len(make_sales_invoice(so.name).get("items")), 0)
+
+		with change_settings("Accounts Settings", {"over_billing_allowance": 100}):
+			si = make_sales_invoice(so.name)
+			self.assertEqual(len(si.get("items")), 1)
+			self.assertEqual(si.get("items")[0].qty, 150)
+
+	def test_billable_sales_orders_query_honours_item_allowance(self):
+		item = make_item("_Test Over Billed Query Item", {"is_stock_item": 1}).name
+		so = make_sales_order(item_code=item, qty=390, rate=100)
+
+		for _ in range(2):
+			si = make_sales_invoice(so.name)
+			si.get("items")[0].qty = 120
+			si.get("items")[0].rate = 162.50
+			si.insert()
+			si.submit()
+
+		so.load_from_db()
+		self.assertEqual(flt(so.per_billed), 100.0)
+
+		filters = {"docstatus": 1, "company": so.company, "customer": so.customer}
+
+		def is_offered():
+			rows = get_billable_sales_orders("Sales Order", "", "name", 0, 50, dict(filters))
+			return so.name in [d.name for d in rows]
+
+		with change_settings("Accounts Settings", {"over_billing_allowance": 0}):
+			self.assertFalse(is_offered())
+			self.assertFalse(has_billable_items(so.name))
+
+			# an item level allowance is honoured even when the global one is zero
+			frappe.db.set_value("Item", item, "over_billing_allowance", 100)
+			self.assertTrue(is_offered())
+			self.assertTrue(has_billable_items(so.name))
+
+			# searching must skip the Date search field, postgres refuses a LIKE on one
+			rows = get_billable_sales_orders("Sales Order", so.customer, "name", 0, 50, dict(filters))
+			self.assertIn(so.name, [d.name for d in rows])
+
+	def test_billable_sales_orders_query_skips_orders_without_pending_qty(self):
+		item = make_item("_Test Under Billed Query Item", {"is_stock_item": 1}).name
+		so = make_sales_order(item_code=item, qty=10, rate=100)
+
+		# billing the whole qty at a lower rate leaves pending amount but no pending qty
+		si = make_sales_invoice(so.name)
+		si.get("items")[0].rate = 50
+		si.insert()
+		si.submit()
+
+		so.load_from_db()
+		self.assertLess(flt(so.get("items")[0].billed_amt), flt(so.get("items")[0].amount))
+		self.assertEqual(len(make_sales_invoice(so.name).get("items")), 0)
+
+		filters = {"docstatus": 1, "company": so.company, "customer": so.customer}
+		rows = get_billable_sales_orders("Sales Order", "", "name", 0, 50, filters)
+		self.assertNotIn(so.name, [d.name for d in rows])
+		self.assertFalse(has_billable_items(so.name))
 
 	def test_make_sales_invoice_after_return_and_redelivery(self):
 		from erpnext.stock.doctype.delivery_note.mapper import make_sales_return

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -855,6 +855,7 @@
    "fieldname": "over_delivery_receipt_allowance",
    "fieldtype": "Float",
    "label": "Over Delivery/Receipt Allowance (%)",
+   "non_negative": 1,
    "oldfieldname": "tolerance",
    "oldfieldtype": "Currency"
   },
@@ -863,7 +864,8 @@
    "description": "Percentage by which over-billing is allowed against a Sales/Purchase Order for this item. If not set, value from Accounts Settings will be used.",
    "fieldname": "over_billing_allowance",
    "fieldtype": "Float",
-   "label": "Over Billing Allowance (%)"
+   "label": "Over Billing Allowance (%)",
+   "non_negative": 1
   },
   {
    "default": "0",
@@ -1116,7 +1118,7 @@
  "image_field": "image",
  "links": [],
  "make_attachments_public": 1,
- "modified": "2026-07-28 18:58:43.328497",
+ "modified": "2026-09-04 10:08:30.115003",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",


### PR DESCRIPTION
**Issue:**
Billing progress is tracked on amount while delivery is tracked on qty, so a Sales Order row invoiced above the ordered rate reaches 100% billed while qty is still pending. The order then disappears from both `Sales Invoice > Get Items From > Sales Order` and `Create > Sales Invoice`, even on sites that have configured an Over Billing Allowance, leaving no way to invoice the remaining qty (repro: 390 qty ordered, 240 invoiced at a higher rate, 150 qty stranded).

Fixed by gating the fetch on the configured over billing allowance instead of a flat 100%, resolved per item so an Item-level override wins over Accounts Settings. The equivalent flat gates on the purchase side are updated too; `purchase_order/mapper.py` already allowed pending-qty rows, so only its list and button filters needed the change.

**Ref:** [#77262](https://support.frappe.io/helpdesk/tickets/77262)