### PR TITLE
fix(selling): subtract billed qty for zero-amount Sales Order rows

### DIFF
--- a/erpnext/selling/doctype/sales_order/mapper.py
+++ b/erpnext/selling/doctype/sales_order/mapper.py
@@ -493,9 +493,7 @@ def make_sales_invoice(
 	def get_pending_qty(source):
 		if source.name not in pending_qty_by_item:
 			billable_qty = get_qty_net_of_returns(source)
-			if source.qty and source.billed_amt:
-				billable_qty -= get_billed_qty_by_item().get(source.name, 0)
-
+			billable_qty -= get_billed_qty_by_item().get(source.name, 0)
 			billable_qty -= mapped_qty_by_item.get(source.name, 0)
 			pending_qty_by_item[source.name] = max(flt(billable_qty, source.precision("qty")), 0)
 

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -427,6 +427,19 @@ class TestSalesOrder(ERPNextTestSuite):
 			self.assertEqual(len(si.get("items")), 1)
 			self.assertEqual(si.get("items")[0].qty, 150)
 
+	def test_make_sales_invoice_skips_fully_invoiced_free_item(self):
+		free_item = make_item("_Test Free Item", {"is_stock_item": 1}).name
+		so = make_sales_order(qty=10, rate=100, do_not_submit=True)
+		so.append("items", {"item_code": free_item, "qty": 5, "rate": 0, "warehouse": so.items[0].warehouse})
+		so.submit()
+
+		si = make_sales_invoice(so.name)
+		self.assertEqual([row.qty for row in si.items], [10, 5])
+		si.insert()
+		si.submit()
+
+		self.assertEqual(len(make_sales_invoice(so.name).items), 0)
+
 	def test_make_sales_invoice_after_return_and_redelivery(self):
 		from erpnext.stock.doctype.delivery_note.mapper import make_sales_return
 

--- a/erpnext/subcontracting/doctype/subcontracting_inward_order/test_subcontracting_inward_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_inward_order/test_subcontracting_inward_order.py
@@ -455,7 +455,7 @@ class IntegrationTestSubcontractingInwardOrder(ERPNextTestSuite):
 
 		scio.reload()
 		si = make_sales_invoice(so.name)
-		self.assertEqual(len(si.items), 1)
+		self.assertEqual(len(si.items), 0)
 
 	def test_extra_items_reservation_transfer(self):
 		so, scio = create_so_scio()


### PR DESCRIPTION
## Problem

`get_pending_qty` in the Sales Order to Sales Invoice mapper only subtracts the invoiced quantity when `billed_amt` is non-zero. A rate-0 row therefore keeps its full pending quantity and is mapped again on every invoice. Since #58751 the Sales Invoice picker and the Sales Order button keep such orders visible after full billing, which exposed the repeat mapping.

## Solution

Subtract the invoiced quantity for every row. The billed-quantity lookup already runs once per mapping.

## Tests

- New regression test passes on PostgreSQL.
- The subcontracting inward order test used a service row with no rate and asserted that the mapper re-added it after full billing. It now expects no rows.
