### PR TITLE
fix(manufacturing): undo material transfer repair data

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -5610,6 +5610,121 @@ class TestWorkOrder(ERPNextTestSuite):
 		conversion_entry = frappe.get_doc(make_fg_conversion_entry(wo_order.name, alt_item, 2))
 		self.assertRaises(frappe.ValidationError, conversion_entry.insert)
 
+	def test_undo_work_order_material_transfer_repair(self):
+		from erpnext.patches.v16_0.undo_work_order_material_transfer_repair import (
+			_get_legacy_material_transferred,
+			get_undo_updates,
+		)
+
+		precision = frappe.get_precision("Work Order Item", "required_qty")
+		hidden_difference = 4 / (10 ** (precision + 1))
+		test_stock_entry.make_stock_entry(
+			item_code="_Test Item", target="_Test Warehouse - _TC", qty=100, basic_rate=5000.0
+		)
+		test_stock_entry.make_stock_entry(
+			item_code="_Test Item Home Desktop 100",
+			target="_Test Warehouse - _TC",
+			qty=100,
+			basic_rate=1000.0,
+		)
+
+		def simulate_repair(work_order):
+			for index, row in enumerate(work_order.required_items):
+				required_qty = flt(row.required_qty) + (hidden_difference if index == 0 else 0)
+				row.db_set("required_qty", required_qty, update_modified=False)
+
+			work_order.reload()
+			required_qty = {row.item_code: row.required_qty for row in work_order.required_items}
+			transfer_entry = frappe.get_doc(
+				make_stock_entry(work_order.name, "Material Transfer for Manufacture", 0)
+			)
+			for item in transfer_entry.items:
+				item.qty = flt(required_qty[item.item_code], precision)
+				item.transfer_qty = item.qty
+			transfer_entry.submit()
+
+			work_order.reload()
+			work_order.db_set("material_transferred_for_manufacturing", work_order.qty, update_modified=False)
+			return transfer_entry
+
+		affected_work_order = make_wo_order_test_record(planned_start_date=now(), qty=2)
+		simulate_repair(affected_work_order)
+		changed_work_order = make_wo_order_test_record(planned_start_date=now(), qty=2)
+		changed_transfer = simulate_repair(changed_work_order)
+		mismatched_work_order = make_wo_order_test_record(planned_start_date=now(), qty=2)
+		simulate_repair(mismatched_work_order)
+		mismatched_row = mismatched_work_order.required_items[0]
+		mismatched_row.db_set("transferred_qty", mismatched_row.transferred_qty + 1, update_modified=False)
+
+		patch_run_at = add_to_date(now(), minutes=1)
+		frappe.db.set_value(
+			"Stock Entry",
+			changed_transfer.name,
+			"modified",
+			add_to_date(patch_run_at, seconds=1),
+			update_modified=False,
+		)
+
+		updates = get_undo_updates(patch_run_at)
+		self.assertIn(affected_work_order.name, updates)
+		self.assertNotIn(changed_work_order.name, updates)
+		self.assertNotIn(mismatched_work_order.name, updates)
+
+		expected_qty = (
+			min(row.transferred_qty / row.required_qty for row in affected_work_order.required_items)
+			* affected_work_order.qty
+		)
+		self.assertAlmostEqual(
+			updates[affected_work_order.name]["material_transferred_for_manufacturing"], expected_qty
+		)
+		self.assertEqual(
+			_get_legacy_material_transferred(
+				{"qty": 2, "required_qty": {"RM": 2}, "transferred_qty": {"RM": 2}},
+				1.25,
+				{"RM": 2},
+			),
+			1.25,
+		)
+
+		frappe.db.bulk_update(
+			"Work Order",
+			{affected_work_order.name: updates[affected_work_order.name]},
+			update_modified=False,
+		)
+		affected_work_order.reload()
+		self.assertAlmostEqual(affected_work_order.material_transferred_for_manufacturing, expected_qty)
+		self.assertNotIn(affected_work_order.name, get_undo_updates(patch_run_at))
+
+	def test_undo_work_order_material_transfer_patch_log_guard(self):
+		from unittest import mock
+
+		from frappe.utils import get_datetime
+
+		from erpnext.patches.v16_0 import undo_work_order_material_transfer_repair as undo_patch
+
+		missing_patch = f"{undo_patch.ORIGINAL_PATCH}.missing.{frappe.generate_hash()}"
+		with (
+			mock.patch.object(undo_patch, "ORIGINAL_PATCH", missing_patch),
+			mock.patch.object(frappe.db, "bulk_update") as bulk_update,
+		):
+			undo_patch.execute()
+		bulk_update.assert_not_called()
+
+		patch_name = f"{undo_patch.ORIGINAL_PATCH}.test.{frappe.generate_hash()}"
+		patch_log = frappe.get_doc({"doctype": "Patch Log", "patch": patch_name}).insert(
+			ignore_permissions=True
+		)
+		updates = {"WO-TEST": {"material_transferred_for_manufacturing": 1}}
+		with (
+			mock.patch.object(undo_patch, "ORIGINAL_PATCH", patch_name),
+			mock.patch.object(undo_patch, "get_undo_updates", return_value=updates) as get_undo_updates,
+			mock.patch.object(frappe.db, "bulk_update") as bulk_update,
+		):
+			undo_patch.execute()
+
+		get_undo_updates.assert_called_once_with(get_datetime(patch_log.creation))
+		bulk_update.assert_called_once_with("Work Order", updates, update_modified=False)
+
 
 def prepare_data_for_fg_conversion_test():
 	fg_item = make_item("_Test FG Conversion Item", {"is_stock_item": 1, "allow_alternative_item": 1}).name

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -520,3 +520,4 @@ erpnext.patches.v16_0.add_transaction_roles_to_sms_settings
 erpnext.patches.v16_0.set_secondary_item_valuation_type
 erpnext.patches.v16_0.append_fieldname_to_pos_search_fields
 erpnext.patches.v16_0.set_supplier_quotation_order_status
