### PR TITLE
fix: clear disabled price lists on new orders

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2524,6 +2524,23 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			.call({
 				method: "erpnext.stock.get_item_details.apply_price_list",
 				args: { ctx: args, doc: me.frm.doc },
+				error: (r) => {
+					if (
+						r?.exc_type !== "InvalidPriceList" ||
+						!me.frm.is_new() ||
+						me.frm.doc.doctype !== args.doctype ||
+						me.frm.doc.name !== args.name
+					) {
+						return;
+					}
+
+					const price_list_field = ["selling_price_list", "buying_price_list"].find(
+						(field) => me.frm.fields_dict[field]
+					);
+					if (price_list_field && me.frm.doc[price_list_field] === args.price_list) {
+						me.frm.set_value(price_list_field, "");
+					}
+				},
 				callback: function (r) {
 					if (!r.exc) {
 						frappe.run_serially([

--- a/erpnext/stock/doctype/price_list/price_list.py
+++ b/erpnext/stock/doctype/price_list/price_list.py
@@ -8,6 +8,10 @@ from frappe.model.document import Document
 from frappe.utils import cint, now
 
 
+class InvalidPriceList(frappe.ValidationError):
+	pass
+
+
 class PriceList(Document):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
@@ -85,7 +89,7 @@ def get_price_list_details(price_list):
 		)
 
 		if not price_list_details or not price_list_details.get("enabled"):
-			throw(_("Price List {0} is disabled or does not exist").format(price_list))
+			throw(_("Price List {0} is disabled or does not exist").format(price_list), InvalidPriceList)
 
 		frappe.cache().hset("price_list_details", price_list, price_list_details)
 


### PR DESCRIPTION
 ### Issue

disabled default Price Lists remain prefilled after the validation error.

  Fixes #58791

  ### Steps to reproduce

  1. Set an enabled Price List as the default in Selling or Buying Settings.
  2. Disable that Price List and reload Desk.
  3. Create a new Sales Order or Purchase Order.

Before :

<img width="1847" height="907" alt="image" src="https://github.com/user-attachments/assets/14f8a675-3163-4adc-ad01-ed32a648cb67" />

After : 

<img width="1860" height="908" alt="image" src="https://github.com/user-attachments/assets/c21e7821-641e-4a2c-be85-a2c7be61bc2b" />



  ### Actual behaviour

  The disabled Price List remains selected after the error.

  ### Expected behaviour

  Clear the rejected Price List without clearing a newer selection or modifying saved orders.

  ### Backport needed for v16 and v15
