### PR TITLE
fix(stock): remove empty delivery stops after mapping

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -54,6 +54,12 @@ class DeliveryTrip(Document):
 		self.update_status()
 		self.update_delivery_notes(delete=True)
 
+	def after_mapping(self, source_doc):
+		# Remove placeholder rows without discarding partially filled stops.
+		for stop in self.delivery_stops[:]:
+			if not any(stop.get(df.fieldname) for df in stop.meta.fields):
+				self.remove(stop)
+
 	def validate(self):
 		if self._action == "submit" and not self.driver:
 			frappe.throw(_("A driver must be set to submit."))

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -55,7 +55,6 @@ class DeliveryTrip(Document):
 		self.update_delivery_notes(delete=True)
 
 	def after_mapping(self, source_doc):
-		# Remove placeholder rows without discarding partially filled stops.
 		for stop in self.delivery_stops[:]:
 			if not any(stop.get(df.fieldname) for df in stop.meta.fields):
 				self.remove(stop)
@@ -86,7 +85,7 @@ class DeliveryTrip(Document):
 
 	def validate_stop_addresses(self):
 		for stop in self.delivery_stops:
-			if not stop.customer_address:
+			if stop.address and not stop.customer_address:
 				stop.customer_address = get_address_display(frappe.get_doc("Address", stop.address).as_dict())
 
 	def validate_delivery_note_not_draft(self):

--- a/erpnext/stock/doctype/delivery_trip/test_delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/test_delivery_trip.py
@@ -6,6 +6,7 @@ import frappe
 from frappe.utils import add_days, flt, now_datetime, nowdate
 
 import erpnext
+from erpnext.stock.doctype.delivery_note.mapper import make_delivery_trip
 from erpnext.stock.doctype.delivery_trip.delivery_trip import (
 	get_contact_and_address,
 	get_default_contact,
@@ -173,6 +174,32 @@ class TestDeliveryTrip(ERPNextTestSuite):
 		self.assertIsNotNone(result)
 		self.assertEqual(result.parent, orphan_parent)
 		self.assertIsNone(result.is_primary_contact)
+
+	def map_delivery_note_onto_trip(self, existing_stop):
+		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
+
+		delivery_note = create_delivery_note()
+		trip = frappe.new_doc("Delivery Trip")
+		trip.append("delivery_stops", existing_stop)
+
+		return delivery_note, make_delivery_trip(delivery_note.name, trip)
+
+	def test_mapping_drops_placeholder_stop(self):
+		delivery_note, trip = self.map_delivery_note_onto_trip({})
+
+		self.assertEqual(len(trip.delivery_stops), 1)
+		self.assertEqual(trip.delivery_stops[0].delivery_note, delivery_note.name)
+
+	def test_mapping_keeps_partially_filled_stop(self):
+		_, trip = self.map_delivery_note_onto_trip({"customer": "_Test Customer"})
+
+		self.assertEqual(len(trip.delivery_stops), 2)
+		self.assertIsNone(trip.delivery_stops[0].delivery_note)
+
+	def test_stop_without_address_throws_mandatory_error(self):
+		self.delivery_trip.append("delivery_stops", {"customer": "_Test Customer"})
+
+		self.assertRaises(frappe.MandatoryError, self.delivery_trip.save)
 
 
 def create_address(driver):


### PR DESCRIPTION
### Issue

An empty default Delivery Stop remains after fetching Delivery Notes and prevents saving.

  Fixes #58781

  ### Steps to reproduce

  1. Create a new Delivery Trip and fill the required fields.
  2. Choose Get stops from → Delivery Note.
  3. Select a Delivery Note with a valid address and click Get Items.
  4. Save without manually deleting the empty first row.

Before:

<img width="1854" height="904" alt="image" src="https://github.com/user-attachments/assets/acd09ffa-083f-4722-b94f-910fa2916996" />

After:

<img width="1854" height="903" alt="image" src="https://github.com/user-attachments/assets/2c294eab-1e6a-4590-8eec-1c4d315b15c2" />


  ### Actual behaviour

  The empty row remains and causes an address validation error.

  ### Expected behaviour

  Remove empty stops after fetching, preserve partially filled stops, and allow saving when all required fields are complete.

  ### Second fix

  `validate()` runs before the mandatory-field check, so a stop with no address reached
  `frappe.get_doc("Address", None)` and failed with "Address None not found". The lookup is now
  skipped when the stop has no address, so the address field reports the usual mandatory error.

  ### Backport needed for v15 and v16
