### PR TITLE
fix(payment reconciliation): correct exchange gain/loss direction for journal-settled foreign currency payables

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -451,9 +451,10 @@ class PaymentReconciliation(Document):
 				)
 
 				# Added If clause to handle return Adhoc payments for account type holders ("Payable")
-				if party_account_defaults.get("account_type") in ("Payable") and invoice.get(
-					"invoice_type"
-				) in ["Payment Entry", "Journal Entry"]:
+				if (
+					party_account_defaults.get("account_type") in ("Payable")
+					and invoice.get("invoice_type") == "Payment Entry"
+				):
 					difference_amount = allocated_amount_in_inv_rate - allocated_amount_in_ref_rate
 				else:
 					difference_amount = allocated_amount_in_ref_rate - allocated_amount_in_inv_rate

--- a/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
@@ -2796,9 +2796,120 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		payments = [payment.as_dict() for payment in pr.payments]
 		pr.allocate_entries(frappe._dict({"invoices": invoices, "payments": payments}))
 
-		# Check the difference_amount is a gain of 5000
-		self.assertEqual(flt(pr.allocation[0].difference_amount), 5000.0)
+		self.assertEqual(flt(pr.allocation[0].difference_amount), -5000.0)
 		pr.reconcile()
+
+		gain_loss_journal = frappe.db.get_value(
+			"Journal Entry Account",
+			{
+				"reference_type": "Journal Entry",
+				"reference_name": je2.name,
+				"party": self.supplier,
+				"docstatus": 1,
+			},
+			"parent",
+		)
+		party_row = frappe.db.get_value(
+			"Journal Entry Account",
+			{"parent": gain_loss_journal, "account": self.creditors_usd, "party": self.supplier},
+			["debit", "credit"],
+			as_dict=True,
+		)
+		self.assertEqual(flt(party_row.debit), 5000)
+		self.assertEqual(flt(party_row.credit), 0)
+
+		party_gl_entries = frappe.get_all(
+			"GL Entry",
+			filters={
+				"voucher_no": ["in", [je1.name, je2.name, gain_loss_journal]],
+				"account": self.creditors_usd,
+				"party": self.supplier,
+				"is_cancelled": 0,
+			},
+			fields=["debit", "credit"],
+		)
+		self.assertEqual(flt(sum(row.debit - row.credit for row in party_gl_entries)), 0)
+
+	def test_foreign_currency_journal_payable_against_journal_gain_loss_for_supplier(self):
+		transaction_date = nowdate()
+		self.supplier = "_Test Supplier USD"
+		amount = 1000
+		allocated = 400
+		invoice_rate = 83
+		settlement_rate = 85
+
+		je1 = self.create_journal_entry(self.cash, self.creditors_usd, amount, transaction_date)
+		je1.multi_currency = 1
+		je1.accounts[0].exchange_rate = 1
+		je1.accounts[0].debit = invoice_rate * amount
+		je1.accounts[0].debit_in_account_currency = invoice_rate * amount
+		je1.accounts[1].party_type = "Supplier"
+		je1.accounts[1].party = self.supplier
+		je1.accounts[1].exchange_rate = invoice_rate
+		je1.accounts[1].credit_in_account_currency = amount
+		je1.accounts[1].credit = invoice_rate * amount
+		je1.save()
+		je1.submit()
+
+		je2 = self.create_journal_entry(self.creditors_usd, self.cash, allocated, transaction_date)
+		je2.multi_currency = 1
+		je2.accounts[0].party_type = "Supplier"
+		je2.accounts[0].party = self.supplier
+		je2.accounts[0].exchange_rate = settlement_rate
+		je2.accounts[0].debit_in_account_currency = allocated
+		je2.accounts[0].debit = settlement_rate * allocated
+		je2.accounts[1].exchange_rate = 1
+		je2.accounts[1].credit = settlement_rate * allocated
+		je2.accounts[1].credit_in_account_currency = settlement_rate * allocated
+		je2.save()
+		je2.submit()
+
+		pr = self.create_payment_reconciliation(party_is_customer=False)
+		pr.party = self.supplier
+		pr.receivable_payable_account = self.creditors_usd
+		pr.get_unreconciled_entries()
+
+		self.assertEqual(len(pr.invoices), 1)
+		self.assertEqual(len(pr.payments), 1)
+
+		invoices = [invoice.as_dict() for invoice in pr.invoices]
+		payments = [payment.as_dict() for payment in pr.payments]
+		pr.allocate_entries(frappe._dict({"invoices": invoices, "payments": payments}))
+
+		self.assertEqual(flt(pr.allocation[0].difference_amount), 800.0)
+		pr.reconcile()
+
+		gain_loss_journal = frappe.db.get_value(
+			"Journal Entry Account",
+			{
+				"reference_type": "Journal Entry",
+				"reference_name": je1.name,
+				"party": self.supplier,
+				"docstatus": 1,
+			},
+			"parent",
+		)
+		party_row = frappe.db.get_value(
+			"Journal Entry Account",
+			{"parent": gain_loss_journal, "account": self.creditors_usd, "party": self.supplier},
+			["debit", "credit"],
+			as_dict=True,
+		)
+		self.assertEqual(flt(party_row.debit), 0)
+		self.assertEqual(flt(party_row.credit), 800)
+
+		party_gl_entries = frappe.get_all(
+			"GL Entry",
+			filters={
+				"voucher_no": ["in", [je1.name, je2.name, gain_loss_journal]],
+				"account": self.creditors_usd,
+				"party": self.supplier,
+				"is_cancelled": 0,
+			},
+			fields=["debit", "credit"],
+		)
+		outstanding_in_base = (amount - allocated) * invoice_rate
+		self.assertEqual(flt(sum(row.credit - row.debit for row in party_gl_entries)), outstanding_in_base)
 
 	def test_cr_note_split_across_invoices_floating_point_precision(self):
 		"""Regression: when a credit note is split across multiple invoices, floating-point


### PR DESCRIPTION
## Issue
When a foreign-currency payable created through a Journal Entry—such as an opening balance, expense accrual, or manual creditor entry—is settled against another Journal Entry through Payment Reconciliation at a different exchange rate, the system-generated Exchange Gain or Loss Journal Entry is posted in the wrong direction.

## Steps to Reproduce
Company currency: `INR`
Payable account currency: `USD`
1. Create `JE-1` to record a USD 1,000 payable at an exchange rate of 83

   * Credit `Creditors (USD)`: USD 1,000 / INR 83,000
   * Debit `Expense`: INR 83,000

2. Create `JE-2` to settle USD 400 at an exchange rate of 85:

   * Debit `Creditors (USD)`: USD 400 / INR 34,000
   * Credit `Cash/Bank`: INR 34,000

3. Open Payment Reconciliation and select:

   * Party Type: `Supplier`
   * Party: the relevant supplier
   * Payable Account: the USD payable account

4. Allocate USD 400 from `JE-2` against `JE-1` and reconcile.

## Before
[Screencast from 2026-09-03 18-32-18.webm](https://github.com/user-attachments/assets/9e7147eb-56d8-48b9-bb49-954166b14e91)


## After
[Screencast from 2026-09-03 18-30-22.webm](https://github.com/user-attachments/assets/f57b2ba8-09fc-4b5e-9b98-843c489c8d51)