+erpnext.patches.v16_0.undo_work_order_material_transfer_repair

--- a/erpnext/patches/v16_0/undo_work_order_material_transfer_repair.py
+++ b/erpnext/patches/v16_0/undo_work_order_material_transfer_repair.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+from frappe.query_builder.functions import IfNull, Sum
+from frappe.utils import create_batch, flt, get_datetime
+from pypika import functions as fn
+
+ORIGINAL_PATCH = "erpnext.patches.v16_0.repair_work_order_material_transfer"
+BATCH_SIZE = 1000
+TERMINAL_STATUSES = ("Stopped", "Closed", "Completed")
+
+
+def execute():
+	patch_run_at = get_original_patch_run_at()
+	if not patch_run_at:
+		return
+
+	updates = get_undo_updates(patch_run_at)
+	if updates:
+		frappe.db.bulk_update("Work Order", updates, update_modified=False)
+
+
+def get_original_patch_run_at():
+	return frappe.db.get_value("Patch Log", {"patch": ORIGINAL_PATCH, "skipped": 0}, "creation")
+
+
+def get_undo_updates(patch_run_at=None):
+	patch_run_at = patch_run_at or get_original_patch_run_at()
+	if not patch_run_at:
+		return {}
+	patch_run_at = get_datetime(patch_run_at)
+
+	work_orders = _get_candidate_work_orders(patch_run_at)
+	for name in _get_work_orders_with_later_stock_entries(work_orders, patch_run_at):
+		work_orders.pop(name, None)
+
+	claimed_qty = _get_claimed_qty(work_orders)
+	transferred_qty = _get_transferred_qty(work_orders)
+	precision = frappe.get_precision("Work Order Item", "required_qty")
+	updates = {}
+	for name, values in work_orders.items():
+		if not _has_full_coverage_at_precision(values, precision):
+			continue
+		if not _matches_cached_transfers(values, transferred_qty.get(name, {})):
+			continue
+
+		legacy_qty = _get_legacy_material_transferred(
+			values, claimed_qty.get(name), transferred_qty.get(name, {})
+		)
+		if legacy_qty < values["current_qty"]:
+			updates[name] = {"material_transferred_for_manufacturing": legacy_qty}
+
+	return updates
+
+
+def _get_candidate_work_orders(patch_run_at):
+	work_orders = {}
+	for row in _get_candidate_rows(patch_run_at):
+		values = work_orders.setdefault(
+			row.work_order,
+			{
+				"qty": flt(row.qty),
+				"current_qty": flt(row.current_qty),
+				"required_qty": {},
+				"transferred_qty": {},
+				"changed_after_patch": False,
+			},
+		)
+		item_code = row.item_code
+		values["required_qty"][item_code] = values["required_qty"].get(item_code, 0.0) + flt(row.required_qty)
+		values["transferred_qty"][item_code] = max(
+			values["transferred_qty"].get(item_code, 0.0), flt(row.transferred_qty)
+		)
+		values["changed_after_patch"] |= get_datetime(row.item_modified) > patch_run_at
+
+	return {name: values for name, values in work_orders.items() if not values["changed_after_patch"]}
+
+
+def _get_candidate_rows(patch_run_at):
+	work_order = frappe.qb.DocType("Work Order")
+	required_item = frappe.qb.DocType("Work Order Item")
+	return (
+		frappe.qb.from_(work_order)
+		.inner_join(required_item)
+		.on(required_item.parent == work_order.name)
+		.select(
+			work_order.name.as_("work_order"),
+			work_order.qty,
+			work_order.material_transferred_for_manufacturing.as_("current_qty"),
+			required_item.item_code,
+			required_item.required_qty,
+			required_item.transferred_qty,
+			required_item.modified.as_("item_modified"),
+		)
+		.where(
+			(work_order.docstatus == 1)
+			& (work_order.status.notin(TERMINAL_STATUSES))
+			& (fn.Coalesce(work_order.skip_transfer, 0) == 0)
+			& (fn.Coalesce(work_order.track_semi_finished_goods, 0) == 0)
+			& (work_order.material_transferred_for_manufacturing == work_order.qty)
+			& (fn.Coalesce(work_order.transfer_material_against, "") != "Job Card")
+			& (work_order.creation <= patch_run_at)
+			& (work_order.modified <= patch_run_at)
+			& (required_item.include_item_in_manufacturing == 1)
+			& (required_item.required_qty > 0)
+		)
+	).run(as_dict=True)
+
+
+def _get_work_orders_with_later_stock_entries(work_orders, patch_run_at):
+	changed_work_orders = set()
+	stock_entry = frappe.qb.DocType("Stock Entry")
+	for names in create_batch(list(work_orders), BATCH_SIZE):
+		rows = (
+			frappe.qb.from_(stock_entry)
+			.select(stock_entry.work_order)
+			.where(
+				(stock_entry.work_order.isin(names))
+				& ((stock_entry.creation > patch_run_at) | (stock_entry.modified > patch_run_at))
+			)
+			.groupby(stock_entry.work_order)
+		).run(as_dict=True)
+		changed_work_orders.update(row.work_order for row in rows)
+
+	return changed_work_orders
+
+
+def _get_claimed_qty(work_orders):
+	claimed_qty = {}
+	stock_entry = frappe.qb.DocType("Stock Entry")
+	job_card = frappe.qb.DocType("Job Card")
+	for names in create_batch(list(work_orders), BATCH_SIZE):
+		rows = (
+			frappe.qb.from_(stock_entry)
+			.left_join(job_card)
+			.on(stock_entry.job_card == job_card.name)
+			.select(stock_entry.work_order, Sum(stock_entry.fg_completed_qty).as_("qty"))
+			.where(
+				(stock_entry.work_order.isin(names))
+				& (stock_entry.docstatus == 1)
+				& (stock_entry.purpose == "Material Transfer for Manufacture")
+				& (stock_entry.is_additional_transfer_entry == 0)
+				& (IfNull(job_card.is_corrective_job_card, 0) == 0)
+			)
+			.groupby(stock_entry.work_order)
+		).run(as_dict=True)
+		claimed_qty.update({row.work_order: flt(row.qty) for row in rows})
+
+	return claimed_qty
+
+
+def _get_transferred_qty(work_orders):
+	transferred_qty = {}
+	stock_entry = frappe.qb.DocType("Stock Entry")
+	stock_entry_detail = frappe.qb.DocType("Stock Entry Detail")
+	job_card = frappe.qb.DocType("Job Card")
+	for names in create_batch(list(work_orders), BATCH_SIZE):
+		rows = (
+			frappe.qb.from_(stock_entry)
+			.inner_join(stock_entry_detail)
+			.on(stock_entry_detail.parent == stock_entry.name)
+			.left_join(job_card)
+			.on(stock_entry.job_card == job_card.name)
+			.select(
+				stock_entry.work_order,
+				stock_entry_detail.item_code,
+				stock_entry_detail.original_item,
+				Sum(stock_entry_detail.transfer_qty).as_("qty"),
+			)
+			.where(
+				(stock_entry.work_order.isin(names))
+				& (stock_entry.docstatus == 1)
+				& (stock_entry.purpose == "Material Transfer for Manufacture")
+				& (stock_entry.is_return == 0)
+				& (IfNull(job_card.is_corrective_job_card, 0) == 0)
+			)
+			.groupby(stock_entry.work_order, stock_entry_detail.item_code, stock_entry_detail.original_item)
+		).run(as_dict=True)
+
+		for row in rows:
+			item_code = row.original_item or row.item_code
+			work_order_qty = transferred_qty.setdefault(row.work_order, {})
+			work_order_qty[item_code] = work_order_qty.get(item_code, 0.0) + flt(row.qty)
+
+	return transferred_qty
+
+
+def _has_full_coverage_at_precision(values, precision):
+	coverage = []
+	for item_code, required_qty in values["required_qty"].items():
+		transferred_qty = flt(values["transferred_qty"].get(item_code))
+		if flt(transferred_qty, precision) == flt(required_qty, precision):
+			coverage.append(1.0)
+		else:
+			coverage.append(transferred_qty / required_qty)
+
+	return min(coverage, default=0.0) >= 1.0
+
+
+def _matches_cached_transfers(values, transferred_qty):
+	# The original patch stored no affected-row list. Matching the source ledger to its cache
+	# avoids changing Work Orders whose transfer state became stale outside that patch.
+	return all(
+		flt(values["transferred_qty"].get(item_code)) == flt(transferred_qty.get(item_code))
+		for item_code in values["required_qty"]
+	)
+
+
+def _get_legacy_material_transferred(values, claimed_qty, transferred_qty):
+	if claimed_qty:
+		return flt(claimed_qty)
+
+	coverage = min(
+		(
+			flt(transferred_qty.get(item_code)) / required_qty
+			for item_code, required_qty in values["required_qty"].items()
+		),
+		default=0.0,
+	)
+	return min(coverage, 1.0) * values["qty"]


