### PR TITLE
fix: prevent duplicate Batch messages and Project links

### DIFF
--- a/erpnext/projects/doctype/project/project.js
+++ b/erpnext/projects/doctype/project/project.js
@@ -67,9 +67,9 @@ frappe.ui.form.on("Project", {
 	},
 
 	refresh: function (frm) {
-		if (frm.doc.__islocal) {
-			frm.web_link && frm.web_link.remove();
-		} else {
+		frm.web_link && frm.web_link.closest(".user-action-row").remove();
+
+		if (!frm.doc.__islocal) {
 			frm.add_web_link("/projects?project=" + encodeURIComponent(frm.doc.name));
 
 			frm.trigger("show_dashboard");

--- a/erpnext/stock/doctype/batch/batch.js
+++ b/erpnext/stock/doctype/batch/batch.js
@@ -14,6 +14,8 @@ frappe.ui.form.on("Batch", {
 		});
 	},
 	refresh: (frm) => {
+		frm.batch_dashboard_request_id = (frm.batch_dashboard_request_id || 0) + 1;
+
 		if (!frm.is_new()) {
 			frm.add_custom_button(__("View Ledger"), () => {
 				frappe.route_options = {
@@ -83,6 +85,8 @@ frappe.ui.form.on("Batch", {
 		);
 	},
 	make_dashboard: (frm) => {
+		const request_id = frm.batch_dashboard_request_id;
+
 		if (!frm.is_new()) {
 			let for_stock_levels = 0;
 			if (!frm.doc.batch_qty && frm.doc.expiry_date) {
@@ -99,6 +103,10 @@ frappe.ui.form.on("Batch", {
 					ignore_reserved_stock: 1,
 				},
 				callback: (r) => {
+					if (request_id !== frm.batch_dashboard_request_id) {
+						return;
+					}
+
 					if (!r.message || r.message.length === 0) {
 						frm.dashboard.add_comment(__("No stock available for this batch."), "Blue", true);
 						return;


### PR DESCRIPTION
### Issue

Batch dashboard messages and Project web links can be displayed more than once when overlapping callbacks or form refreshes render the same UI element repeatedly.

Partially addresses #58699.

The Translation case is caused by `frm.set_intro()` in Frappe version 16 and requires a separate Frappe backport.

### Changes

- Ignore stale Batch dashboard responses so only the latest request renders its message.
- Remove the existing Project web link before adding it again during refresh.

### Steps to reproduce

#### Batch

1. Create and save a Batch without available stock.
2. Observe the stock availability notification after the form refreshes.

#### Project

1. Create and save a Project.
2. Observe the **See on Website** link in the sidebar after the form refreshes.

### Actual behaviour

The Batch notification or Project web link can appear twice.

### Expected behaviour

Each UI element is displayed only once.

**Backport Needed For V16**
