### PR TITLE
fix(accounts): hide fully returned invoices from gross profit report

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -627,6 +627,25 @@ class GrossProfitGenerator:
 		if self.grouped:
 			self.get_average_rate_based_on_group_by()
 
+		if grouped_by_invoice:
+			self.hide_fully_returned_invoices()
+
+	def hide_fully_returned_invoices(self):
+		segments = []
+		for row in self.si_list:
+			if row.indent == 0.0:
+				segments.append([row])
+			elif segments:
+				segments[-1].append(row)
+
+		kept = []
+		for header, *rows in segments:
+			if any(flt(item.qty) for item in rows if item.indent == 1.0):
+				kept.append(header)
+				kept.extend(rows)
+
+		self.si_list = kept
+
 	def update_return_invoices(self, row, sales_invoice_item):
 		returned_item_rows = self.returned_invoices.get(row.parent, {}).get(sales_invoice_item)
 		if not returned_item_rows:

--- a/erpnext/accounts/report/gross_profit/test_gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/test_gross_profit.py
@@ -352,30 +352,27 @@ class TestGrossProfit(ERPNextTestSuite):
 		)
 
 		columns, data = execute(filters=filters)
-		expected_entry = {
-			"parent_invoice": sinv.name,
-			"currency": "INR",
-			"sales_invoice": self.item,
-			"customer": self.customer,
-			"posting_date": frappe.utils.datetime.date.fromisoformat(nowdate()),
-			"item_code": self.item,
-			"item_name": self.item,
-			"warehouse": "Stores - _TC",
-			"qty": 0.0,
-			"avg._selling_rate": 100.0,
-			"valuation_rate": 100.0,
-			"selling_amount": 0.0,
-			"buying_amount": 0.0,
-			"gross_profit": 0.0,
-			"gross_profit_%": 0.0,
-		}
 		gp_entry = [x for x in data if x.parent_invoice == sinv.name]
-		# Both items of Invoice should have '0' qty
-		self.assertEqual(len(gp_entry), 2)
-		report_output = {k: v for k, v in gp_entry[0].items() if k in expected_entry}
-		self.assertEqual(report_output, expected_entry)
-		report_output = {k: v for k, v in gp_entry[1].items() if k in expected_entry}
-		self.assertEqual(report_output, expected_entry)
+		# Both item instances net to '0' qty, so the fully returned invoice is hidden
+		self.assertEqual(len(gp_entry), 0)
+
+	def test_fully_returned_invoice_is_hidden(self):
+		"""
+		A Sales Invoice fully reversed by a Credit Note has zero impact on Gross
+		Profit and should not appear in the report at all.
+		"""
+		sinv = self.create_sales_invoice(qty=1, rate=100, posting_date=nowdate())
+
+		cr_note = make_sales_return(sinv.name)
+		cr_note = cr_note.save().submit()
+
+		filters = frappe._dict(
+			company=self.company, from_date=nowdate(), to_date=nowdate(), group_by="Invoice"
+		)
+
+		columns, data = execute(filters=filters)
+		gp_entry = [x for x in data if x.parent_invoice == sinv.name or x.sales_invoice == sinv.name]
+		self.assertEqual(len(gp_entry), 0)
 
 	def test_standalone_cr_notes(self):
 		"""


### PR DESCRIPTION
**Issue:**
In the Gross Profit Report, a Sales Invoice is still appearing even though a Credit Note has been issued for the complete Sales Invoice amount.

Since the full invoice amount has already been credited, this Sales Invoice should ideally not be considered in the Gross Profit Report.

**Before:**
<img width="1290" height="598" alt="image" src="https://github.com/user-attachments/assets/bd2fb640-35fc-447c-b67d-84876a1f4e2a" />

**After:**
<img width="1290" height="598" alt="image" src="https://github.com/user-attachments/assets/fd659df9-7b7f-4ce5-8a67-fc3ba44fb4a3" />


