### PR TITLE
fix: guard acc_frozen_upto reads in pre-v16 patches

### DIFF
--- a/erpnext/patches/v13_0/modify_invalid_gain_loss_gl_entries.py
+++ b/erpnext/patches/v13_0/modify_invalid_gain_loss_gl_entries.py
@@ -45,7 +45,7 @@ def execute():
 			message=json.dumps(purchase_invoices + sales_invoices, indent=2),
 		)
 
-	acc_frozen_upto = frappe.db.get_single_value("Accounts Settings", "acc_frozen_upto")
+	acc_frozen_upto = _acc_frozen_upto()
 	if acc_frozen_upto:
 		frappe.db.set_single_value("Accounts Settings", "acc_frozen_upto", None)
 
@@ -66,3 +66,9 @@ def execute():
 
 	if acc_frozen_upto:
 		frappe.db.set_single_value("Accounts Settings", "acc_frozen_upto", acc_frozen_upto)
+
+
+def _acc_frozen_upto():
+	if not frappe.get_meta("Accounts Settings").has_field("acc_frozen_upto"):
+		return None  # freezing settings moved to Company in v16
+	return frappe.db.get_single_value("Accounts Settings", "acc_frozen_upto")

--- a/erpnext/patches/v14_0/single_to_multi_dunning.py
+++ b/erpnext/patches/v14_0/single_to_multi_dunning.py
@@ -63,9 +63,10 @@ def execute():
 
 def get_accounts_closing_date():
 	"""Get the date when accounts were frozen/closed"""
-	accounts_frozen_till = frappe.db.get_single_value(
-		"Accounts Settings", "acc_frozen_upto"
-	)  # always returns datetime.date
+	accounts_frozen_till = None
+	if frappe.get_meta("Accounts Settings").has_field("acc_frozen_upto"):
+		# freezing settings moved to Company in v16
+		accounts_frozen_till = frappe.db.get_single_value("Accounts Settings", "acc_frozen_upto")
 
 	period_closing_date = frappe.db.get_value(
 		"Period Closing Voucher", {"docstatus": 1}, "period_end_date", order_by="period_end_date desc"

--- a/erpnext/patches/v15_0/recalculate_amount_difference_field.py
+++ b/erpnext/patches/v15_0/recalculate_amount_difference_field.py
@@ -58,7 +58,9 @@ def execute():
 		):
 			posting_date = period_closing_voucher[0].period_end_date
 
-		acc_frozen_upto = frappe.db.get_single_value("Accounts Settings", "acc_frozen_upto")
+		acc_frozen_upto = None
+		if frappe.get_meta("Accounts Settings").has_field("acc_frozen_upto"):
+			acc_frozen_upto = frappe.db.get_single_value("Accounts Settings", "acc_frozen_upto")
 		if acc_frozen_upto and getdate(acc_frozen_upto) > getdate(posting_date):
 			posting_date = acc_frozen_upto
 


### PR DESCRIPTION
## Problem

Three old patches (`v13_0.modify_invalid_gain_loss_gl_entries`, `v14_0.single_to_multi_dunning`, `v15_0.recalculate_amount_difference_field`) read `Accounts Settings.acc_frozen_upto`, which was removed when the books-freeze setting moved to Company. Any migration path that runs these patches on current develop crashes.

Found while migrating a v14-era production backup to develop.

## Fix

The patches guard the read: they only lift/restore the freeze when the field still exists in the schema being migrated. The temporary freeze-lift lives on Company now and does not apply to these historical patches anyway.

## How to test

Restore a pre-v15 backup and run `bench migrate` — all three patches complete instead of raising on the missing field.