### PR TITLE
fix: prevent max recursion on supplier scorecard save

### DIFF
--- a/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
+++ b/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
@@ -55,9 +55,16 @@ class SupplierScorecard(Document):
 		self.update_standing()
 
 	def on_update(self):
-		score = make_all_scorecards(self.name)
-		if score > 0:
-			self.save()
+		# Guard against recursion: the save() below re-enters on_update().
+		if self.flags.in_rescore:
+			return
+		if make_all_scorecards(self.name) > 0:
+			# New periods were created; re-save to refresh score and standings.
+			self.flags.in_rescore = True
+			try:
+				self.save()
+			finally:
+				self.flags.in_rescore = False
 
 	def validate_standings(self):
 		# Check that there are no overlapping scores and check that there are no missing scores
@@ -213,25 +220,18 @@ def make_all_scorecards(docname):
 
 	while (start_date < todays) and (end_date <= todays):
 		# check to make sure there is no scorecard period already created
-		scorecards = frappe.db.sql(
-			"""
-			SELECT
-				scp.name
-			FROM
-				`tabSupplier Scorecard Period` scp
-			WHERE
-				scp.scorecard = %(sc)s
-				AND scp.docstatus = 1
-				AND (
-					(scp.start_date > %(end_date)s
-					AND scp.end_date < %(start_date)s)
-				OR
-					(scp.start_date < %(end_date)s
-					AND scp.end_date > %(start_date)s))
-			ORDER BY
-				scp.end_date DESC""",
-			{"sc": docname, "start_date": start_date, "end_date": end_date},
-			as_dict=1,
+		# (inclusive bounds: a single-day period — supplier created on a month's
+		# last day — must match its own window, else it is re-created every run)
+		scorecards = frappe.get_all(
+			"Supplier Scorecard Period",
+			fields=["name"],
+			filters={
+				"scorecard": docname,
+				"docstatus": 1,
+				"start_date": ["<=", end_date],
+				"end_date": [">=", start_date],
+			},
+			order_by="end_date desc",
 		)
 		if len(scorecards) == 0:
 			period_card = make_supplier_scorecard(docname, None)


### PR DESCRIPTION
## Issue

Creating or updating a Supplier Scorecard for a supplier whose `creation` date falls on the last day of a month causes an infinite recursive save loop. The request eventually fails with:

```text
RecursionError: maximum recursion depth exceeded
```

This prevents the Supplier Scorecard from being saved.

**Reference:** [[Support Ticket #77256](https://support.frappe.io/helpdesk/tickets/77256?view=VIEW-HD+Ticket-745)](https://support.frappe.io/helpdesk/tickets/77256?view=VIEW-HD+Ticket-745)

## Root Cause

`SupplierScorecard.on_update()` calls `make_all_scorecards(self.name)`. If a new Supplier Scorecard Period is created, it calls `self.save()` again.

The initial period starts from `supplier.creation`. For a scorecard configured as **Per Month**, the period end date is calculated using `get_last_day(start_date)`.

When the supplier was created on the last day of a month, the calculated period has the same start and end date. The same one-day period is repeatedly created during each save, causing `on_update()` and `self.save()` to call each other recursively until the recursion limit is reached.

## Steps to Reproduce

1. Create a Supplier whose `creation` date is the last calendar day of a month, such as October 31.
2. Configure the minimum required Supplier Scorecard data:

   * Supplier standings covering scores from 0 to 100
   * Criteria weights totaling 100%
3. Create a Supplier Scorecard for that supplier.
4. Set **Period** to **Per Month**.
5. Save the Supplier Scorecard.

## Fix

The fix prevents recursive saves while generating Supplier Scorecard Periods and avoids creating duplicate periods when the supplier was created on the last day of a month.

Related fixes already included in `develop`:

* [[PR #56703 — Prevent maximum recursion on Supplier Scorecard save](https://github.com/frappe/erpnext/pull/56703)](https://github.com/frappe/erpnext/pull/56703)
* [[PR #57115 — Prevent duplicate scorecard period when Supplier is created at month-end](https://github.com/frappe/erpnext/pull/57115)](https://github.com/frappe/erpnext/pull/57115)