### PR TITLE
fix: skip reporting-currency conversion when no reporting currency is set

### DIFF
--- a/erpnext/accounts/doctype/account_closing_balance/account_closing_balance.py
+++ b/erpnext/accounts/doctype/account_closing_balance/account_closing_balance.py
@@ -158,6 +158,9 @@ def set_amount_in_reporting_currency(cle, company, closing_date):
 		"Company", company, ["default_currency", "reporting_currency"]
 	)
 
+	if not reporting_currency:
+		return
+
 	reporting_currency_exchange_rate = get_exchange_rate(default_currency, reporting_currency, closing_date)
 	if not reporting_currency_exchange_rate:
 		frappe.throw(

--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -303,6 +303,9 @@ class GLEntry(Document):
 		default_currency, reporting_currency = frappe.get_cached_value(
 			"Company", self.company, ["default_currency", "reporting_currency"]
 		)
+		if not reporting_currency:
+			return
+
 		transaction_date = self.transaction_date or self.posting_date
 		self.reporting_currency_exchange_rate = get_exchange_rate(
 			default_currency, reporting_currency, transaction_date


### PR DESCRIPTION
## Problem

Companies without a configured reporting currency — which includes every company migrated from pre-v15 data — crash with `ReportingCurrencyExchangeNotFoundError`: `get_exchange_rate` returns None for a missing target currency and both conversion sites then throw. This breaks the v14 `update_closing_balances` patch during migration and every GL insert afterwards.

Found while migrating a v14-era production backup to develop.

## Fix

No reporting currency configured means the feature is off — both conversion sites now skip instead of throwing.

## How to test

Restore a pre-v15 backup (companies have no reporting currency), run `bench migrate`, then submit any GL-posting voucher. Both complete; with a reporting currency configured, conversion behaves as before.