### PR DESCRIPTION
## What changed

- Add a one-time patch that behaviorally reverses the Work Order data changes made by #58110.
- Consider only Work Orders that the original repair patch could have changed and whose transferred quantity still equals the planned quantity.
- Require cached transferred quantities to match submitted Stock Entry totals before an update.
- Reconstruct the pre-#58110 value from submitted Stock Entries. Use the legacy claimed quantity first, then the exact least-covered component ratio.
- Skip Work Orders, required-item rows, and Stock Entry histories changed after the original patch ran.
- No-op on sites where the original patch did not run.

## Merge order

Merge after #58714. That PR removes the code and patch introduced by #58110 and its dependent changes from `develop`.

## Safety

This is a conservative behavioral reconstruction. The original patch did not record its affected rows or their previous values.

The patch uses the original Patch Log timestamp. It also skips records with detectable later activity or a mismatch between the source ledger and the Work Order cache.

The `develop` calculation excludes additional transfers and corrective Job Card transfers. This matches the branch behavior from before #58110.

## Tests

- Added regression coverage for hidden precision differences, later Stock Entry activity, cache mismatches, claimed quantities, Patch Log gating, and idempotence.
- `pre-commit run --files erpnext/patches/v16_0/undo_work_order_material_transfer_repair.py erpnext/manufacturing/doctype/work_order/test_work_order.py erpnext/patches.txt`
- Executed the patch queries in read-only mode against a local MariaDB site.
- The focused Frappe test could not run locally because this bench's Frappe checkout cannot import the `Gender` controller during test discovery.
