### PR TITLE
ci: authenticate github clones in install.sh

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -4,6 +4,36 @@ set -e
 
 cd ~ || exit
 
+# Authenticate git against github.com with the job token: anonymous git-over-HTTPS from the
+# runners gets throttled to a 401, which kills whichever clone is in flight — the frappe fetch
+# below, or payments under `bench get-app`. See the PR description.
+#
+# A credential helper rather than a url.insteadOf rewrite, because `git clone` PERSISTS a
+# rewritten URL into the new repo's .git/config: an insteadOf would leave the token sitting in
+# apps/payments/.git/config on the runner. A helper is consulted only when github.com actually
+# challenges, and leaves the stored remote URL untouched. Passing it through GIT_CONFIG_* keeps
+# the token out of ~/.gitconfig too, and child processes inherit it (bench shells out to git).
+ci_github_token=${CI_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}
+if [ -n "$ci_github_token" ]; then
+    export CI_GITHUB_TOKEN="$ci_github_token"
+    export GIT_CONFIG_COUNT=3
+    # Reset first: git runs EVERY configured helper and calls `store` on them after a successful
+    # auth, so a `credential.helper=store` inherited from the image's gitconfig would write the
+    # token to ~/.git-credentials. An empty value clears the list before ours is added.
+    export GIT_CONFIG_KEY_0="credential.helper"
+    export GIT_CONFIG_VALUE_0=""
+    export GIT_CONFIG_KEY_1="credential.https://github.com.username"
+    export GIT_CONFIG_VALUE_1="x-access-token"
+    export GIT_CONFIG_KEY_2="credential.https://github.com.helper"
+    # Single-quoted: $CI_GITHUB_TOKEN is expanded by the shell git runs the helper in, so the
+    # token is read from the environment at call time and never stored anywhere. Answering only
+    # `get` makes the helper inert for git's `store`/`erase` calls.
+    export GIT_CONFIG_VALUE_2='!f() { test "$1" = get && echo "password=$CI_GITHUB_TOKEN"; }; f'
+fi
+
+# Whatever happens, never sit on a credential prompt: fail fast and legibly instead.
+export GIT_TERMINAL_PROMPT=0
+
 githubbranch=${GITHUB_BASE_REF:-${GITHUB_REF##*/}}
 frappeuser=${FRAPPE_USER:-"frappe"}
 frappecommitish=${FRAPPE_BRANCH:-}

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -121,6 +121,8 @@ jobs:
         env:
           DB: mariadb
           TYPE: server
+          # Anonymous git to github.com gets throttled to a 401; authenticate the clones.
+          CI_GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run Patch Tests
         run: |

--- a/.github/workflows/run-individual-tests.yml
+++ b/.github/workflows/run-individual-tests.yml
@@ -129,6 +129,8 @@ jobs:
           TYPE: server
           FRAPPE_USER: ${{ github.event.inputs.user }}
           FRAPPE_BRANCH: ${{ github.event.inputs.branch }}
+          # Anonymous git to github.com gets throttled to a 401; authenticate the clones.
+          CI_GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run Tests
         run: |

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -102,6 +102,8 @@ jobs:
           TYPE: server
           FRAPPE_USER: ${{ github.event.inputs.user }}
           FRAPPE_BRANCH: ${{ github.event.client_payload.sha || github.event.inputs.branch }}
+          # Anonymous git to github.com gets throttled to a 401; authenticate the clones.
+          CI_GITHUB_TOKEN: ${{ github.token }}
           DB_HOST: 127.0.0.1
           DB_USER_HOST: '%'
           WKHTMLTOX_DEB: /tmp/wkhtmltox.deb

--- a/.github/workflows/server-tests-postgres.yml
+++ b/.github/workflows/server-tests-postgres.yml
@@ -103,6 +103,8 @@ jobs:
           DB: postgres
           TYPE: server
           FRAPPE_BRANCH: develop
+          # Anonymous git to github.com gets throttled to a 401; authenticate the clones.
+          CI_GITHUB_TOKEN: ${{ github.token }}
           BENCH_CACHE_DIR: /home/runner/bench-cache
 
       - name: Warm up test data


### PR DESCRIPTION
## Problem

Setup jobs fail intermittently — roughly half of all runs — when git clones from github.com:

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: expected flush after ref listing
```

Of the last 26 failed runs of `server-tests-mariadb.yml`, 24 carry this signature, on `develop` and the hotfix branches alike.

## Root cause

`install.sh` clones frappe and payments anonymously over HTTPS. GitHub throttles unauthenticated git-over-HTTPS from the shared egress addresses of the ARC cluster and answers with a 401; git then falls back to prompting for a username on a tty that does not exist, and exits 128.

It hits whichever anonymous clone is in flight rather than one specific command — the frappe fetch in `install.sh`, or the payments clone under `bench get-app`. `actions/checkout` in the same job always succeeds, because it is authenticated.

## Fix

Point git at a credential helper for `github.com`, fed the job token. The helper is passed through `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_*` / `GIT_CONFIG_VALUE_*` and reads the token from the environment when git invokes it, so every git process in the step is covered — including the clones bench shells out to — without having to touch bench.

`GIT_TERMINAL_PROMPT=0` makes any future rejection fail immediately, instead of on the confusing username prompt above.

If the token is ever missing or invalid, GitHub serves public refs anonymously, so the worst case is current behaviour.

## Why a credential helper and not `url.<…>.insteadOf`

`git clone` persists a rewritten URL into the new repository's config, so an `insteadOf` rewrite would leave the token sitting in `apps/payments/.git/config` on the runner. (It would not reach the test shards — both bench tarballs exclude `.git` — but writing a credential to disk at all is avoidable.) A helper leaves stored remote URLs untouched, and is consulted only when github.com actually issues a challenge.

The helper list is also reset before ours is installed. Git runs every configured helper and calls `store` on them after a successful auth, so a `credential.helper = store` inherited from the image's gitconfig would otherwise write the token to `~/.git-credentials`. With the reset, and with our helper answering only `get`, the token stays in the environment and is never written to disk.
