### PR TITLE
fix: preserve mixed purchase and sales discounts

### DIFF
--- a/erpnext/buying/doctype/purchase_order/mapper.py
+++ b/erpnext/buying/doctype/purchase_order/mapper.py
@@ -18,6 +18,13 @@ from erpnext.stock.doctype.item.item import get_item_defaults
 
 def set_missing_values(source, target):
 	target.run_method("set_missing_values")
+	source_item_fieldname = "po_detail" if target.doctype == "Purchase Invoice" else "purchase_order_item"
+	target.run_method(
+		"preserve_mapped_source_discounts",
+		source.doctype,
+		"purchase_order",
+		source_item_fieldname,
+	)
 	target.run_method("calculate_taxes_and_totals")
 	target.run_method("set_use_serial_batch_fields")
 

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1423,6 +1423,63 @@ class AccountsController(TransactionBase):
 	def after_mapping(self, source_doc):
 		self.set_discount_amount_after_mapping(source_doc)
 
+	def preserve_mapped_source_discounts(self, source_doctype, source_fieldname, source_item_fieldname):
+		if not self.has_mixed_source_discounts(source_doctype, source_fieldname):
+			return
+
+		mapped_items = [item for item in self.get("items") if item.get(source_fieldname)]
+		source_item_names = {item.get(source_item_fieldname) for item in mapped_items}
+		if None in source_item_names:
+			return
+
+		source_item_doctype = f"{source_doctype} Item"
+		source_rates = self.get_reference_details(source_item_names, source_item_doctype)
+		source_net_rates = self.get_reference_details(source_item_names, source_item_doctype, "net_rate")
+		if len(source_rates) != len(source_item_names) or len(source_net_rates) != len(source_item_names):
+			return
+
+		for item in mapped_items:
+			source_item_name = item.get(source_item_fieldname)
+			reference_rate = flt(source_rates[source_item_name])
+			item.price_list_rate = reference_rate
+			item.rate = flt(source_net_rates[source_item_name])
+			item.discount_percentage = 0
+			item.discount_amount = flt(
+				max(reference_rate - flt(item.rate), 0), item.precision("discount_amount")
+			)
+			item.distributed_discount_amount = 0
+			item.margin_type = None
+			item.margin_rate_or_amount = 0
+			item.pricing_rules = None
+
+		self.additional_discount_percentage = 0
+		self.discount_amount = 0
+		self.base_discount_amount = 0
+
+	def has_mixed_source_discounts(self, source_doctype, source_fieldname):
+		source_names = {
+			item.get(source_fieldname) for item in self.get("items") if item.get(source_fieldname)
+		}
+		if len(source_names) < 2:
+			return False
+
+		source_discounts = frappe.get_all(
+			source_doctype,
+			filters={"name": ("in", source_names)},
+			fields=["apply_discount_on", "additional_discount_percentage", "discount_amount"],
+		)
+		return self._has_mixed_source_discounts(source_discounts)
+
+	def _has_mixed_source_discounts(self, source_discounts):
+		if not any(flt(discount.discount_amount) for discount in source_discounts):
+			return False
+
+		percentage_discounts = {
+			(discount.apply_discount_on, flt(discount.additional_discount_percentage))
+			for discount in source_discounts
+		}
+		return len(percentage_discounts) != 1 or not next(iter(percentage_discounts))[1]
+
 	def set_discount_amount_after_mapping(self, source_doc):
 		"""
 		Ensures that Additional Discount Amount is not copied repeatedly

--- a/erpnext/controllers/tests/test_accounts_controller.py
+++ b/erpnext/controllers/tests/test_accounts_controller.py
@@ -2251,6 +2251,63 @@ class TestAccountsController(ERPNextTestSuite):
 		self.assertEqual(pr2.discount_amount, 0)
 		self.assertEqual(pr2.grand_total, 500)
 
+	@ERPNextTestSuite.change_settings("Stock Settings", {"auto_insert_price_list_rate_if_missing": 0})
+	@ERPNextTestSuite.change_settings(
+		"Buying Settings", {"maintain_same_rate": 1, "maintain_same_rate_action": "Stop"}
+	)
+	def test_source_discounts_are_preserved_when_combining_purchase_documents(self):
+		from frappe.model.mapper import map_docs
+
+		from erpnext.buying.doctype.purchase_order.mapper import make_purchase_receipt
+
+		item_a = "_Test Item"
+		item_b = "_Test Item 2"
+
+		po1 = create_purchase_order(item_code=item_a, qty=1, rate=100, do_not_save=True)
+		po1.apply_discount_on = "Grand Total"
+		po1.additional_discount_percentage = 35
+		po1.save().submit()
+
+		po2 = create_purchase_order(item_code=item_b, qty=1, rate=100)
+		po3 = create_purchase_order(item_code=item_b, qty=1, rate=100)
+
+		pr1 = make_purchase_receipt(po1.name).save().submit()
+		pr2 = make_purchase_receipt(po2.name).save().submit()
+		pr3 = make_purchase_receipt(po3.name).save().submit()
+
+		mapping_scenarios = (
+			(
+				"erpnext.buying.doctype.purchase_order.mapper.make_purchase_invoice",
+				(po1.name, po2.name, po3.name),
+			),
+			(
+				"erpnext.stock.doctype.purchase_receipt.mapper.make_purchase_invoice",
+				(pr1.name, pr2.name, pr3.name),
+			),
+		)
+		for mapper, source_names in mapping_scenarios:
+			for document_names in (source_names, tuple(reversed(source_names))):
+				with self.subTest(mapper=mapper, document_names=document_names):
+					invoice = map_docs(mapper, document_names, frappe.new_doc("Purchase Invoice").as_dict())
+					invoice.save()
+					items = {item.purchase_order: item for item in invoice.items}
+
+					self.assertEqual(invoice.additional_discount_percentage, 0)
+					self.assertEqual(invoice.discount_amount, 0)
+					self.assertEqual(invoice.grand_total, 265)
+					self.assertEqual(items[po1.name].price_list_rate, 100)
+					self.assertEqual(items[po1.name].rate, 65)
+					self.assertEqual(items[po1.name].discount_amount, 35)
+					self.assertEqual(items[po1.name].net_amount, 65)
+					for purchase_order in (po2.name, po3.name):
+						self.assertEqual(items[purchase_order].rate, 100)
+						self.assertEqual(items[purchase_order].discount_amount, 0)
+						self.assertEqual(items[purchase_order].net_amount, 100)
+
+					items[po1.name].rate = 64
+					with self.assertRaisesRegex(frappe.ValidationError, "Rate must be same"):
+						invoice.save()
+
 	def test_discount_amount_partial_application_in_mapped_transactions(self):
 		"""
 		Test that discount amount is partially applied when some discount

