### PR TITLE
fix: check material request price list permission

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -102,8 +102,27 @@ frappe.ui.form.on("Material Request", {
 		erpnext.accounts.dimensions.setup_dimension_filters(frm, frm.doctype);
 		if (!frm.doc.buying_price_list) {
 			const buying_price_list = frappe.defaults.get_default("buying_price_list");
-			if (frappe.has_permission("Price List", "read", buying_price_list)) {
-				frm.set_value("buying_price_list", buying_price_list);
+			if (buying_price_list) {
+				const docname = frm.doc.name;
+				frappe.call({
+					type: "GET",
+					method: "frappe.client.has_permission",
+					no_spinner: true,
+					args: {
+						doctype: "Price List",
+						docname: buying_price_list,
+						perm_type: "read",
+					},
+					callback: ({ message }) => {
+						if (
+							message?.has_permission &&
+							frm.doc.name === docname &&
+							!frm.doc.buying_price_list
+						) {
+							frm.set_value("buying_price_list", buying_price_list);
+						}
+					},
+				});
 			}
 		}
 	},


### PR DESCRIPTION
### Issue
-  When a new Material Request has no Price List while a default Buying Price List is configured, the form calls `frappe.has_permission`. 

Closes : [#58739](https://github.com/frappe/erpnext/issues/58739)

  ### Steps to reproduce

  1. Configure a default Buying Price List in Buying Settings.
  2. Open a new Material Request where the Price List is not already populated.
  3. Check the browser console.


### Before 

<img width="1280" height="663" alt="image" src="https://github.com/user-attachments/assets/e1ad6598-dfd5-40f9-a428-8bff5bfef402" />


### After 

<img width="1852" height="898" alt="image" src="https://github.com/user-attachments/assets/f45ead9d-5a7e-401f-8edd-f58546f913c4" />


  ### Actual behaviour

  The form raises:

  `TypeError: frappe.has_permission is not a function.`

  The default Buying Price List is not applied.

  ### Expected behaviour

  The default Buying Price List should be applied only when the user has read permission for it, without producing a JavaScript error or overwriting a manually selected Price List.

  ### Backport needed for v15 and v16