### PR TITLE
fix(manufacturing): sum required quantity when consolidating sub-assemblies

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/services/sub_assembly.py
+++ b/erpnext/manufacturing/doctype/production_plan/services/sub_assembly.py
@@ -159,6 +159,7 @@ class SubAssemblyService:
 	def _merge_subassembly_row(existing_row, row):
 		existing_row.qty += flt(row.qty)
 		existing_row.stock_qty += flt(row.stock_qty)
+		existing_row.required_qty += flt(row.required_qty)
 		existing_row.bom_level = max(existing_row.bom_level, row.bom_level)
 
 	def all_items_completed(self):

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -869,11 +869,44 @@ class TestProductionPlan(ERPNextTestSuite):
 		self.assertTrue(len(plan.sub_assembly_items), 1)  # check if sub-assembly items merged
 		self.assertEqual(plan.sub_assembly_items[0].qty, 2.0)
 		self.assertEqual(plan.sub_assembly_items[0].stock_qty, 2.0)
+		self.assertEqual(plan.sub_assembly_items[0].required_qty, 2.0)
 
 		# change warehouse in one row, sub-assemblies should not merge
 		plan.po_items[0].warehouse = "Finished Goods - _TC"
 		plan.get_sub_assembly_items()
 		self.assertTrue(len(plan.sub_assembly_items), 2)
+
+	def test_consolidated_subassembly_required_qty_with_projected_stock(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		rm_item = make_item(properties={"is_stock_item": 1}).name
+		subassembly = make_item(properties={"is_stock_item": 1, "is_sub_contracted_item": 1}).name
+		make_bom(item=subassembly, raw_materials=[rm_item])
+		warehouse = create_warehouse("Consolidated Sub Assembly Warehouse", company="_Test Company")
+		make_stock_entry(item_code=subassembly, qty=750, rate=100, target=warehouse)
+		plan = self._plan_with_shared_raw_material(subassembly, qty_per_order=1000)
+		plan.sub_assembly_warehouse = warehouse
+
+		for consider_projected_qty in (0, 1):
+			with self.subTest(consider_projected_qty=consider_projected_qty):
+				plan.skip_available_sub_assembly_item = consider_projected_qty
+				plan.combine_sub_items = 0
+				plan.get_sub_assembly_items()
+				self.assertEqual([row.required_qty for row in plan.sub_assembly_items], [1000, 1000])
+				self.assertEqual(
+					[row.qty for row in plan.sub_assembly_items],
+					[250, 1000] if consider_projected_qty else [1000, 1000],
+				)
+
+				plan.combine_sub_items = 1
+				plan.get_sub_assembly_items()
+				self.assertEqual(len(plan.sub_assembly_items), 1)
+				row = plan.sub_assembly_items[0]
+				self.assertEqual(row.required_qty, 2000)
+				self.assertEqual(row.projected_qty, 750)
+				self.assertEqual(row.actual_qty, 750)
+				self.assertEqual(row.qty, 1250 if consider_projected_qty else 2000)
+				self.assertEqual(row.stock_qty, row.qty)
 
 	def test_pp_to_mr_customer_provided(self):
 		"Test Material Request from Production Plan for Customer Provided Item."


### PR DESCRIPTION
Sub-assembly consolidation summed Qty to Order and stock quantity but kept Required Qty from the first row. Sum Required Qty when rows are combined.

Two requirements of 1,000 with projected quantity 750 now consolidate to Required Qty 2,000 and Qty to Order 1,250. Projected Qty and Qty in Stock remain 750 because the rows share the same stock.

Required Qty also feeds stock reservation for sub-assembly rows, so a fully stocked consolidated row now reserves the combined requirement instead of the first row's.

Extend the existing consolidation test and add coverage with projected-stock calculation enabled and disabled.

Validation: both consolidation tests pass on PostgreSQL (`testing.localhost`). Pre-commit checks passed for the changed files.

Independent of the MOQ stack (#58805, #58806, #58812); targets develop directly.

fixes https://github.com/frappe/erpnext/issues/58809
