### PR TITLE
fix: persist rendered terms on transaction save

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -226,6 +226,7 @@ class PurchaseOrder(BuyingController):
 			self.doctype, self.supplier, self.company, self.inter_company_order_reference
 		)
 		self.reset_default_field_value("set_warehouse", "items", "warehouse")
+		self.set_missing_terms()
 
 	def set_has_unit_price_items(self):
 		"""


### PR DESCRIPTION
### Issue

  Transactions created through the API can save the selected Terms and Conditions template in `tc_name` while leaving the persisted `terms` field empty.

  The existing print fallback renders the terms only while printing and does not persist them.

 Fixes #58846

  ### Steps to reproduce

  1. Create an enabled buying Terms and Conditions template.
  2. Create a Purchase Order through the REST API.
  3. Provide `tc_name` but omit `terms`.
  4. Reload the saved Purchase Order.

  ### Actual behaviour

  The Terms and Conditions template is selected, but the saved `terms` field is empty.

  ### Expected behaviour

  The selected template should be rendered and persisted during transaction validation. Existing customized terms should not be overwritten.

  ### Backport needed for V15 and v16