### PR TITLE
fix(stock): show actual outgoing rate in ledger preview

### DIFF
--- a/erpnext/controllers/ledger_preview.py
+++ b/erpnext/controllers/ledger_preview.py
@@ -13,6 +13,8 @@ services it orchestrates. The whitelisted ``show_*_preview`` entry points stay o
 
 import frappe
 
+from erpnext import get_company_currency
+
 
 def get_accounting_ledger_preview(doc, filters):
 	from erpnext.accounts.report.general_ledger.general_ledger import get_columns as get_gl_columns
@@ -44,7 +46,7 @@ def get_accounting_ledger_preview(doc, filters):
 		columns = get_gl_columns(filters)
 		gl_entries = get_gl_entries_for_preview(doc.doctype, doc.name, fields)
 
-		gl_columns = get_columns(columns, fields)
+		gl_columns = get_columns(columns, fields, get_company_currency(filters.company))
 		gl_data = get_data(fields, gl_entries)
 	finally:
 		frappe.db.rollback(save_point="ledger_preview")
@@ -92,7 +94,7 @@ def get_stock_ledger_preview(doc, filters):
 			columns = get_sl_columns(filters)
 			sl_entries = get_sl_entries_for_preview(doc.doctype, doc.name, fields)
 
-			sl_columns = get_columns(columns, columns_fields)
+			sl_columns = get_columns(columns, columns_fields, get_company_currency(filters.company))
 			sl_data = get_data(columns_fields, sl_entries)
 		finally:
 			frappe.db.rollback(save_point="ledger_preview")
@@ -113,7 +115,8 @@ def get_sl_entries_for_preview(doctype, docname, fields):
 			entry["out_qty"] = abs(entry.actual_qty)
 			entry["in_qty"] = 0
 
-		entry["in_out_rate"] = entry["valuation_rate"]
+		if entry.actual_qty < 0:
+			entry["in_out_rate"] = entry.stock_value_difference / entry.actual_qty
 
 	return sl_entries
 
@@ -122,12 +125,23 @@ def get_gl_entries_for_preview(doctype, docname, fields):
 	return frappe.get_all("GL Entry", filters={"voucher_type": doctype, "voucher_no": docname}, fields=fields)
 
 
-def get_columns(raw_columns, fields):
-	return [
-		{"name": d.get("label"), "editable": False, "width": 110, "fieldtype": d.get("fieldtype")}
-		for d in raw_columns
-		if not d.get("hidden") and d.get("fieldname") in fields
-	]
+def get_columns(raw_columns, fields, currency):
+	columns = []
+	for source_column in raw_columns:
+		if source_column.get("hidden") or source_column.get("fieldname") not in fields:
+			continue
+
+		column = {
+			"name": source_column.get("label"),
+			"editable": False,
+			"width": 110,
+			"fieldtype": source_column.get("fieldtype"),
+		}
+		if column["fieldtype"] == "Currency":
+			column["options"] = currency
+		columns.append(column)
+
+	return columns
 
 
 def get_data(raw_columns, raw_data):

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -641,7 +641,7 @@ def show_accounting_ledger_preview(company: str, doctype: str, docname: str):
 def show_stock_ledger_preview(company: str, doctype: str, docname: str):
 	from erpnext.controllers.ledger_preview import get_stock_ledger_preview
 
-	filters = frappe._dict(company=company)
+	filters = frappe._dict(company=company, valuation_field_type="Currency")
 	doc = frappe.get_lazy_doc(doctype, docname)
 	doc.check_permission("read")
 	doc.run_method("before_sl_preview")

--- a/erpnext/controllers/tests/test_ledger_preview.py
+++ b/erpnext/controllers/tests/test_ledger_preview.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+from unittest.mock import patch
+
+import frappe
+
+from erpnext.controllers.ledger_preview import get_sl_entries_for_preview
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestLedgerPreview(ERPNextTestSuite):
+	def test_in_out_rate_is_only_set_for_outgoing_entries(self):
+		stock_ledger_entries = [
+			frappe._dict(actual_qty=5, stock_value_difference=10),
+			frappe._dict(actual_qty=-5, stock_value_difference=-15),
+		]
+
+		with patch("frappe.get_all", return_value=stock_ledger_entries):
+			entries = get_sl_entries_for_preview("Delivery Note", "DN-0001", [])
+
+		self.assertIsNone(entries[0].get("in_out_rate"))
+		self.assertEqual(entries[1].in_out_rate, 3)

--- a/erpnext/public/js/utils/ledger_preview.js
+++ b/erpnext/public/js/utils/ledger_preview.js
@@ -87,7 +87,7 @@ erpnext.accounts.ledger_preview = {
 		columns.forEach((col) => {
 			if (col.fieldtype === "Currency") {
 				col.format = (value) => {
-					return format_currency(value);
+					return format_currency(value, col.options);
 				};
 			}
 		});


### PR DESCRIPTION
## Issue

Stock Ledger Preview incorrectly displayed the post-transaction average valuation rate as the **Outgoing Rate**. With FIFO valuation, the cost of the outgoing FIFO layer can differ from the average valuation rate of the remaining stock. The preview also rendered the rate as a raw decimal instead of Currency.

This was a display issue only. Stock and accounting entries use `stock_value_difference` and remain balanced.

## Fix

- Calculate Outgoing Rate using:       `stock_value_difference / actual_qty`
- Apply the System Settings float precision, consistent with the Stock Ledger report.
- Render Outgoing Rate using the Currency field type.
- Leave Outgoing Rate empty for incoming entries.

## Steps to reproduce

1. Create a stock item with FIFO valuation.
2. Submit a Material Receipt for:
   - Quantity: `10`
   - Rate: `1`
3. Submit another Material Receipt into the same warehouse for:
   - Quantity: `10`
   - Rate: `3`
4. Create and save a draft Delivery Note for:
   - Quantity: `5`
   - The same item and warehouse
5. Open **Preview > Stock Ledger**.

### Before the fix

- Out Qty: `5`
- Balance Qty: `15`
- Balance Value: `35`
- Value Change: `-5`
- Correct FIFO outgoing rate: `1`
- Displayed Outgoing Rate: `2.333333333`

The incorrect rate was calculated from the remaining balance:

`35 / 15 = 2.333333333`

### After the fix

- Outgoing Rate: `1.0000` 
- Balance Value: `35.0000`
- Value Change: `-5.0000`

Before:
<img width="1073" height="217" alt="image" src="https://github.com/user-attachments/assets/9ea17237-3830-4f49-a02b-35dd356d7307" />

After:
<img width="1073" height="217" alt="image" src="https://github.com/user-attachments/assets/f6bf7a16-b3f2-4b82-8a8f-81c768a91b3a" />

Bonus : Now Preview follows Company Currency

Support Ticket : [#77125](https://support.frappe.io/helpdesk/tickets/77125)
