### PR TITLE
fix(banking): find transfers on the same day

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -912,7 +912,7 @@ def search_for_transfer_transaction(transaction_id: str | int):
 
 	days = frappe.db.get_single_value("Accounts Settings", "transfer_match_days")
 
-	if not days:
+	if days is None:
 		days = 3
 
 	min_date = frappe.utils.add_days(date, -days)


### PR DESCRIPTION
When same day is selected for finding transfers, the system was defaulting to 3 days because of a wrong value check.

`no-docs`