### PR TITLE
test(stock): use existing warehouse fixtures in Pick List tests (v15)

### DIFF
--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -1734,7 +1734,7 @@ class TestPickList(FrappeTestCase):
 		stock_entry.cancel()
 
 	def test_packed_item_in_pick_list(self):
-		warehouse_1 = "RJ Warehouse - _TC"
+		warehouse_1 = "_Test Warehouse - _TC"
 		warehouse_2 = "_Test Warehouse 2 - _TC"
 		item_1 = make_item(properties={"is_stock_item": 0}).name
 		item_2 = make_item().name
@@ -1765,7 +1765,7 @@ class TestPickList(FrappeTestCase):
 
 	def test_packed_item_multiple_times_in_so(self):
 		frappe.db.delete("Item Price")
-		warehouse_1 = "RJ Warehouse - _TC"
+		warehouse_1 = "_Test Warehouse - _TC"
 		warehouse_2 = "_Test Warehouse 2 - _TC"
 		warehouse = "_Test Warehouse - _TC"
 		item_1 = make_item(properties={"is_stock_item": 0}).name


### PR DESCRIPTION
Backport of #51249 to `version-15-hotfix`.

Two packed-item Pick List tests use `RJ Warehouse - _TC` without creating it. The only test that creates this warehouse is an Inventory Dimension test. The extra test cases from #58686 moved Pick List from shard 3 to shard 4. Inventory Dimension stayed in shard 3, exposing the dependency. Both Pick List tests then raise `LinkValidationError` when they insert stock entries.

Use the standard `_Test Warehouse - _TC` fixture, as develop and v16 already do. This changes two test setup lines and preserves the existing assertions.

The failure reproduces on `version-15-hotfix` at `6c6ee7c524`, without any Production Plan backports. It is the remaining CI failure on #58827, #58828, #58829, and #58830.

Validation:

- Both affected tests fail before the change and pass after it on an isolated MariaDB site with Frappe v15.
- All 38 Pick List tests pass in the full shard run.
- The broader local shard ran 610 tests with 3 failures and 4 errors in Purchase Receipt and Stock Reconciliation on the reused local test site. The full shard is not reported as passing. GitHub CI will validate the change on a fresh site.
- Pre-commit and Frappe Semgrep checks pass.
