### PR TITLE
test(manufacturing): refresh cached production plans before assertion

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -1402,9 +1402,11 @@ class TestProductionPlan(FrappeTestCase):
 
 		self.assertEqual(after_qty, before_qty)
 
-		completed_plans = get_non_completed_production_plans()
+		# Plan submission cached this list before the Work Orders updated ordered quantities.
+		frappe.clear_cache()
+		non_completed_plans = get_non_completed_production_plans()
 		for plan in plans:
-			self.assertFalse(plan in completed_plans)
+			self.assertNotIn(plan, non_completed_plans)
 
 	def test_resered_qty_for_production_plan_for_material_requests_with_multi_UOM(self):
 		from erpnext.stock.utils import get_or_make_bin

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -1403,7 +1403,7 @@ class TestProductionPlan(FrappeTestCase):
 		self.assertEqual(after_qty, before_qty)
 
 		# Plan submission cached this list before the Work Orders updated ordered quantities.
-		frappe.clear_cache()
+		frappe.local.request_cache.clear()
 		non_completed_plans = get_non_completed_production_plans()
 		for plan in plans:
 			self.assertNotIn(plan, non_completed_plans)


### PR DESCRIPTION
The version-15 Production Plan test reads a cached list after it submits Work Orders. The stale list still includes the plan and causes the final assertion to fail.

Clear the request cache before the final query so the assertion checks the submitted Work Orders. Keep the existing reservation assertions and use `assertNotIn` for the plan check.

The same failure appears in the CI runs for #58686, #58771, and #58702.

Validation:
- Reproduced the original failure on an isolated Frappe and ERPNext version-15 bench.
- Passed the focused test after the change.
- Passed all 52 tests with `bench --site test_site run-tests --doctype "Production Plan"`.
- Passed pre-commit checks for the changed file.
