### PR TITLE
fix(timesheet): handle empty allowed projects

### DIFF
--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 import datetime
+from unittest.mock import patch
 
 import frappe
 from frappe.utils import add_to_date, now_datetime, nowdate
@@ -8,12 +9,20 @@ from frappe.utils import add_to_date, now_datetime, nowdate
 from erpnext.accounts.doctype.sales_invoice.mapper import make_sales_return
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.projects.doctype.task.test_task import create_task
-from erpnext.projects.doctype.timesheet.timesheet import OverlapError, make_sales_invoice
+from erpnext.projects.doctype.timesheet.timesheet import (
+	OverlapError,
+	get_projectwise_timesheet_data,
+	make_sales_invoice,
+)
 from erpnext.setup.doctype.employee.test_employee import make_employee
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestTimesheet(ERPNextTestSuite):
+	def test_get_projectwise_timesheet_data_without_allowed_projects(self):
+		with patch("frappe.get_list", side_effect=[["TS-0001"], []]):
+			self.assertEqual(get_projectwise_timesheet_data(), [])
+
 	def test_timesheet_post_update(self):
 		frappe.get_doc(
 			{

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -339,9 +339,13 @@ def get_projectwise_timesheet_data(
 			& (tsd.is_billable == 1)
 			& tsd.sales_invoice.isnull()
 			& (tsd.parent.isin(allowed_timesheets))
-			& ((tsd.project.isin(allowed_projects)) | (tsd.project.isnull()))
 		)
 	)
+
+	if allowed_projects:
+		query = query.where((tsd.project.isin(allowed_projects)) | (tsd.project.isnull()))
+	else:
+		query = query.where(tsd.project.isnull())
 
 	if project:
 		query = query.where(tsd.project == project)


### PR DESCRIPTION
Handle users with no accessible Projects when fetching billable Timesheets.