### PR TITLE
fix(batch): show Expired status only after expiry date has passed

### DIFF
--- a/erpnext/stock/doctype/batch/batch_list.js
+++ b/erpnext/stock/doctype/batch/batch_list.js
@@ -5,12 +5,12 @@ frappe.listview_settings["Batch"] = {
 			return [__("Disabled"), "gray", "disabled,=,1"];
 		} else if (
 			doc.expiry_date &&
-			frappe.datetime.get_diff(doc.expiry_date, frappe.datetime.nowdate()) <= 0
+			frappe.datetime.get_diff(doc.expiry_date, frappe.datetime.nowdate()) < 0
 		) {
 			return [
 				__("Expired"),
 				"red",
-				"expiry_date,not in,|expiry_date,<=,Today|batch_qty,>,0|disabled,=,0",
+				"expiry_date,not in,|expiry_date,<,Today|batch_qty,>,0|disabled,=,0",
 			];
 		} else if (!doc.batch_qty) {
 			return [__("Empty"), "gray", "batch_qty,=,0|disabled,=,0"];


### PR DESCRIPTION
### Issue

  Closes #58735

-  ERPNext handles a batch whose Expiry Date is today inconsistently. Stock transactions consider the expiry date the last valid day, while the Batch list and Pick List consider the batch already expired.

### Steps to reproduce

1. Create a Batch for a batched item with Expiry Date = today and keep qty > 0 in stock.
2. Open the Batch list → before this fix, the batch shows the red Expired indicator.
3. Create a Delivery Note for the same item → the batch is still selectable in the Batch No field, and the document submits successfully.
4. (Optional) Try a Pick List for the same batch → validation throws "The following batches are expired".

### After 

[Screencast from 2026-09-03 17-15-49.webm](https://github.com/user-attachments/assets/a7678094-2402-4081-8e90-51b4f8bcbe6c)


### Actual behaviour

A batch whose Expiry Date is today shows the red Expired indicator in the Batch list view, while the same batch is still valid and selectable in Delivery Note and other stock transactions — the system contradicts itself on the same day. Pick List validation even blocks the same batch, so on the expiry date: the list view says Expired, Delivery Note accepts the batch, and Pick List rejects it.

### Expected behaviour

The expiry date is the last day the batch is valid. A batch should be shown as Expired only when its expiry date is in the past, and the Batch list view should agree with the transactional behaviour of Delivery Note and other stock documents.


**Backport Needed For V15 and V16**