### PR TITLE
fix: select tax withholding columns only when they exist

### DIFF
--- a/erpnext/patches/v15_0/migrate_old_item_wise_tax_detail_data_to_table.py
+++ b/erpnext/patches/v15_0/migrate_old_item_wise_tax_detail_data_to_table.py
@@ -92,7 +92,9 @@ def get_items_for_docs(parents, doctype):
 	item = frappe.qb.DocType(f"{doctype} Item")
 	additional_fields = []
 
-	if doctype in TAX_WITHHOLDING_DOCS:
+	# the tax withholding refactor removed these columns; fresh migrations of
+	# old databases never get them, so select only what exists
+	if doctype in TAX_WITHHOLDING_DOCS and frappe.db.has_column(f"{doctype} Item", "apply_tds"):
 		additional_fields.append(item.apply_tds)
 
 	return (
@@ -116,7 +118,7 @@ def get_items_for_docs(parents, doctype):
 def get_doc_details(parents, doctype):
 	inv = frappe.qb.DocType(doctype)
 	additional_fields = []
-	if doctype in TAX_WITHHOLDING_DOCS:
+	if doctype in TAX_WITHHOLDING_DOCS and frappe.db.has_column(doctype, "base_tax_withholding_net_total"):
 		additional_fields.append(inv.base_tax_withholding_net_total)
 
 	return (


### PR DESCRIPTION
## Problem

The tax-withholding patch path selects columns that were removed from the doctype in a later refactor; migrating any site whose schema predates the removal crashes with an unknown-column OperationalError.

Found while migrating a v14-era production backup to develop.

## Fix

The query builds its column list from the columns actually present on the table being migrated, so era-dependent schemas migrate cleanly.

## How to test

Restore a pre-v15 backup with tax-withholding data and run `bench migrate` — the patch completes on both old and current schemas.