### PR TITLE
fix: % Amount Billed exceeds 100% on fully rejected Purchase Receipts

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/services/billing_status.py
+++ b/erpnext/stock/doctype/purchase_receipt/services/billing_status.py
@@ -200,10 +200,14 @@ def update_billing_percentage(
 		returned_qty = flt(item_wise_returned_qty.get(item.name))
 		returned_amount = flt(returned_qty) * flt(item.rate)
 		pending_amount = flt(item.amount) - returned_amount
-		if buying_settings.bill_for_rejected_quantity_in_purchase_invoice:
-			pending_amount = flt(item.amount)
 
-		total_billable_amount = abs(flt(item.amount))
+		# When rejected qty is billable, its value is part of the billable base too
+		rejected_amount = 0.0
+		if buying_settings.bill_for_rejected_quantity_in_purchase_invoice:
+			rejected_amount = flt(item.rejected_qty * item.rate, item.precision("amount"))
+			pending_amount = flt(item.amount) + rejected_amount
+
+		total_billable_amount = abs(flt(item.amount) + rejected_amount)
 		if pending_amount > 0:
 			total_billable_amount = pending_amount if item.billed_amt <= pending_amount else item.billed_amt
 
@@ -213,9 +217,7 @@ def update_billing_percentage(
 		if pr_doc.get("is_return") and not total_amount and total_billed_amount:
 			total_amount = total_billed_amount
 
-		amount = item.amount
-		if frappe.db.get_single_value("Buying Settings", "bill_for_rejected_quantity_in_purchase_invoice"):
-			amount += flt(item.rejected_qty * item.rate, item.precision("amount"))
+		amount = flt(item.amount) + rejected_amount
 
 		if adjust_incoming_rate:
 			adjusted_amt = 0.0

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -617,6 +617,44 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 		return_pr.cancel()
 		pr.cancel()
 
+	def test_per_billed_for_fully_rejected_receipt(self):
+		from erpnext.stock.doctype.purchase_receipt.services.billing_status import (
+			update_billing_percentage,
+		)
+
+		bill_rejected = frappe.db.get_single_value(
+			"Buying Settings", "bill_for_rejected_quantity_in_purchase_invoice"
+		)
+		frappe.db.set_single_value("Buying Settings", "bill_for_rejected_quantity_in_purchase_invoice", 1)
+
+		try:
+			# Fully rejected receipt: accepted qty 0, whole qty in rejected warehouse
+			pr = make_purchase_receipt(
+				received_qty=10,
+				qty=0,
+				rejected_qty=10,
+				rate=9.5,
+				rejected_warehouse="_Test Warehouse 1 - _TC",
+				do_not_save=True,
+			)
+			pr.items[0].warehouse = ""
+			pr.submit()
+
+			# Bill the rejected qty (10 x 9.5) directly against the receipt item
+			pr.items[0].db_set("billed_amt", 95)
+			update_billing_percentage(pr)
+
+			pr.load_from_db()
+			# Billing the rejected qty must not push per_billed above 100
+			self.assertEqual(pr.per_billed, 100)
+			self.assertEqual(pr.status, "Completed")
+
+			pr.cancel()
+		finally:
+			frappe.db.set_single_value(
+				"Buying Settings", "bill_for_rejected_quantity_in_purchase_invoice", bill_rejected
+			)
+
 	def test_purchase_receipt_for_rejected_gle_without_accepted_warehouse(self):
 		from erpnext.stock.doctype.warehouse.test_warehouse import get_warehouse
 


### PR DESCRIPTION
**Issue:** On a Purchase Receipt whose accepted qty is 0 (whole qty rejected) and "Bill for Rejected Quantity in Purchase Invoice" is enabled, % Amount Billed shows an absurd value (e.g. 9,500%) because the billed amount includes the rejected qty but the billable base does not.

**Fix:** When rejected billing is on, base the billing % on the whole retained receipt value — accepted + rejected qty, minus everything returned (via either return flow) — instead of accepted qty alone.

https://support.frappe.io/helpdesk/tickets/77948?view=VIEW-HD+Ticket-70178

<img width="886" height="226" alt="Screenshot 2026-09-08 at 5 18 03 PM" src="https://github.com/user-attachments/assets/acfa6057-2b30-44b6-b68b-a48e3c0b734c" />
<img width="870" height="440" alt="Screenshot 2026-09-08 at 5 18 18 PM" src="https://github.com/user-attachments/assets/893fc6df-1db5-4ac7-a3de-f7661d636ff7" />
<img width="859" height="188" alt="Screenshot 2026-09-08 at 5 18 27 PM" src="https://github.com/user-attachments/assets/e87d544f-97a0-4338-8aff-abb118d2ba3b" />

