### PR TITLE
fix: keep each row's own rate under maintain same rate

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -225,10 +225,11 @@ def get_rate_locked_source_row(ctx: ItemDetailsCtx, doc) -> frappe._dict | None:
 		doc = json.loads(doc)
 
 	source_fields = maintain_same_rate_source_fields.get(ctx.parenttype or ctx.doctype)
-	if not source_fields or not doc or ctx.get("is_return") or not maintain_same_rate_enabled(ctx):
+	if not source_fields or ctx.get("is_return") or not maintain_same_rate_enabled(ctx):
 		return None
 
-	row = next((d for d in doc.get("items") or [] if d.get("name") == ctx.child_docname), None)
+	# use ctx's own source links when present; else match by name, never on an empty name (collapses every unsaved row onto the first)
+	row = ctx if any(ctx.get(field) for field in source_fields) else find_row_by_name(doc, ctx.child_docname)
 	if not row:
 		return None
 
@@ -243,6 +244,12 @@ def get_rate_locked_source_row(ctx: ItemDetailsCtx, doc) -> frappe._dict | None:
 				return source
 			return None
 	return None
+
+
+def find_row_by_name(doc, child_docname) -> frappe._dict | None:
+	if not doc or not child_docname:
+		return None
+	return next((d for d in doc.get("items") or [] if d.get("name") == child_docname), None)
 
 
 def maintain_same_rate_enabled(ctx: ItemDetailsCtx) -> bool:

--- a/erpnext/stock/tests/test_get_item_details.py
+++ b/erpnext/stock/tests/test_get_item_details.py
@@ -458,6 +458,43 @@ class TestGetItemDetail(ERPNextTestSuite):
 			frappe.db.set_single_value("Buying Settings", "maintain_same_rate", original)
 			frappe.clear_cache(doctype="Buying Settings")
 
+	def test_rate_lock_keeps_each_rows_rate_for_batch_items(self):
+		"""Batch rows mapped PR->PI must each keep their own rate, not collapse onto the first."""
+		from erpnext.buying.doctype.purchase_order.mapper import make_purchase_receipt
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+		from erpnext.stock.doctype.purchase_receipt.mapper import make_purchase_invoice
+
+		frappe.db.set_single_value("Buying Settings", "maintain_same_rate", 1)
+		frappe.clear_cache(doctype="Buying Settings")
+		self.addCleanup(frappe.db.set_single_value, "Buying Settings", "maintain_same_rate", 0)
+
+		item_a, batches_a = self.make_batched_item_with_stock([5])
+		item_b, batches_b = self.make_batched_item_with_stock([5])
+
+		# one PO with both items at different rates
+		po = create_purchase_order(item_code=item_a, qty=5, rate=28, do_not_save=True)
+		po.append("items", {
+			"item_code": item_b, "qty": 5, "rate": 275,
+			"warehouse": "_Test Warehouse - _TC", "schedule_date": frappe.utils.nowdate(),
+		})
+		po.set_missing_values()
+		po.insert()
+		po.submit()
+
+		# receive both against their own batches
+		pr = make_purchase_receipt(po.name)
+		for row in pr.items:
+			row.use_serial_batch_fields = 1
+		pr.items[0].batch_no = batches_a[0]
+		pr.items[1].batch_no = batches_b[0]
+		pr.insert()
+		pr.submit()
+
+		# the batch_no branch force-writes the fetched rate during mapping
+		pi = make_purchase_invoice(pr.name)
+		self.assertEqual(pi.items[0].rate, 28)
+		self.assertEqual(pi.items[1].rate, 275)  # used to collapse onto the first row (28)
+
 	def make_batched_item_with_stock(self, quantities, uoms=None, **properties):
 		from erpnext.stock.doctype.item.test_item import make_item
 		from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle import (

--- a/erpnext/stock/tests/test_get_item_details.py
+++ b/erpnext/stock/tests/test_get_item_details.py
@@ -473,10 +473,16 @@ class TestGetItemDetail(ERPNextTestSuite):
 
 		# one PO with both items at different rates
 		po = create_purchase_order(item_code=item_a, qty=5, rate=28, do_not_save=True)
-		po.append("items", {
-			"item_code": item_b, "qty": 5, "rate": 275,
-			"warehouse": "_Test Warehouse - _TC", "schedule_date": frappe.utils.nowdate(),
-		})
+		po.append(
+			"items",
+			{
+				"item_code": item_b,
+				"qty": 5,
+				"rate": 275,
+				"warehouse": "_Test Warehouse - _TC",
+				"schedule_date": frappe.utils.nowdate(),
+			},
+		)
 		po.set_missing_values()
 		po.insert()
 		po.submit()


### PR DESCRIPTION
### Issue

With "Maintain same rate throughout the purchase cycle" enabled, creating a Purchase Invoice from a Purchase Receipt set **every** item's rate to the first item's rate, changing the total value. It shows up for batch/serial-tracked items and only when the setting is on.

### Fix

To keep the rate consistent, the code re-reads each row's rate from its source document, finding the source row by the row's name. On a freshly mapped invoice the rows have no name yet, so every row matched the first row and got the first item's rate.

Now each row is matched by its own source link (`po_detail`/`pr_detail`) instead of the empty name, so every row keeps its correct rate.

https://support.frappe.io/helpdesk/tickets/77710?view=VIEW-HD+Ticket-70178
