### PR TITLE
fix: reset price list fallback when changing parties

### DIFF
--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -24,14 +24,14 @@ erpnext.utils.get_party_details = function (frm, method, args, callback) {
 			args = {
 				party: frm.doc.customer || frm.doc.party_name,
 				party_type: party_type,
-				price_list: frm.doc.selling_price_list,
+				price_list: frappe.defaults.get_default("selling_price_list"),
 			};
 		} else if (frm.doc.supplier) {
 			args = {
 				party: frm.doc.supplier,
 				party_type: "Supplier",
 				bill_date: frm.doc.bill_date,
-				price_list: frm.doc.buying_price_list,
+				price_list: frappe.defaults.get_default("buying_price_list"),
 			};
 		}
 


### PR DESCRIPTION
  ### Issue

-  When changing the customer or supplier on a Sales Order or Purchase Order, the previous party’s Price List remains selected if the newly selected party has no default Price List. The form should use the applicable default or clear the field when no default exists.

  Fixes #58793 

### Steps to reproduce

  1. Create two enabled Price Lists for the relevant transaction type: a settings default and a party-specific list.
  2. Set the default Price List in Selling Settings or Buying Settings. Save and reload Desk.
  3. Configure Customer/Supplier A with the party-specific Price List.
  4. Leave Customer/Supplier B’s default Price List blank. For customers, ensure the Customer Group default is also blank.
  5. Create a new Sales Order or Purchase Order and select the company.
  6. Select Customer/Supplier A and confirm its Price List is applied.
  7. On the same unsaved order, switch to Customer/Supplier B and observe the Price List.
  8. Clear the settings default, save, reload Desk, and repeat the party-switching steps on a new order.

  ### Actual behaviour

  - The previous party’s Price List remains selected, whether the settings default is configured or blank.

  ### Expected behaviour

  - Use the applicable settings default when the new party has no default. Clear the field when no applicable default exists. Preserve existing party, Customer Group, POS, and permission-specific precedence.

  ### Backport needed for v15 and v16