### PR TITLE
fix(manufacturing): sum consolidated sub-assembly required quantity (v16)

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -1174,6 +1174,7 @@ class ProductionPlan(Document):
 			if existing_row:
 				# if row with same (item, wh, bom no, man.g type) key, merge
 				existing_row.qty += flt(row.qty)
+				existing_row.required_qty += flt(row.required_qty)
 				existing_row.stock_qty += flt(row.stock_qty)
 				existing_row.bom_level = max(existing_row.bom_level, row.bom_level)
 				continue

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -869,11 +869,58 @@ class TestProductionPlan(ERPNextTestSuite):
 		self.assertTrue(len(plan.sub_assembly_items), 1)  # check if sub-assembly items merged
 		self.assertEqual(plan.sub_assembly_items[0].qty, 2.0)
 		self.assertEqual(plan.sub_assembly_items[0].stock_qty, 2.0)
+		self.assertEqual(plan.sub_assembly_items[0].required_qty, 2.0)
 
 		# change warehouse in one row, sub-assemblies should not merge
 		plan.po_items[0].warehouse = "Finished Goods - _TC"
 		plan.get_sub_assembly_items()
 		self.assertTrue(len(plan.sub_assembly_items), 2)
+
+	def test_consolidated_subassembly_required_qty_with_projected_stock(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		rm_item = make_item(properties={"is_stock_item": 1}).name
+		subassembly = make_item(properties={"is_stock_item": 1, "is_sub_contracted_item": 1}).name
+		make_bom(item=subassembly, raw_materials=[rm_item])
+		warehouse = create_warehouse("Consolidated Sub Assembly Warehouse", company="_Test Company")
+		make_stock_entry(item_code=subassembly, qty=750, rate=100, target=warehouse)
+		finished_item = make_item(properties={"is_stock_item": 1}).name
+		make_bom(item=finished_item, raw_materials=[subassembly])
+		plan = create_production_plan(
+			item_code=finished_item, planned_qty=1000, do_not_save=1, skip_getting_mr_items=1
+		)
+		plan.append(
+			"po_items",
+			{
+				"item_code": finished_item,
+				"bom_no": plan.po_items[0].bom_no,
+				"planned_qty": 1000,
+				"use_multi_level_bom": 1,
+				"planned_start_date": now_datetime(),
+			},
+		)
+		plan.sub_assembly_warehouse = warehouse
+
+		for consider_projected_qty in (0, 1):
+			with self.subTest(consider_projected_qty=consider_projected_qty):
+				plan.skip_available_sub_assembly_item = consider_projected_qty
+				plan.combine_sub_items = 0
+				plan.get_sub_assembly_items()
+				self.assertEqual([row.required_qty for row in plan.sub_assembly_items], [1000, 1000])
+				self.assertEqual(
+					[row.qty for row in plan.sub_assembly_items],
+					[250, 1000] if consider_projected_qty else [1000, 1000],
+				)
+
+				plan.combine_sub_items = 1
+				plan.get_sub_assembly_items()
+				self.assertEqual(len(plan.sub_assembly_items), 1)
+				row = plan.sub_assembly_items[0]
+				self.assertEqual(row.required_qty, 2000)
+				self.assertEqual(row.projected_qty, 750)
+				self.assertEqual(row.actual_qty, 750)
+				self.assertEqual(row.qty, 1250 if consider_projected_qty else 2000)
+				self.assertEqual(row.stock_qty, row.qty)
 
 	def test_pp_to_mr_customer_provided(self):
 		"Test Material Request from Production Plan for Customer Provided Item."


### PR DESCRIPTION
Backport of #58807 to `version-16-hotfix`, adapted to the release controller in `production_plan.py`.

v16 has separate `required_qty` and `qty` fields. Consolidation summed `qty` but kept `required_qty` from the first row. Add the missing sum in the existing controller method.

Two demands of 1,000 with projected stock 750 now consolidate to Required Qty 2,000 and Qty to Order 1,250. Actual and projected stock remain 750. Tests cover projected-stock calculation enabled and disabled.

This PR targets `version-16-hotfix` directly and can merge independently of the other Production Plan backports.

Validation: all 71 tests in the Production Plan module passed with this change alone on an isolated MariaDB site with Frappe v16. Pre-commit checks passed for the changed files.
