### PR TITLE
test(manufacturing): cover consolidated sub-assembly quantity (v15)

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -710,6 +710,49 @@ class TestProductionPlan(FrappeTestCase):
 		plan.get_sub_assembly_items()
 		self.assertTrue(len(plan.sub_assembly_items), 2)
 
+	def test_consolidated_subassembly_quantity_with_projected_stock(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		rm_item = make_item(properties={"is_stock_item": 1}).name
+		subassembly = make_item(properties={"is_stock_item": 1, "is_sub_contracted_item": 1}).name
+		make_bom(item=subassembly, raw_materials=[rm_item])
+		warehouse = create_warehouse("Consolidated Sub Assembly Warehouse", company="_Test Company")
+		make_stock_entry(item_code=subassembly, qty=750, rate=100, target=warehouse)
+		finished_item = make_item(properties={"is_stock_item": 1}).name
+		make_bom(item=finished_item, raw_materials=[subassembly])
+		plan = create_production_plan(
+			item_code=finished_item, planned_qty=1000, do_not_save=1, skip_getting_mr_items=1
+		)
+		plan.append(
+			"po_items",
+			{
+				"item_code": finished_item,
+				"bom_no": plan.po_items[0].bom_no,
+				"planned_qty": 1000,
+				"use_multi_level_bom": 1,
+				"planned_start_date": now_datetime(),
+			},
+		)
+		plan.sub_assembly_warehouse = warehouse
+
+		for consider_projected_qty in (0, 1):
+			with self.subTest(consider_projected_qty=consider_projected_qty):
+				plan.skip_available_sub_assembly_item = consider_projected_qty
+				plan.combine_sub_items = 0
+				plan.get_sub_assembly_items()
+				self.assertEqual(
+					[row.qty for row in plan.sub_assembly_items],
+					[250, 1000] if consider_projected_qty else [1000, 1000],
+				)
+
+				plan.combine_sub_items = 1
+				plan.get_sub_assembly_items()
+				self.assertEqual(len(plan.sub_assembly_items), 1)
+				row = plan.sub_assembly_items[0]
+				self.assertEqual(row.actual_qty, 750)
+				self.assertEqual(row.qty, 1250 if consider_projected_qty else 2000)
+				self.assertEqual(row.stock_qty, row.qty)
+
 	def test_pp_to_mr_customer_provided(self):
 		"Test Material Request from Production Plan for Customer Provided Item."
 		create_item("CUST-0987", is_customer_provided_item=1, customer="_Test Customer", is_purchase_item=0)


### PR DESCRIPTION
Backport of #58807 to `version-15-hotfix`, adapted to the release controller in `production_plan.py`.

v15 has one sub-assembly quantity field, `qty`, displayed as Required Qty. It already sums `qty` during consolidation. The separate `required_qty` field fixed in #58807 does not exist on v15.

Add regression coverage for v15's existing calculation. Two demands of 1,000 with projected stock 750 consolidate to 1,250 when available stock is considered, or 2,000 otherwise. Check the combined stock quantity and actual stock as well. This backport changes tests only and preserves the v15 schema.

This PR targets `version-15-hotfix` directly and can merge independently of the other Production Plan backports.

Validation: all 56 tests in the Production Plan module passed with this change alone on an isolated MariaDB site with Frappe v15. Pre-commit checks passed for the changed files.