--- a/erpnext/controllers/tests/test_accounts_controller.py
+++ b/erpnext/controllers/tests/test_accounts_controller.py
@@ -2308,6 +2308,87 @@ class TestAccountsController(ERPNextTestSuite):
 					with self.assertRaisesRegex(frappe.ValidationError, "Rate must be same"):
 						invoice.save()
 
+	@ERPNextTestSuite.change_settings(
+		"Stock Settings", {"allow_negative_stock": 1, "auto_insert_price_list_rate_if_missing": 0}
+	)
+	@ERPNextTestSuite.change_settings(
+		"Selling Settings", {"maintain_same_sales_rate": 1, "maintain_same_rate_action": "Stop"}
+	)
+	def test_source_discounts_are_preserved_when_combining_sales_documents(self):
+		from frappe.model.mapper import map_docs
+
+		from erpnext.selling.doctype.sales_order.mapper import make_delivery_note
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+
+		item_a = "_Test Item"
+		item_b = "_Test Item 2"
+
+		so1 = make_sales_order(item_code=item_a, qty=1, rate=100, do_not_save=True)
+		so1.apply_discount_on = "Grand Total"
+		so1.additional_discount_percentage = 35
+		so1.save().submit()
+
+		so2 = make_sales_order(item_code=item_b, qty=1, rate=100)
+		so3 = make_sales_order(item_code=item_b, qty=1, rate=100)
+
+		def assert_mapped_discounts(document, source_fieldname):
+			items = {item.get(source_fieldname): item for item in document.items}
+
+			self.assertEqual(document.additional_discount_percentage, 0)
+			self.assertEqual(document.discount_amount, 0)
+			self.assertEqual(document.grand_total, 265)
+			self.assertEqual(items[so1.name].price_list_rate, 100)
+			self.assertEqual(items[so1.name].rate, 65)
+			self.assertEqual(items[so1.name].discount_amount, 35)
+			self.assertEqual(items[so1.name].net_amount, 65)
+			for sales_order in (so2.name, so3.name):
+				self.assertEqual(items[sales_order].rate, 100)
+				self.assertEqual(items[sales_order].discount_amount, 0)
+				self.assertEqual(items[sales_order].net_amount, 100)
+
+			return items
+
+		delivery_note_mapper = "erpnext.selling.doctype.sales_order.mapper.make_delivery_note"
+		for document_names in (
+			(so1.name, so2.name, so3.name),
+			(so3.name, so2.name, so1.name),
+		):
+			with self.subTest(mapper=delivery_note_mapper, document_names=document_names):
+				delivery_note = map_docs(
+					delivery_note_mapper, document_names, frappe.new_doc("Delivery Note").as_dict()
+				)
+				delivery_note.save()
+				items = assert_mapped_discounts(delivery_note, "against_sales_order")
+
+				items[so1.name].rate = 64
+				with self.assertRaisesRegex(frappe.ValidationError, "Rate must be same"):
+					delivery_note.save()
+
+		dn1 = make_delivery_note(so1.name).save().submit()
+		dn2 = make_delivery_note(so2.name).save().submit()
+		dn3 = make_delivery_note(so3.name).save().submit()
+
+		mapping_scenarios = (
+			(
+				"erpnext.selling.doctype.sales_order.mapper.make_sales_invoice",
+				(so1.name, so2.name, so3.name),
+			),
+			(
+				"erpnext.stock.doctype.delivery_note.mapper.make_sales_invoice",
+				(dn1.name, dn2.name, dn3.name),
+			),
+		)
+		for mapper, source_names in mapping_scenarios:
+			for document_names in (source_names, tuple(reversed(source_names))):
+				with self.subTest(mapper=mapper, document_names=document_names):
+					invoice = map_docs(mapper, document_names, frappe.new_doc("Sales Invoice").as_dict())
+					invoice.save()
+					items = assert_mapped_discounts(invoice, "sales_order")
+
+					items[so1.name].rate = 64
+					with self.assertRaisesRegex(frappe.ValidationError, "Rate must be same"):
+						invoice.save()
+
 	def test_discount_amount_partial_application_in_mapped_transactions(self):
 		"""
 		Test that discount amount is partially applied when some discount

--- a/erpnext/selling/doctype/sales_order/mapper.py
+++ b/erpnext/selling/doctype/sales_order/mapper.py
@@ -280,6 +280,12 @@ def make_delivery_note(
 
 		target.run_method("set_missing_values")
 		target.run_method("set_po_nos")
+		target.run_method(
+			"preserve_mapped_source_discounts",
+			source.doctype,
+			"against_sales_order",
+			"so_detail",
+		)
 		target.run_method("calculate_taxes_and_totals")
 		target.run_method("set_use_serial_batch_fields")
 
@@ -507,6 +513,12 @@ def make_sales_invoice(
 		target.flags.ignore_permissions = True
 		target.run_method("set_missing_values")
 		target.run_method("set_po_nos")
+		target.run_method(
+			"preserve_mapped_source_discounts",
+			source.doctype,
+			"sales_order",
+			"so_detail",
+		)
 		target.run_method("calculate_taxes_and_totals")
 		target.run_method("set_use_serial_batch_fields")
 

--- a/erpnext/stock/doctype/delivery_note/mapper.py
+++ b/erpnext/stock/doctype/delivery_note/mapper.py
@@ -88,6 +88,12 @@ def make_sales_invoice(
 		if args and args.get("merge_taxes"):
 			merge_taxes(source, target)
 
+		target.run_method(
+			"preserve_mapped_source_discounts",
+			source.doctype,
+			"delivery_note",
+			"dn_detail",
+		)
 		target.run_method("calculate_taxes_and_totals")
 
 		# set company address

--- a/erpnext/stock/doctype/purchase_receipt/mapper.py
+++ b/erpnext/stock/doctype/purchase_receipt/mapper.py
@@ -83,6 +83,12 @@ def make_purchase_invoice(
 		if args and args.get("merge_taxes"):
 			merge_taxes(source, doc)
 
+		doc.run_method(
+			"preserve_mapped_source_discounts",
+			source.doctype,
+			"purchase_receipt",
+			"pr_detail",
+		)
 		doc.run_method("calculate_taxes_and_totals")
 		from erpnext.accounts.services.payment_schedule import PaymentScheduleService
 

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -160,12 +160,31 @@ class TransactionBase(StatusUpdater):
 		stop_actions = []
 		for ref_dt, ref_dn_field, ref_link_field in ref_details:
 			reference_names = [d.get(ref_link_field) for d in self.get("items") if d.get(ref_link_field)]
+			uses_mapped_source_discounts = (
+				not flt(self.get("discount_amount"))
+				and not flt(self.get("additional_discount_percentage"))
+				and hasattr(self, "has_mixed_source_discounts")
+				and self.has_mixed_source_discounts(ref_dt, ref_dn_field)
+			)
 			reference_details = self.get_reference_details(reference_names, ref_dt + " Item")
+			reference_net_rates = (
+				self.get_reference_details(reference_names, ref_dt + " Item", "net_rate")
+				if uses_mapped_source_discounts
+				else {}
+			)
 			for d in self.get("items"):
 				if d.get(ref_link_field):
 					ref_rate = reference_details.get(d.get(ref_link_field))
+					ref_net_rate = reference_net_rates.get(d.get(ref_link_field))
+					mapped_discount_matches = ref_net_rate is not None and (
+						abs(flt(d.price_list_rate - ref_rate, d.precision("rate"))) < 0.01
+						and abs(flt(d.rate - ref_net_rate, d.precision("rate"))) < 0.01
+					)
 
-					if abs(flt(d.rate - ref_rate, d.precision("rate"))) >= 0.01:
+					if (
+						abs(flt(d.rate - ref_rate, d.precision("rate"))) >= 0.01
+						and not mapped_discount_matches
+					):
 						if action == "Stop":
 							if role_allowed_to_override not in frappe.get_roles():
 								stop_actions.append(
@@ -184,12 +203,12 @@ class TransactionBase(StatusUpdater):
 		if stop_actions:
 			frappe.throw(stop_actions, as_list=True)
 
-	def get_reference_details(self, reference_names, reference_doctype):
+	def get_reference_details(self, reference_names, reference_doctype, rate_fieldname="rate"):
 		return frappe._dict(
 			frappe.get_all(
 				reference_doctype,
 				filters={"name": ("in", reference_names)},
-				fields=["name", "rate"],
+				fields=["name", rate_fieldname],
 				as_list=1,
 			)
 		)


### PR DESCRIPTION
  ### Issue

  When Purchase Orders or Purchase Receipts with different additional discounts are combined into one Purchase Invoice, the discount from the last mapped document overwrites the previous discount.

**Ref:** [#77599](https://support.frappe.io/helpdesk/tickets/77599)

  ### Steps to reproduce

  1. Create a Purchase Order for Item A with a rate of 100.
  2. Apply a 35% additional discount on the Grand Total.
  3. Create another Purchase Order for Item B with a rate of 100 and no additional discount.
  4. Create separate Purchase Receipts for both orders.
  5. Fetch both Purchase Receipts into one Purchase Invoice.
  6. Repeat with the receipts fetched in the reverse order.

**Before:**

[Screencast from 2026-09-03 14-00-26.webm](https://github.com/user-attachments/assets/b975de8e-6cbf-4f42-9907-7602935b75a8)

**After:**

[Screencast from 2026-09-03 13-58-08.webm](https://github.com/user-attachments/assets/09695a4d-bd2e-4b38-a6d5-82562de7a196)


### Actual behaviour

  The final value depends on the order in which the source transactions are fetched.

  When the discounted transaction is fetched first:

  - Item A: 100 with its 35% discount lost = 100
  - Item B: 100 with no discount = 100
  - Final Purchase Invoice total: 200

  When the discounted transaction is fetched last:

  - Item A: 100 less 35% = 65
  - Item B: 100 incorrectly reduced by 35% = 65
  - Final Purchase Invoice total: 130

  ### Expected behaviour

  The discount from each source transaction should only apply to its corresponding items.

  - Item A: 100 less 35% = 65
  - Item B: 100 with no discount = 100
  - Final Purchase Invoice total: 165

  The final value should remain 165 regardless of the order in which the source transactions are fetched.


**Backport Needed For V16 and v15**