### PR TITLE
fix: clear stock value for zero-quantity balances

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1153,7 +1153,7 @@ class update_entries_after:
 
 		# rounding as per precision
 		self.wh_data.stock_value = flt(self.wh_data.stock_value, self.currency_precision)
-		if not self.wh_data.qty_after_transaction:
+		if not flt(self.wh_data.qty_after_transaction, self.flt_precision):
 			self.wh_data.stock_value = 0.0
 
 		if sle.actual_qty < 0:


### PR DESCRIPTION
Issue:
- After stock is consumed or transferred out, tiny decimal-calculation differences can leave the quantity slightly above or below zero. The Stock Ledger saves this quantity as zero, but its stock value can remain positive or negative.

Description:

- Check the remaining quantity using the configured precision. If it rounds to zero, clear the stock value and include the remaining amount in the transaction’s stock value difference. This prevents ledger entries showing zero quantity with leftover stock value.

Fixes #58848

  ### Steps to reproduce

  1. Process fractional stock movements for an item and warehouse.
  2. Reach a balance that is nonzero internally but rounds to zero.
  3. Check the final Stock Ledger Entry’s balance quantity and value.

  ### Actual behaviour

  Balance quantity is zero, but residual stock value can remain.

  ### Expected behaviour

  Clear the stock value when the quantity rounds to zero, including the remaining value in the stock value difference.

**Backport Needed For v15 and v16**