### PR TITLE
fix(journal-entry): avoid full grid re-render per row in set_exchange_rate (backport #58328)

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -623,7 +623,7 @@ $.extend(erpnext.journal_entry, {
 		} else {
 			erpnext.journal_entry.set_debit_credit_in_company_currency(frm, cdt, cdn);
 		}
-		refresh_field("exchange_rate", cdn, "accounts");
+		frm.get_field("accounts").grid.refresh_row(cdn);
 	},
 
 	quick_entry: function (frm) {


### PR DESCRIPTION
Backport of #58328 to `version-16-hotfix`. Mergify's automatic backport (#58330) hit a conflict and was closed, so this is the manual one.

### The problem

`refresh()` loops over every row in the accounts child table and calls `set_exchange_rate()` for each one. On v16 that function ends with:

```js
refresh_field("exchange_rate", cdn, "accounts");
```

That helper only takes the cheap per-field path when the row is currently rendered. For any row outside the visible page `grid.grid_rows_by_docname` has no entry, and it falls back to a full `grid.refresh()`: header, pagination and the whole current page get rebuilt, once per off-screen row.

Develop had the same function ending in `frm.refresh_field("accounts")`. Different line, same problem, so the fix is the one develop already got.

### The fix

Use `grid.refresh_row(cdn)`. It re-renders only the row that actually changed and is a no-op for rows outside the current page.

### Measured

1000-row Journal Entry, headless Chromium, local v16 site, median of 3 runs:

| | before | after |
|---|---|---|
| full grid rebuilds during the refresh loop | 950 | 0 |
| time to first rendered row | 5.3s | 1.7s |
| time to network-idle | 5.9s | 2.3s |
| `set_exchange_rate` loop itself | 4.7s | 1.3s |

### Side effect

The visible row now stays in sync. Before, only the `exchange_rate` cell was repainted, so the debit/credit columns that `set_debit_credit_in_company_currency` had just recomputed kept showing stale amounts. Checked in the browser on a multi-currency JE: changing rate and amount on row 1 left the debit column showing `$ 10.00` before the fix, and repaints to `$ 25.00` after.

### How to test

1. Create a Journal Entry with several hundred rows in the accounts table.
2. Open it and watch how long the grid takes to appear.
3. On a multi-currency JE, change the posting date and confirm the rows repaint with the new rate and the recomputed debit/credit.
