### PR TITLE
feat(stock): add DuckDB execution for stock reports

### DIFF
--- a/erpnext/stock/report/stock_ageing/stock_ageing.json
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.json
@@ -13,7 +13,7 @@
  "snapshot_report": 0,
  "idx": 3, 
  "is_standard": "Yes", 
- "modified": "2017-02-24 20:14:20.184693", 
+ "modified": "2026-09-11 22:10:00.000000", 
  "modified_by": "Administrator", 
  "module": "Stock", 
  "name": "Stock Ageing", 

--- a/erpnext/stock/report/stock_ageing/stock_ageing.json
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.json
@@ -5,6 +5,12 @@
  "disabled": 0, 
  "docstatus": 0, 
  "doctype": "Report", 
+ "doctype_to_sync": [
+  {
+   "doc_type": "Stock Ledger Entry"
+  }
+ ],
+ "snapshot_report": 0,
  "idx": 3, 
  "is_standard": "Yes", 
  "modified": "2017-02-24 20:14:20.184693", 

--- a/erpnext/stock/report/stock_ageing/stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.py
@@ -9,6 +9,7 @@ import frappe
 from frappe import _
 from frappe.query_builder.functions import Abs, Count
 from frappe.utils import cint, date_diff, flt, get_datetime
+from pypika.queries import QueryBuilder
 
 from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 from erpnext.stock.doctype.warehouse.warehouse import apply_warehouse_filter
@@ -31,6 +32,32 @@ BATCH_SLOT_VALUE_INDEX = 4
 
 AVERAGE_AGE_COLUMN = 6
 MAX_CHART_ITEMS = 10
+
+ITEM_FIELDS = (
+	"name",
+	"item_name",
+	"item_group",
+	"brand",
+	"description",
+	"stock_uom",
+	"has_batch_no",
+	"has_serial_no",
+)
+LEDGER_FIELDS = (
+	"actual_qty",
+	"stock_value_difference",
+	"valuation_rate",
+	"posting_date",
+	"voucher_type",
+	"voucher_no",
+	"voucher_detail_no",
+	"serial_no",
+	"batch_no",
+	"qty_after_transaction",
+	"serial_and_batch_bundle",
+	"warehouse",
+)
+DETAIL_FIELDS = ITEM_FIELDS + LEDGER_FIELDS
 
 
 def execute(filters: Filters = None) -> tuple:
@@ -327,14 +354,9 @@ class FIFOSlots:
 			self._prefetch_valuation_methods()
 			query = self._get_stock_ledger_query()
 
-			snapshot_details = None
-			if self.snapshot:
-				from erpnext.stock.report.stock_ageing.stock_ageing_snapshot import SnapshotFIFO
-
-				snapshot_details = SnapshotFIFO(self).generate(bundle_wise_serial_nos, bundle_wise_batch_nos)
-			if snapshot_details is not None:
-				self.item_details = snapshot_details
-			else:
+			if not self.snapshot or not self._generate_from_snapshot(
+				bundle_wise_serial_nos, bundle_wise_batch_nos
+			):
 				with nullcontext() if self.snapshot else frappe.db.unbuffered_cursor():
 					for row in run_stock_query(query, self.snapshot, as_dict=True, as_iterator=True):
 						self._process_stock_ledger_entry(row, bundle_wise_serial_nos, bundle_wise_batch_nos)
@@ -351,6 +373,21 @@ class FIFOSlots:
 			self.item_details = self._aggregate_details_by_item(self.item_details)
 
 		return self.item_details
+
+	def _generate_from_snapshot(self, serial_bundles: dict, batch_bundles: dict) -> bool:
+		from erpnext.stock.report.stock_ageing.stock_ageing_snapshot import SnapshotFIFO
+
+		result = SnapshotFIFO(self).generate()
+		if result is None:
+			return False
+
+		self.item_details = result.details
+		if result.replay_query is not None:
+			for row in self.snapshot.run(result.replay_query, as_dict=True, as_iterator=True):
+				self._process_stock_ledger_entry(row, serial_bundles, batch_bundles)
+
+		self.item_details = {key: self.item_details[key] for key in result.ordered_keys}
+		return True
 
 	def _recompute_moving_average_slots(self) -> None:
 		for item_dict in self.item_details.values():
@@ -1032,7 +1069,7 @@ class FIFOSlots:
 
 		return item_aggregated_data
 
-	def _get_stock_ledger_query(self, ordered=True):
+	def _get_stock_ledger_query(self, ordered: bool = True) -> QueryBuilder:
 		sle = frappe.qb.DocType("Stock Ledger Entry")
 		item = self._get_item_query()  # used as derived table in sle query
 		to_date = get_datetime(self.filters.get("to_date") + " 23:59:59")
@@ -1041,26 +1078,8 @@ class FIFOSlots:
 			frappe.qb.from_(sle)
 			.from_(item)
 			.select(
-				item.name,
-				item.item_name,
-				item.item_group,
-				item.brand,
-				item.description,
-				item.stock_uom,
-				item.has_batch_no,
-				item.has_serial_no,
-				sle.actual_qty,
-				sle.stock_value_difference,
-				sle.valuation_rate,
-				sle.posting_date,
-				sle.voucher_type,
-				sle.voucher_no,
-				sle.voucher_detail_no,
-				sle.serial_no,
-				sle.batch_no,
-				sle.qty_after_transaction,
-				sle.serial_and_batch_bundle,
-				sle.warehouse,
+				*(item[field] for field in ITEM_FIELDS),
+				*(sle[field] for field in LEDGER_FIELDS),
 			)
 			.where(
 				(sle.item_code == item.name)
@@ -1156,19 +1175,10 @@ class FIFOSlots:
 
 		return bundle_wise_batch_nos
 
-	def _get_item_query(self) -> str:
+	def _get_item_query(self) -> QueryBuilder:
 		item_table = frappe.qb.DocType("Item")
 
-		item = frappe.qb.from_("Item").select(
-			"name",
-			"item_name",
-			"description",
-			"stock_uom",
-			"brand",
-			"item_group",
-			"has_serial_no",
-			"has_batch_no",
-		)
+		item = frappe.qb.from_("Item").select(*ITEM_FIELDS)
 
 		item = self._apply_filter(item, item_table, "item_code")
 

--- a/erpnext/stock/report/stock_ageing/stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.py
@@ -2,7 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 
-from collections.abc import Iterator
+from contextlib import nullcontext
 from operator import itemgetter
 
 import frappe
@@ -12,6 +12,7 @@ from frappe.utils import cint, date_diff, flt, get_datetime
 
 from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 from erpnext.stock.doctype.warehouse.warehouse import apply_warehouse_filter
+from erpnext.stock.report.stock_report_snapshot import StockReportSnapshot, run_stock_query
 from erpnext.stock.valuation import round_off_if_near_zero
 
 Filters = frappe._dict
@@ -33,11 +34,20 @@ MAX_CHART_ITEMS = 10
 
 
 def execute(filters: Filters = None) -> tuple:
+	return _execute(filters)
+
+
+def execute_snapshot_report(filters):
+	with StockReportSnapshot("Stock Ageing", filters) as snapshot:
+		return _execute(filters, snapshot)
+
+
+def _execute(filters, snapshot=None):
 	to_date = filters["to_date"]
 	filters.ranges = get_age_ranges(filters.range)
 	columns = get_columns(filters)
 
-	item_details = FIFOSlots(filters).generate()
+	item_details = FIFOSlots(filters, snapshot=snapshot).generate()
 	data = format_report_data(filters, item_details, to_date)
 
 	chart_data = get_chart_data(data, filters)
@@ -283,7 +293,7 @@ def is_qty_slot(slot: list) -> bool:
 class FIFOSlots:
 	"Returns FIFO computed slots of inwarded stock as per date."
 
-	def __init__(self, filters: dict | None = None, sle: list | None = None):
+	def __init__(self, filters: dict | None = None, sle: list | None = None, snapshot=None):
 		self.item_details = {}
 		self.transferred_item_details = {}
 		self.serial_no_details = {}
@@ -292,6 +302,7 @@ class FIFOSlots:
 		self.valuation_method_by_item = {}
 		self.filters = filters
 		self.sle = sle
+		self.snapshot = snapshot
 
 	def generate(self) -> dict:
 		"""
@@ -311,29 +322,24 @@ class FIFOSlots:
 		self.float_precision = get_float_precision()
 
 		if stock_ledger_entries is None:
-			# streaming path: nested queries invalidate the streaming cursor below,
-			# so batchwise valuation flags and item valuation methods must be resolved beforehand
+			# Resolve supporting records and warehouse filters before opening the streaming cursor.
 			self._prefetch_batchwise_valuations()
 			self._prefetch_valuation_methods()
+			query = self._get_stock_ledger_query()
 
-			if frappe.db.db_type == "postgres":
-				# postgres server-side cursors can't run nested queries mid-iteration; _get_stock_ledger_entries
-				# returns a buffered result there, so process it directly (no unbuffered cursor).
-				for row in self._get_stock_ledger_entries():
-					self._process_stock_ledger_entry(row, bundle_wise_serial_nos, bundle_wise_batch_nos)
+			snapshot_details = None
+			if self.snapshot:
+				from erpnext.stock.report.stock_ageing.stock_ageing_snapshot import SnapshotFIFO
+
+				snapshot_details = SnapshotFIFO(self).generate(bundle_wise_serial_nos, bundle_wise_batch_nos)
+			if snapshot_details is not None:
+				self.item_details = snapshot_details
 			else:
-				with frappe.db.unbuffered_cursor():
-					stock_ledger_entries = self._get_stock_ledger_entries()
-
-					for row in stock_ledger_entries:
+				with nullcontext() if self.snapshot else frappe.db.unbuffered_cursor():
+					for row in run_stock_query(query, self.snapshot, as_dict=True, as_iterator=True):
 						self._process_stock_ledger_entry(row, bundle_wise_serial_nos, bundle_wise_batch_nos)
-
-					# Note that stock_ledger_entries is an iterator, you can not reuse it like a list
-					del stock_ledger_entries
 		else:
-			# entries passed in directly as a list: no streaming cursor is opened, so the batchwise
-			# valuation flags can be resolved lazily — a nested get_value here is safe on postgres too
-			# (running it inside an unbuffered/named cursor would raise on postgres).
+			# Supplied entries can resolve supporting records lazily without a streaming cursor.
 			for row in stock_ledger_entries:
 				self._process_stock_ledger_entry(row, bundle_wise_serial_nos, bundle_wise_batch_nos)
 
@@ -472,12 +478,12 @@ class FIFOSlots:
 
 		if row.serial_and_batch_bundle:
 			if row.has_serial_no:
-				if bundle_wise_serial_nos:
+				if self.sle is None or bundle_wise_serial_nos:
 					serial_nos = bundle_wise_serial_nos.get(row.serial_and_batch_bundle) or []
 				else:
 					serial_nos = sorted(get_serial_nos_from_bundle(row.serial_and_batch_bundle)) or []
 			elif row.has_batch_no:
-				if bundle_wise_batch_nos:
+				if self.sle is None or bundle_wise_batch_nos:
 					batch_nos = bundle_wise_batch_nos.get(row.serial_and_batch_bundle) or []
 				else:
 					batch_nos = (
@@ -547,13 +553,13 @@ class FIFOSlots:
 
 		query = self._apply_filter(query, sle, "item_code")
 
-		for batch_no, use_batchwise_valuation in query.run():
+		for batch_no, use_batchwise_valuation in run_stock_query(query, self.snapshot):
 			self.batchwise_valuation_by_batch[batch_no] = use_batchwise_valuation
 
 	def _get_item_valuation_method(self, item_code: str) -> str:
-		from erpnext.stock.utils import get_valuation_method
-
 		if item_code not in self.valuation_method_by_item:
+			from erpnext.stock.utils import get_valuation_method
+
 			# only reachable when stock ledger entries are passed in directly;
 			# the streaming path prefetches all methods before iteration
 			self.valuation_method_by_item[item_code] = get_valuation_method(
@@ -566,23 +572,19 @@ class FIFOSlots:
 		from erpnext.stock.utils import get_valuation_method
 
 		company = self.filters.get("company")
-		sle = frappe.qb.DocType("Stock Ledger Entry")
 		item = frappe.qb.DocType("Item")
-		to_date = get_datetime(self.filters.get("to_date") + " 23:59:59")
-
-		query = (
-			frappe.qb.from_(sle)
-			.inner_join(item)
-			.on(sle.item_code == item.name)
-			.select(item.name, item.valuation_method)
-			.distinct()
-			.where((sle.company == company) & (sle.posting_datetime <= to_date) & (sle.is_cancelled != 1))
-		)
-		query = self._apply_filter(query, sle, "item_code")
+		query = frappe.qb.from_(item).select(item.name, item.valuation_method)
+		query = self._apply_filter(query, item, "item_code")
+		if self.filters.get("item_code"):
+			methods = query.run()
+		else:
+			entries = self._get_stock_ledger_query(ordered=False).as_("valuation_entries")
+			query = query.where(item.name.isin(frappe.qb.from_(entries).select(entries.name)))
+			methods = run_stock_query(query, self.snapshot)
 
 		# items with no item-level method share the company/settings default; resolve it once
 		default_method = None
-		for item_code, valuation_method in query.run():
+		for item_code, valuation_method in methods:
 			if not valuation_method:
 				if default_method is None:
 					default_method = get_valuation_method(item_code, company)
@@ -593,11 +595,11 @@ class FIFOSlots:
 		"Initialise keys and FIFO Queue."
 
 		key = (row.name, row.warehouse)
-		self.item_details.setdefault(key, {"details": row, "fifo_queue": []})
+		if key not in self.item_details:
+			self.item_details[key] = {"details": row, "fifo_queue": []}
 		fifo_queue = self.item_details[key]["fifo_queue"]
 
 		transferred_item_key = (row.voucher_no, row.name, row.warehouse)
-		self.transferred_item_details.setdefault(transferred_item_key, [])
 
 		return key, fifo_queue, transferred_item_key
 
@@ -714,6 +716,7 @@ class FIFOSlots:
 		from_end: bool = False,
 	):
 		"Update FIFO Queue on outward stock."
+		self.transferred_item_details.setdefault(transfer_key, [])
 		if serial_nos:
 			self._consume_serial_fifo_slots(fifo_queue, serial_nos)
 		elif batch_nos:
@@ -1029,7 +1032,7 @@ class FIFOSlots:
 
 		return item_aggregated_data
 
-	def _get_stock_ledger_entries(self) -> Iterator[dict]:
+	def _get_stock_ledger_query(self, ordered=True):
 		sle = frappe.qb.DocType("Stock Ledger Entry")
 		item = self._get_item_query()  # used as derived table in sle query
 		to_date = get_datetime(self.filters.get("to_date") + " 23:59:59")
@@ -1079,11 +1082,7 @@ class FIFOSlots:
 			if warehouses:
 				sle_query = sle_query.where(sle.warehouse.isin(warehouses))
 
-		sle_query = sle_query.orderby(sle.posting_datetime, sle.creation)
-
-		# postgres server-side (named) cursors can't run nested queries mid-iteration, which
-		# _process_stock_ledger_entry needs; fall back to a buffered fetch there. MariaDB streams.
-		return sle_query.run(as_dict=True, as_iterator=frappe.db.db_type != "postgres")
+		return sle_query.orderby(sle.posting_datetime, sle.creation) if ordered else sle_query
 
 	def _get_bundle_wise_serial_nos(self) -> dict:
 		bundle = frappe.qb.DocType("Serial and Batch Bundle")
@@ -1211,7 +1210,7 @@ class FIFOSlots:
 			.groupby(doctype.voucher_detail_no)
 		)
 
-		data = query.run(as_dict=True)
+		data = run_stock_query(query, self.snapshot, as_dict=True)
 		if not data:
 			return
 

--- a/erpnext/stock/report/stock_ageing/stock_ageing_snapshot.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing_snapshot.py
@@ -5,8 +5,8 @@ from collections import defaultdict
 from typing import NamedTuple
 
 import frappe
+from frappe.query_builder import Case, CustomFunction, Field
 from frappe.query_builder.functions import Abs, Cast, Count, Floor, IfNull, Max, Min, Sum
-from pypika import Case, CustomFunction, Field
 from pypika.analytics import CURRENT_ROW, Preceding
 from pypika.analytics import Sum as WindowSum
 from pypika.queries import QueryBuilder

--- a/erpnext/stock/report/stock_ageing/stock_ageing_snapshot.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing_snapshot.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+from frappe.query_builder.functions import Abs, Count, Floor, IfNull, Max, Min, Sum
+from pypika import Case, CustomFunction, Tuple
+from pypika.analytics import CURRENT_ROW, Preceding
+from pypika.analytics import Sum as WindowSum
+
+ArgMin = CustomFunction("arg_min_null", ["value", "order"])
+ArgMax = CustomFunction("arg_max_null", ["value", "order"])
+Row = CustomFunction("row", ["posting_datetime", "creation"])
+Least = CustomFunction("least", ["left", "right"])
+
+
+class SnapshotFIFO:
+	"""Resolve surviving receipt layers in DuckDB when FIFO arithmetic is exact."""
+
+	def __init__(self, fifo):
+		self.fifo = fifo
+		self.snapshot = fifo.snapshot
+		ledger = frappe.qb.DocType("Stock Ledger Entry")
+		self.entries = fifo._get_stock_ledger_query(ordered=False).select(
+			ledger.posting_datetime, ledger.creation
+		)
+
+	def generate(self, serial_bundles=None, batch_bundles=None):
+		summaries = self.snapshot.run(self.get_summary_query(), as_dict=True)
+		if len({row.first_order for row in summaries}) != len(summaries):
+			return None
+		eligible = [row for row in summaries if self.can_aggregate(row)]
+		if summaries and not eligible:
+			return None
+
+		details = {}
+		for row in eligible:
+			key = (row.name, row.warehouse)
+			details[key] = {
+				"details": frappe._dict({field: row[field] for field in DETAIL_FIELDS}),
+				"fifo_queue": [],
+				"total_qty": row.total_qty,
+				"qty_after_transaction": row.final_qty,
+				"has_serial_no": row.has_serial_no,
+				"has_batch_no": row.has_batch_no,
+			}
+
+		self.fast_keys = list(details)
+		if len(eligible) != len(summaries):
+			entries = frappe.qb.Table("fifo_scope")
+			self.entries = (
+				frappe.qb.from_(self.entries.as_("fifo_scope"))
+				.select(entries.star)
+				.where(Tuple(entries.name, entries.warehouse).isin(self.fast_keys))
+			)
+		if details:
+			for row in self.snapshot.run(self.get_layers_query(), as_iterator=True):
+				item, warehouse, qty, posting_date, value = row
+				details[(item, warehouse)]["fifo_queue"].append([qty, posting_date, value])
+		if len(eligible) != len(summaries):
+			self.fifo.item_details = details
+			serial_bundles = serial_bundles or {}
+			batch_bundles = batch_bundles or {}
+			ledger = frappe.qb.DocType("Stock Ledger Entry")
+			query = self.fifo._get_stock_ledger_query().where(
+				~Tuple(ledger.item_code, ledger.warehouse).isin(self.fast_keys) | ledger.warehouse.isnull()
+			)
+			for row in self.snapshot.run(query, as_dict=True, as_iterator=True):
+				self.fifo._process_stock_ledger_entry(row, serial_bundles, batch_bundles)
+		return {(row.name, row.warehouse): details[(row.name, row.warehouse)] for row in summaries}
+
+	def can_aggregate(self, row):
+		return (
+			not row.unsupported
+			and row.min_balance >= 0
+			and row.row_count == row.voucher_count == row.order_count
+			and row.qty_bound < 2**52
+			and row.value_bound < 2**52
+			and self.fifo._get_item_valuation_method(row.name) in ("FIFO", "Moving Average")
+		)
+
+	def get_summary_query(self):
+		entries = frappe.qb.Table("fifo_entries")
+		progress = frappe.qb.Table("fifo_progress")
+		order = Row(progress.posting_datetime, progress.creation)
+		progress_query = frappe.qb.from_(entries).select(
+			entries.star, self.running_sum(entries.actual_qty, entries).as_("running_qty")
+		)
+		unsupported = (
+			(progress.voucher_type == "Stock Reconciliation")
+			| (IfNull(progress.has_serial_no, 0) != 0)
+			| (IfNull(progress.has_batch_no, 0) != 0)
+		)
+		for field in ("serial_no", "batch_no", "serial_and_batch_bundle"):
+			unsupported |= IfNull(progress[field], "") != ""
+		unsupported |= progress.warehouse.isnull() | progress.creation.isnull()
+		# Restrict reassociation to exactly representable binary fractions with bounded sums.
+		for field in (progress.actual_qty, progress.stock_value_difference):
+			unsupported |= field.isnull() | (field * 1024 != Floor(field * 1024))
+
+		return (
+			frappe.qb.with_(self.entries, "fifo_entries")
+			.with_(progress_query, "fifo_progress")
+			.from_(progress)
+			.select(
+				progress.name,
+				progress.warehouse,
+				*[
+					ArgMin(progress[field], order).as_(field)
+					for field in DETAIL_FIELDS
+					if field not in ("name", "warehouse", "valuation_rate")
+				],
+				ArgMax(progress.valuation_rate, order).as_("valuation_rate"),
+				ArgMax(progress.qty_after_transaction, order).as_("final_qty"),
+				Min(order).as_("first_order"),
+				Count("*").as_("row_count"),
+				Count(progress.voucher_no).distinct().as_("voucher_count"),
+				Count(order).distinct().as_("order_count"),
+				Max(Case().when(unsupported, 1).else_(0)).as_("unsupported"),
+				Min(progress.running_qty).as_("min_balance"),
+				Sum(progress.actual_qty).as_("total_qty"),
+				Sum(Abs(progress.actual_qty) * 1024).as_("qty_bound"),
+				Sum(Abs(progress.stock_value_difference) * 1024).as_("value_bound"),
+			)
+			.groupby(progress.name, progress.warehouse)
+			.orderby("first_order")
+		)
+
+	def get_layers_query(self):
+		entries = frappe.qb.Table("fifo_entries")
+		progress = frappe.qb.Table("fifo_progress")
+		receipts = frappe.qb.Table("fifo_receipts")
+		issues = frappe.qb.Table("fifo_issues")
+		totals = frappe.qb.Table("fifo_totals")
+		resets = frappe.qb.Table("fifo_resets")
+		progress_query = frappe.qb.from_(entries).select(
+			entries.name,
+			entries.warehouse,
+			entries.actual_qty,
+			entries.stock_value_difference,
+			entries.posting_date,
+			entries.posting_datetime,
+			entries.creation,
+			*self.get_cumulative_columns(entries),
+		)
+		totals_query = (
+			frappe.qb.from_(progress)
+			.select(
+				progress.name,
+				progress.warehouse,
+				Max(progress.out_qty).as_("out_qty"),
+				Max(progress.out_value).as_("out_value"),
+			)
+			.groupby(progress.name, progress.warehouse)
+		)
+		# Exact layer exhaustion discards the issue's residual value in the existing FIFO replay.
+		resets_query = (
+			frappe.qb.from_(issues)
+			.join(receipts)
+			.on(self.same_stock(issues, receipts) & (issues.out_qty == receipts.in_qty))
+			.select(
+				issues.name,
+				issues.warehouse,
+				ArgMax(issues.out_value - receipts.in_value, issues.out_qty).as_("correction"),
+			)
+			.groupby(issues.name, issues.warehouse)
+		)
+		return (
+			frappe.qb.with_(self.entries, "fifo_entries")
+			.with_(progress_query, "fifo_progress")
+			.with_(
+				frappe.qb.from_(progress).select(progress.star).where(progress.actual_qty > 0),
+				"fifo_receipts",
+			)
+			.with_(
+				frappe.qb.from_(progress).select(progress.star).where(progress.actual_qty < 0), "fifo_issues"
+			)
+			.with_(totals_query, "fifo_totals")
+			.with_(resets_query, "fifo_resets")
+			.from_(receipts)
+			.join(totals)
+			.on(self.same_stock(receipts, totals))
+			.left_join(resets)
+			.on(self.same_stock(receipts, resets))
+			.select(
+				receipts.name,
+				receipts.warehouse,
+				Least(receipts.actual_qty, receipts.in_qty - totals.out_qty).as_("qty"),
+				receipts.posting_date,
+				Case()
+				.when(
+					receipts.in_qty - receipts.actual_qty < totals.out_qty,
+					receipts.in_value - totals.out_value + IfNull(resets.correction, 0),
+				)
+				.else_(receipts.stock_value_difference)
+				.as_("value"),
+			)
+			.where(receipts.in_qty > totals.out_qty)
+			.orderby(receipts.name, receipts.warehouse, receipts.posting_datetime, receipts.creation)
+		)
+
+	def get_cumulative_columns(self, entries):
+		for field, condition, value in (
+			("in_qty", entries.actual_qty > 0, entries.actual_qty),
+			("in_value", entries.actual_qty > 0, entries.stock_value_difference),
+			("out_qty", entries.actual_qty < 0, -entries.actual_qty),
+			("out_value", entries.actual_qty < 0, Abs(entries.stock_value_difference)),
+		):
+			yield self.running_sum(Case().when(condition, value).else_(0), entries).as_(field)
+
+	@staticmethod
+	def running_sum(value, table):
+		return (
+			WindowSum(value)
+			.over(table.name, table.warehouse)
+			.orderby(table.posting_datetime, table.creation)
+			.rows(Preceding(), CURRENT_ROW)
+		)
+
+	@staticmethod
+	def same_stock(left, right):
+		return (left.name == right.name) & (left.warehouse == right.warehouse)
+
+
+DETAIL_FIELDS = (
+	"name",
+	"item_name",
+	"item_group",
+	"brand",
+	"description",
+	"stock_uom",
+	"has_batch_no",
+	"has_serial_no",
+	"actual_qty",
+	"stock_value_difference",
+	"valuation_rate",
+	"posting_date",
+	"voucher_type",
+	"voucher_no",
+	"voucher_detail_no",
+	"serial_no",
+	"batch_no",
+	"qty_after_transaction",
+	"serial_and_batch_bundle",
+	"warehouse",
+)

--- a/erpnext/stock/report/stock_ageing/stock_ageing_snapshot.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing_snapshot.py
@@ -1,12 +1,18 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+from collections import defaultdict
+from typing import NamedTuple
+
 import frappe
 from frappe.query_builder.functions import Abs, Cast, Count, Floor, IfNull, Max, Min, Sum
 from pypika import Case, CustomFunction, Field
 from pypika.analytics import CURRENT_ROW, Preceding
 from pypika.analytics import Sum as WindowSum
+from pypika.queries import QueryBuilder
 from pypika.terms import Star
+
+from erpnext.stock.report.stock_ageing.stock_ageing import DETAIL_FIELDS
 
 ArgMin = CustomFunction("arg_min_null", ["value", "order"])
 ArgMax = CustomFunction("arg_max_null", ["value", "order"])
@@ -14,6 +20,20 @@ Row = CustomFunction("row", ["posting_datetime", "creation"])
 Least = CustomFunction("least", ["left", "right"])
 
 FAST_KEYS = "fifo_fast_keys"
+# Scaling by a power of two admits exact binary fractions. Keep scaled totals below 2**52
+# to leave headroom for intermediate additions and subtractions in the layer calculation.
+BINARY_FRACTION_SCALE = 1024
+MAX_EXACT_SCALED_SUM = 2**52
+
+StockKey = tuple[str, str | None]
+
+
+class SnapshotFIFOResult(NamedTuple):
+	"""Aggregated groups and the remaining query for FIFOSlots to replay in ledger order."""
+
+	details: dict[StockKey, dict]
+	replay_query: QueryBuilder | None
+	ordered_keys: list[StockKey]
 
 
 class SnapshotFIFO:
@@ -26,9 +46,9 @@ class SnapshotFIFO:
 		self.ledger_entries = fifo._get_stock_ledger_query(ordered=False).select(
 			ledger.posting_datetime, ledger.creation
 		)
-		self.entries = self.ledger_entries
 
-	def generate(self, serial_bundles=None, batch_bundles=None):
+	def generate(self) -> SnapshotFIFOResult | None:
+		"""Return aggregated groups and optional replay, or None when every entry needs replay."""
 		summaries = self.snapshot.run(self.get_summary_query(), as_dict=True)
 		if len({row.first_order for row in summaries}) != len(summaries):
 			return None
@@ -36,58 +56,53 @@ class SnapshotFIFO:
 		if summaries and not eligible:
 			return None
 
-		details = {self.stock_key(row): self.build_details(row) for row in eligible}
-		replayed = len(eligible) != len(summaries)
-		if replayed:
-			self.narrow_entries_to(details)
-		if details:
-			self.add_surviving_layers(details)
-		if replayed:
-			self.replay_remaining_entries(details, serial_bundles or {}, batch_bundles or {})
+		entries = self.ledger_entries
+		replay_query = None
+		if len(eligible) != len(summaries):
+			self.register_fast_keys([self.stock_key(row) for row in eligible])
+			entries = self.get_fast_entries()
+			replay_query = self.get_replay_query()
 
-		ordered_keys = [self.stock_key(row) for row in summaries]
-		return {key: details[key] for key in ordered_keys}
+		layers = self.get_surviving_layers(entries) if eligible else {}
+		details = {
+			self.stock_key(row): self.build_details(row, layers.get(self.stock_key(row), []))
+			for row in eligible
+		}
+		return SnapshotFIFOResult(details, replay_query, [self.stock_key(row) for row in summaries])
 
 	@staticmethod
-	def stock_key(row):
+	def stock_key(row) -> StockKey:
 		return (row.name, row.warehouse)
 
 	@staticmethod
-	def build_details(row):
+	def build_details(row, layers: list) -> dict:
 		return {
 			"details": frappe._dict({field: row[field] for field in DETAIL_FIELDS}),
-			"fifo_queue": [],
+			"fifo_queue": layers,
 			"total_qty": row.total_qty,
 			"qty_after_transaction": row.final_qty,
 			"has_serial_no": row.has_serial_no,
 			"has_batch_no": row.has_batch_no,
 		}
 
-	def narrow_entries_to(self, details):
-		"""Publish the aggregated groups to DuckDB and scope the entry queries to them, so the
-		split needs no parameter per group. Must run before the layer query is built."""
-		rows = [{"name": name, "warehouse": warehouse} for name, warehouse in details]
+	def register_fast_keys(self, keys: list[StockKey]) -> None:
+		"""Publish the aggregated groups to DuckDB so the split needs no parameter per group."""
+		rows = [{"name": name, "warehouse": warehouse} for name, warehouse in keys]
 		self.snapshot.register(FAST_KEYS, rows, {"name": "string", "warehouse": "string"})
-		self.entries = self.get_fast_entries()
 
-	def add_surviving_layers(self, details):
+	def get_surviving_layers(self, entries: QueryBuilder) -> dict[StockKey, list]:
+		layers = defaultdict(list)
 		for item, warehouse, qty, posting_date, value in self.snapshot.run(
-			self.get_layers_query(), as_iterator=True
+			self.get_layers_query(entries), as_iterator=True
 		):
-			details[(item, warehouse)]["fifo_queue"].append([qty, posting_date, value])
+			layers[(item, warehouse)].append([qty, posting_date, value])
+		return dict(layers)
 
-	def replay_remaining_entries(self, details, serial_bundles, batch_bundles):
-		"""Replay the groups DuckDB did not aggregate into the same details, so they keep the
-		layers attached above."""
-		self.fifo.item_details = details
-		for row in self.snapshot.run(self.get_replay_query(), as_dict=True, as_iterator=True):
-			self.fifo._process_stock_ledger_entry(row, serial_bundles, batch_bundles)
-
-	def get_fast_entries(self):
+	def get_fast_entries(self) -> QueryBuilder:
 		entries, keys = self.ledger_entries.as_("fifo_scope"), frappe.qb.Table(FAST_KEYS)
 		return frappe.qb.from_(entries).join(keys).on(self.same_stock(entries, keys)).select(Star(entries))
 
-	def get_replay_query(self):
+	def get_replay_query(self) -> QueryBuilder:
 		"""Entries left to the existing replay. Rows without a warehouse never match a key."""
 		entries, keys = frappe.qb.Table("fifo_replay"), frappe.qb.Table(FAST_KEYS)
 		return (
@@ -100,17 +115,17 @@ class SnapshotFIFO:
 			.orderby(Field("posting_datetime", table=entries), Field("creation", table=entries))
 		)
 
-	def can_aggregate(self, row):
+	def can_aggregate(self, row) -> bool:
 		return (
 			not row.unsupported
 			and row.min_balance >= 0
 			and row.row_count == row.voucher_count == row.order_count
-			and row.qty_bound < 2**52
-			and row.value_bound < 2**52
+			and row.qty_bound < MAX_EXACT_SCALED_SUM
+			and row.value_bound < MAX_EXACT_SCALED_SUM
 			and self.fifo._get_item_valuation_method(row.name) in ("FIFO", "Moving Average")
 		)
 
-	def get_summary_query(self):
+	def get_summary_query(self) -> QueryBuilder:
 		entries = frappe.qb.Table("fifo_entries")
 		progress = frappe.qb.Table("fifo_progress")
 		order = Row(progress.posting_datetime, progress.creation)
@@ -127,10 +142,11 @@ class SnapshotFIFO:
 		unsupported |= progress.warehouse.isnull() | progress.creation.isnull()
 		# Restrict reassociation to exactly representable binary fractions with bounded sums.
 		for field in (progress.actual_qty, progress.stock_value_difference):
-			unsupported |= field.isnull() | (field * 1024 != Floor(field * 1024))
+			scaled = field * BINARY_FRACTION_SCALE
+			unsupported |= field.isnull() | (scaled != Floor(scaled))
 
 		return (
-			frappe.qb.with_(self.entries, "fifo_entries")
+			frappe.qb.with_(self.ledger_entries, "fifo_entries")
 			.with_(progress_query, "fifo_progress")
 			.from_(progress)
 			.select(
@@ -150,55 +166,25 @@ class SnapshotFIFO:
 				Max(Case().when(unsupported, 1).else_(0)).as_("unsupported"),
 				Min(progress.running_qty).as_("min_balance"),
 				Sum(progress.actual_qty).as_("total_qty"),
-				Sum(Cast(Abs(progress.actual_qty), "DOUBLE") * 1024).as_("qty_bound"),
-				Sum(Cast(Abs(progress.stock_value_difference), "DOUBLE") * 1024).as_("value_bound"),
+				Sum(Cast(Abs(progress.actual_qty), "DOUBLE") * BINARY_FRACTION_SCALE).as_("qty_bound"),
+				Sum(Cast(Abs(progress.stock_value_difference), "DOUBLE") * BINARY_FRACTION_SCALE).as_(
+					"value_bound"
+				),
 			)
 			.groupby(progress.name, progress.warehouse)
 			.orderby("first_order")
 		)
 
-	def get_layers_query(self):
+	def get_layers_query(self, ledger_entries: QueryBuilder) -> QueryBuilder:
 		entries = frappe.qb.Table("fifo_entries")
 		progress = frappe.qb.Table("fifo_progress")
 		receipts = frappe.qb.Table("fifo_receipts")
 		issues = frappe.qb.Table("fifo_issues")
 		totals = frappe.qb.Table("fifo_totals")
 		resets = frappe.qb.Table("fifo_resets")
-		progress_query = frappe.qb.from_(entries).select(
-			entries.name,
-			entries.warehouse,
-			entries.actual_qty,
-			entries.stock_value_difference,
-			entries.posting_date,
-			entries.posting_datetime,
-			entries.creation,
-			*self.get_cumulative_columns(entries),
-		)
-		totals_query = (
-			frappe.qb.from_(progress)
-			.select(
-				progress.name,
-				progress.warehouse,
-				Max(progress.out_qty).as_("out_qty"),
-				Max(progress.out_value).as_("out_value"),
-			)
-			.groupby(progress.name, progress.warehouse)
-		)
-		# Exact layer exhaustion discards the issue's residual value in the existing FIFO replay.
-		resets_query = (
-			frappe.qb.from_(issues)
-			.join(receipts)
-			.on(self.same_stock(issues, receipts) & (issues.out_qty == receipts.in_qty))
-			.select(
-				issues.name,
-				issues.warehouse,
-				ArgMax(issues.out_value - receipts.in_value, issues.out_qty).as_("correction"),
-			)
-			.groupby(issues.name, issues.warehouse)
-		)
 		return (
-			frappe.qb.with_(self.entries, "fifo_entries")
-			.with_(progress_query, "fifo_progress")
+			frappe.qb.with_(ledger_entries, "fifo_entries")
+			.with_(self.get_progress_query(entries), "fifo_progress")
 			.with_(
 				frappe.qb.from_(progress).select(progress.star).where(progress.actual_qty > 0),
 				"fifo_receipts",
@@ -206,8 +192,8 @@ class SnapshotFIFO:
 			.with_(
 				frappe.qb.from_(progress).select(progress.star).where(progress.actual_qty < 0), "fifo_issues"
 			)
-			.with_(totals_query, "fifo_totals")
-			.with_(resets_query, "fifo_resets")
+			.with_(self.get_totals_query(progress), "fifo_totals")
+			.with_(self.get_resets_query(issues, receipts), "fifo_resets")
 			.from_(receipts)
 			.join(totals)
 			.on(self.same_stock(receipts, totals))
@@ -228,6 +214,48 @@ class SnapshotFIFO:
 			)
 			.where(receipts.in_qty > totals.out_qty)
 			.orderby(receipts.name, receipts.warehouse, receipts.posting_datetime, receipts.creation)
+		)
+
+	def get_progress_query(self, entries) -> QueryBuilder:
+		return frappe.qb.from_(entries).select(
+			entries.name,
+			entries.warehouse,
+			entries.actual_qty,
+			entries.stock_value_difference,
+			entries.posting_date,
+			entries.posting_datetime,
+			entries.creation,
+			*self.get_cumulative_columns(entries),
+		)
+
+	def get_totals_query(self, progress) -> QueryBuilder:
+		return (
+			frappe.qb.from_(progress)
+			.select(
+				progress.name,
+				progress.warehouse,
+				Max(progress.out_qty).as_("out_qty"),
+				Max(progress.out_value).as_("out_value"),
+			)
+			.groupby(progress.name, progress.warehouse)
+		)
+
+	def get_resets_query(self, issues, receipts) -> QueryBuilder:
+		"""Match replay's discarded residual value when a receipt layer is exhausted.
+
+		For (quantity, value): receive (10, 100), issue (10, 90), receive (5, 50), issue (1, 10).
+		The exhausted first layer discards 10 of value, leaving (4, 40) in the second layer.
+		"""
+		return (
+			frappe.qb.from_(issues)
+			.join(receipts)
+			.on(self.same_stock(issues, receipts) & (issues.out_qty == receipts.in_qty))
+			.select(
+				issues.name,
+				issues.warehouse,
+				ArgMax(issues.out_value - receipts.in_value, issues.out_qty).as_("correction"),
+			)
+			.groupby(issues.name, issues.warehouse)
 		)
 
 	def get_cumulative_columns(self, entries):
@@ -253,27 +281,3 @@ class SnapshotFIFO:
 		return (Field("name", table=left) == Field("name", table=right)) & (
 			Field("warehouse", table=left) == Field("warehouse", table=right)
 		)
-
-
-DETAIL_FIELDS = (
-	"name",
-	"item_name",
-	"item_group",
-	"brand",
-	"description",
-	"stock_uom",
-	"has_batch_no",
-	"has_serial_no",
-	"actual_qty",
-	"stock_value_difference",
-	"valuation_rate",
-	"posting_date",
-	"voucher_type",
-	"voucher_no",
-	"voucher_detail_no",
-	"serial_no",
-	"batch_no",
-	"qty_after_transaction",
-	"serial_and_batch_bundle",
-	"warehouse",
-)

--- a/erpnext/stock/report/stock_ageing/stock_ageing_snapshot.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing_snapshot.py
@@ -36,37 +36,52 @@ class SnapshotFIFO:
 		if summaries and not eligible:
 			return None
 
-		details = {}
-		for row in eligible:
-			key = (row.name, row.warehouse)
-			details[key] = {
-				"details": frappe._dict({field: row[field] for field in DETAIL_FIELDS}),
-				"fifo_queue": [],
-				"total_qty": row.total_qty,
-				"qty_after_transaction": row.final_qty,
-				"has_serial_no": row.has_serial_no,
-				"has_batch_no": row.has_batch_no,
-			}
-
+		details = {self.stock_key(row): self.build_details(row) for row in eligible}
 		replayed = len(eligible) != len(summaries)
 		if replayed:
-			self.register_fast_keys(details)
-			self.entries = self.get_fast_entries()
+			self.narrow_entries_to(details)
 		if details:
-			for item, warehouse, qty, posting_date, value in self.snapshot.run(
-				self.get_layers_query(), as_iterator=True
-			):
-				details[(item, warehouse)]["fifo_queue"].append([qty, posting_date, value])
+			self.add_surviving_layers(details)
 		if replayed:
-			self.fifo.item_details = details
-			for row in self.snapshot.run(self.get_replay_query(), as_dict=True, as_iterator=True):
-				self.fifo._process_stock_ledger_entry(row, serial_bundles or {}, batch_bundles or {})
-		return {(row.name, row.warehouse): details[(row.name, row.warehouse)] for row in summaries}
+			self.replay_remaining_entries(details, serial_bundles or {}, batch_bundles or {})
 
-	def register_fast_keys(self, details):
-		"""Publish the aggregated groups to DuckDB so the split needs no per-key parameters."""
+		ordered_keys = [self.stock_key(row) for row in summaries]
+		return {key: details[key] for key in ordered_keys}
+
+	@staticmethod
+	def stock_key(row):
+		return (row.name, row.warehouse)
+
+	@staticmethod
+	def build_details(row):
+		return {
+			"details": frappe._dict({field: row[field] for field in DETAIL_FIELDS}),
+			"fifo_queue": [],
+			"total_qty": row.total_qty,
+			"qty_after_transaction": row.final_qty,
+			"has_serial_no": row.has_serial_no,
+			"has_batch_no": row.has_batch_no,
+		}
+
+	def narrow_entries_to(self, details):
+		"""Publish the aggregated groups to DuckDB and scope the entry queries to them, so the
+		split needs no parameter per group. Must run before the layer query is built."""
 		rows = [{"name": name, "warehouse": warehouse} for name, warehouse in details]
 		self.snapshot.register(FAST_KEYS, rows, {"name": "string", "warehouse": "string"})
+		self.entries = self.get_fast_entries()
+
+	def add_surviving_layers(self, details):
+		for item, warehouse, qty, posting_date, value in self.snapshot.run(
+			self.get_layers_query(), as_iterator=True
+		):
+			details[(item, warehouse)]["fifo_queue"].append([qty, posting_date, value])
+
+	def replay_remaining_entries(self, details, serial_bundles, batch_bundles):
+		"""Replay the groups DuckDB did not aggregate into the same details, so they keep the
+		layers attached above."""
+		self.fifo.item_details = details
+		for row in self.snapshot.run(self.get_replay_query(), as_dict=True, as_iterator=True):
+			self.fifo._process_stock_ledger_entry(row, serial_bundles, batch_bundles)
 
 	def get_fast_entries(self):
 		entries, keys = self.ledger_entries.as_("fifo_scope"), frappe.qb.Table(FAST_KEYS)

--- a/erpnext/stock/report/stock_ageing/stock_ageing_snapshot.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing_snapshot.py
@@ -2,15 +2,18 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
-from frappe.query_builder.functions import Abs, Count, Floor, IfNull, Max, Min, Sum
-from pypika import Case, CustomFunction, Tuple
+from frappe.query_builder.functions import Abs, Cast, Count, Floor, IfNull, Max, Min, Sum
+from pypika import Case, CustomFunction, Field
 from pypika.analytics import CURRENT_ROW, Preceding
 from pypika.analytics import Sum as WindowSum
+from pypika.terms import Star
 
 ArgMin = CustomFunction("arg_min_null", ["value", "order"])
 ArgMax = CustomFunction("arg_max_null", ["value", "order"])
 Row = CustomFunction("row", ["posting_datetime", "creation"])
 Least = CustomFunction("least", ["left", "right"])
+
+FAST_KEYS = "fifo_fast_keys"
 
 
 class SnapshotFIFO:
@@ -20,9 +23,10 @@ class SnapshotFIFO:
 		self.fifo = fifo
 		self.snapshot = fifo.snapshot
 		ledger = frappe.qb.DocType("Stock Ledger Entry")
-		self.entries = fifo._get_stock_ledger_query(ordered=False).select(
+		self.ledger_entries = fifo._get_stock_ledger_query(ordered=False).select(
 			ledger.posting_datetime, ledger.creation
 		)
+		self.entries = self.ledger_entries
 
 	def generate(self, serial_bundles=None, batch_bundles=None):
 		summaries = self.snapshot.run(self.get_summary_query(), as_dict=True)
@@ -44,29 +48,42 @@ class SnapshotFIFO:
 				"has_batch_no": row.has_batch_no,
 			}
 
-		self.fast_keys = list(details)
-		if len(eligible) != len(summaries):
-			entries = frappe.qb.Table("fifo_scope")
-			self.entries = (
-				frappe.qb.from_(self.entries.as_("fifo_scope"))
-				.select(entries.star)
-				.where(Tuple(entries.name, entries.warehouse).isin(self.fast_keys))
-			)
+		replayed = len(eligible) != len(summaries)
+		if replayed:
+			self.register_fast_keys(details)
+			self.entries = self.get_fast_entries()
 		if details:
-			for row in self.snapshot.run(self.get_layers_query(), as_iterator=True):
-				item, warehouse, qty, posting_date, value = row
+			for item, warehouse, qty, posting_date, value in self.snapshot.run(
+				self.get_layers_query(), as_iterator=True
+			):
 				details[(item, warehouse)]["fifo_queue"].append([qty, posting_date, value])
-		if len(eligible) != len(summaries):
+		if replayed:
 			self.fifo.item_details = details
-			serial_bundles = serial_bundles or {}
-			batch_bundles = batch_bundles or {}
-			ledger = frappe.qb.DocType("Stock Ledger Entry")
-			query = self.fifo._get_stock_ledger_query().where(
-				~Tuple(ledger.item_code, ledger.warehouse).isin(self.fast_keys) | ledger.warehouse.isnull()
-			)
-			for row in self.snapshot.run(query, as_dict=True, as_iterator=True):
-				self.fifo._process_stock_ledger_entry(row, serial_bundles, batch_bundles)
+			for row in self.snapshot.run(self.get_replay_query(), as_dict=True, as_iterator=True):
+				self.fifo._process_stock_ledger_entry(row, serial_bundles or {}, batch_bundles or {})
 		return {(row.name, row.warehouse): details[(row.name, row.warehouse)] for row in summaries}
+
+	def register_fast_keys(self, details):
+		"""Publish the aggregated groups to DuckDB so the split needs no per-key parameters."""
+		rows = [{"name": name, "warehouse": warehouse} for name, warehouse in details]
+		self.snapshot.register(FAST_KEYS, rows, {"name": "string", "warehouse": "string"})
+
+	def get_fast_entries(self):
+		entries, keys = self.ledger_entries.as_("fifo_scope"), frappe.qb.Table(FAST_KEYS)
+		return frappe.qb.from_(entries).join(keys).on(self.same_stock(entries, keys)).select(Star(entries))
+
+	def get_replay_query(self):
+		"""Entries left to the existing replay. Rows without a warehouse never match a key."""
+		entries, keys = frappe.qb.Table("fifo_replay"), frappe.qb.Table(FAST_KEYS)
+		return (
+			frappe.qb.with_(self.ledger_entries, "fifo_replay")
+			.from_(entries)
+			.left_join(keys)
+			.on(self.same_stock(entries, keys))
+			.select(*(Field(field, table=entries) for field in DETAIL_FIELDS))
+			.where(Field("name", table=keys).isnull())
+			.orderby(Field("posting_datetime", table=entries), Field("creation", table=entries))
+		)
 
 	def can_aggregate(self, row):
 		return (
@@ -118,8 +135,8 @@ class SnapshotFIFO:
 				Max(Case().when(unsupported, 1).else_(0)).as_("unsupported"),
 				Min(progress.running_qty).as_("min_balance"),
 				Sum(progress.actual_qty).as_("total_qty"),
-				Sum(Abs(progress.actual_qty) * 1024).as_("qty_bound"),
-				Sum(Abs(progress.stock_value_difference) * 1024).as_("value_bound"),
+				Sum(Cast(Abs(progress.actual_qty), "DOUBLE") * 1024).as_("qty_bound"),
+				Sum(Cast(Abs(progress.stock_value_difference), "DOUBLE") * 1024).as_("value_bound"),
 			)
 			.groupby(progress.name, progress.warehouse)
 			.orderby("first_order")
@@ -218,7 +235,9 @@ class SnapshotFIFO:
 
 	@staticmethod
 	def same_stock(left, right):
-		return (left.name == right.name) & (left.warehouse == right.warehouse)
+		return (Field("name", table=left) == Field("name", table=right)) & (
+			Field("warehouse", table=left) == Field("warehouse", table=right)
+		)
 
 
 DETAIL_FIELDS = (

--- a/erpnext/stock/report/stock_ageing/test_stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/test_stock_ageing.py
@@ -19,6 +19,26 @@ class TestStockAgeing(ERPNextTestSuite):
 	def setUp(self) -> None:
 		self.filters = frappe._dict(company="_Test Company", to_date="2021-12-10", ranges=["30", "60", "90"])
 
+	def test_receipt_does_not_allocate_transfer_history(self):
+		slots = FIFOSlots(self.filters, [])
+		row = frappe._dict(name="Item A", warehouse="WH 1", voucher_no="Receipt 1")
+		slots._init_key_stores(row)
+		self.assertEqual(slots.transferred_item_details, {})
+
+	def test_empty_prefetched_bundles_do_not_query_during_streaming(self):
+		slots = FIFOSlots(self.filters)
+		for serial in (0, 1):
+			row = frappe._dict(
+				serial_and_batch_bundle="Missing bundle", has_serial_no=serial, has_batch_no=not serial
+			)
+			with (
+				patch("erpnext.stock.serial_batch_bundle.get_serial_nos_from_bundle") as serial_lookup,
+				patch.object(slots, "_get_bundle_wise_batch_nos") as batch_lookup,
+			):
+				self.assertEqual(slots._get_serial_and_batch_nos(row, {}, {}), ([], []))
+				serial_lookup.assert_not_called()
+				batch_lookup.assert_not_called()
+
 	def test_normal_inward_outward_queue(self):
 		"Reference: Case 1 in stock_ageing_fifo_logic.md (same wh)"
 		sle = [

--- a/erpnext/stock/report/stock_ageing/test_stock_ageing_snapshot.py
+++ b/erpnext/stock/report/stock_ageing/test_stock_ageing_snapshot.py
@@ -12,7 +12,11 @@ import frappe
 import pyarrow as pa
 
 from erpnext.stock.report.stock_ageing.stock_ageing import FIFOSlots
-from erpnext.stock.report.stock_ageing.stock_ageing_snapshot import DETAIL_FIELDS, SnapshotFIFO
+from erpnext.stock.report.stock_ageing.stock_ageing_snapshot import (
+	DETAIL_FIELDS,
+	FAST_KEYS,
+	SnapshotFIFO,
+)
 from erpnext.stock.report.stock_report_snapshot import StockReportSnapshot
 from erpnext.tests.utils import ERPNextTestSuite
 
@@ -80,12 +84,35 @@ class TestStockAgeingSnapshot(ERPNextTestSuite):
 				other[field] = rows[0][field]
 			self.assertIsNone(self.calculate(rows))
 
+	def test_split_does_not_bind_a_parameter_per_group(self):
+		rows = self.make_rows(5)
+		rows[0].stock_value_difference = 0.1
+		counts = self.count_split_parameters(rows)
+		self.assertTrue(counts)
+		self.assertEqual(set(counts), {0})
+
+	def count_split_parameters(self, rows):
+		"""Parameters bound by the queries that split aggregated groups from replayed ones."""
+		counts = []
+		compile_query = StockReportSnapshot.compile
+
+		def record(query):
+			sql, parameters = compile_query(query)
+			if FAST_KEYS in sql:
+				counts.append(len(parameters))
+			return sql, parameters
+
+		with patch.object(StockReportSnapshot, "compile", staticmethod(record)):
+			self.assertEqual(self.calculate(rows), self.replay(rows))
+
+		return counts
+
 	def calculate(self, rows, method="FIFO"):
 		fifo = self.make_fifo(rows, method)
 		with duckdb.connect(":memory:") as conn:
 			conn.from_arrow(self.as_arrow(rows)).create("tabStock Ledger Entry")
 			snapshot = StockReportSnapshot.__new__(StockReportSnapshot)
-			snapshot.conn, snapshot.filters, snapshot.live_tables = conn, {}, {}
+			snapshot.conn, snapshot.filters, snapshot.tables = conn, {}, {}
 			fifo.snapshot = snapshot
 			ledger = frappe.qb.DocType("Stock Ledger Entry")
 			query = frappe.qb.from_(ledger).select(*(ledger[field] for field in DETAIL_FIELDS))

--- a/erpnext/stock/report/stock_ageing/test_stock_ageing_snapshot.py
+++ b/erpnext/stock/report/stock_ageing/test_stock_ageing_snapshot.py
@@ -17,7 +17,6 @@ from erpnext.stock.report.stock_ageing.stock_ageing import FIFOSlots
 from erpnext.stock.report.stock_ageing.stock_ageing_snapshot import (
 	DETAIL_FIELDS,
 	FAST_KEYS,
-	SnapshotFIFO,
 )
 from erpnext.stock.report.stock_report_snapshot import StockReportSnapshot
 from erpnext.tests.utils import ERPNextTestSuite
@@ -137,11 +136,9 @@ class TestStockAgeingSnapshot(ERPNextTestSuite):
 				if ordered
 				else query,
 			):
-				details = SnapshotFIFO(fifo).generate()
-			if details is not None:
-				fifo.item_details = details
-				fifo._recompute_moving_average_slots()
-			return details
+				if fifo._generate_from_snapshot({}, {}):
+					fifo._recompute_moving_average_slots()
+					return fifo.item_details
 
 	def replay(self, rows, method="FIFO"):
 		fifo = self.make_fifo(rows, method)

--- a/erpnext/stock/report/stock_ageing/test_stock_ageing_snapshot.py
+++ b/erpnext/stock/report/stock_ageing/test_stock_ageing_snapshot.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from copy import deepcopy
+from datetime import datetime, timedelta
+from decimal import Decimal
+from random import Random
+from unittest.mock import patch
+
+import duckdb
+import frappe
+import pyarrow as pa
+
+from erpnext.stock.report.stock_ageing.stock_ageing import FIFOSlots
+from erpnext.stock.report.stock_ageing.stock_ageing_snapshot import DETAIL_FIELDS, SnapshotFIFO
+from erpnext.stock.report.stock_report_snapshot import StockReportSnapshot
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestStockAgeingSnapshot(ERPNextTestSuite):
+	def test_randomized_fifo_layers_match_replay(self):
+		for seed in range(20):
+			with self.subTest(seed=seed):
+				rows = self.make_rows(seed)
+				self.assertEqual(self.calculate(rows), self.replay(rows))
+
+	def test_exact_exhaustion_discards_residual_value(self):
+		rows = self.make_rows(0)[:7]
+		for row, qty, value in zip(
+			rows, (10, 5, -10, -2, 4, -7, 3), (100, 200, -90, -30, 100, -300, 75), strict=True
+		):
+			row.update(name="Item", warehouse="Warehouse", actual_qty=qty, stock_value_difference=value)
+		self.assertEqual(self.calculate(rows), self.replay(rows))
+
+	def test_moving_average_layers_match_replay(self):
+		rows = self.make_rows(2)
+		self.assertEqual(self.calculate(rows, "Moving Average"), self.replay(rows, "Moving Average"))
+
+	def test_fractional_group_does_not_disable_other_groups(self):
+		rows = self.make_rows(5)
+		for row in rows:
+			row.name += "' quoted item"
+			row.warehouse += '" quoted warehouse'
+		rows[0].stock_value_difference = 0.1
+		self.assertEqual(self.calculate(rows), self.replay(rows))
+
+	def test_unsupported_histories_use_replay(self):
+		for update in (
+			{"actual_qty": -100},
+			{"actual_qty": 0.1},
+			{"stock_value_difference": 0.1},
+			{"voucher_type": "Stock Reconciliation"},
+			{"serial_no": "Serial"},
+			{"batch_no": "Batch"},
+			{"serial_and_batch_bundle": "Bundle"},
+			{"has_serial_no": 1},
+			{"has_batch_no": 1},
+		):
+			with self.subTest(update=update):
+				rows = self.make_rows(0)
+				for row in rows:
+					row.update(name="Item", warehouse="Warehouse")
+				rows[0].update(update)
+				self.assertIsNone(self.calculate(rows))
+		self.assertIsNone(self.calculate(self.make_rows(0), "LIFO"))
+		rows = self.make_rows(0)
+		for row in rows:
+			row.stock_value_difference = 999999999999
+		self.assertIsNone(self.calculate(rows))
+
+	def test_reused_voucher_and_ambiguous_order_use_replay(self):
+		for fields in (("voucher_no",), ("posting_datetime", "creation")):
+			rows = self.make_rows(0)
+			for row in rows:
+				row.update(name="Item", warehouse="Warehouse")
+			other = next(
+				row for row in rows[1:] if (row.name, row.warehouse) == (rows[0].name, rows[0].warehouse)
+			)
+			for field in fields:
+				other[field] = rows[0][field]
+			self.assertIsNone(self.calculate(rows))
+
+	def calculate(self, rows, method="FIFO"):
+		fifo = self.make_fifo(rows, method)
+		with duckdb.connect(":memory:") as conn:
+			conn.from_arrow(self.as_arrow(rows)).create("tabStock Ledger Entry")
+			snapshot = StockReportSnapshot.__new__(StockReportSnapshot)
+			snapshot.conn, snapshot.filters, snapshot.live_tables = conn, {}, {}
+			fifo.snapshot = snapshot
+			ledger = frappe.qb.DocType("Stock Ledger Entry")
+			query = frappe.qb.from_(ledger).select(*(ledger[field] for field in DETAIL_FIELDS))
+			with patch.object(
+				fifo,
+				"_get_stock_ledger_query",
+				side_effect=lambda ordered=True: query.orderby(ledger.posting_datetime, ledger.creation)
+				if ordered
+				else query,
+			):
+				details = SnapshotFIFO(fifo).generate()
+			if details is not None:
+				fifo.item_details = details
+				fifo._recompute_moving_average_slots()
+			return details
+
+	def replay(self, rows, method="FIFO"):
+		fifo = self.make_fifo(rows, method)
+		for row in rows:
+			fifo._process_stock_ledger_entry(
+				frappe._dict({field: row[field] for field in DETAIL_FIELDS}), {}, {}
+			)
+		fifo._recompute_moving_average_slots()
+		return fifo.item_details
+
+	def make_fifo(self, rows, method):
+		fifo = FIFOSlots(frappe._dict(company="_Test Company", to_date="2026-12-31"), deepcopy(rows))
+		fifo.valuation_method_by_item = {row.name: method for row in rows}
+		fifo.stock_reco_voucher_wise_count = {}
+		fifo.float_precision = 3
+		return fifo
+
+	def make_rows(self, seed):
+		random = Random(seed)
+		balances, rows = {}, []
+		for index in range(120):
+			item, warehouse = random.choice(("C", "A", "B")), random.choice(("W2", "W1"))
+			key = (item, warehouse)
+			balance = balances.get(key, 0)
+			qty = random.randint(1, 40) / 4
+			if balance and random.random() < 0.6:
+				qty = -min(qty, balance)
+			balances[key] = balance + qty
+			date = datetime(2026, 1, 1) + timedelta(hours=index)
+			row = frappe._dict({field: None for field in DETAIL_FIELDS})
+			row.update(
+				name=item,
+				warehouse=warehouse,
+				item_name=item,
+				item_group="Products",
+				brand="Brand",
+				description=item,
+				stock_uom="Nos",
+				has_serial_no=0,
+				has_batch_no=0,
+				actual_qty=qty,
+				qty_after_transaction=balances[key],
+				valuation_rate=random.randint(1, 100) / 4,
+				stock_value_difference=random.randint(-400, 400) / 4,
+				posting_date=date.date(),
+				posting_datetime=date,
+				creation=date,
+				voucher_no=f"Voucher {index}",
+				voucher_detail_no=f"Detail {index}",
+				voucher_type="Stock Entry",
+			)
+			rows.append(row)
+		return rows
+
+	def as_arrow(self, rows):
+		rows = deepcopy(rows)
+		for row in rows:
+			row.item_code = row.name
+		decimals = {"actual_qty", "qty_after_transaction", "stock_value_difference", "valuation_rate"}
+		fields = []
+		for field in (*DETAIL_FIELDS, "posting_datetime", "creation", "item_code"):
+			if field in decimals:
+				dtype = pa.decimal128(21, 9)
+				for row in rows:
+					row[field] = Decimal(str(row[field])) if row[field] is not None else None
+			elif field in ("posting_datetime", "creation"):
+				dtype = pa.timestamp("us")
+			elif field == "posting_date":
+				dtype = pa.date32()
+			elif field in ("has_serial_no", "has_batch_no"):
+				dtype = pa.int64()
+			else:
+				dtype = pa.string()
+			fields.append((field, dtype))
+		return pa.Table.from_pylist(rows, schema=pa.schema(fields))

--- a/erpnext/stock/report/stock_ageing/test_stock_ageing_snapshot.py
+++ b/erpnext/stock/report/stock_ageing/test_stock_ageing_snapshot.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+import hashlib
+import json
 from copy import deepcopy
 from datetime import datetime, timedelta
 from decimal import Decimal
@@ -22,6 +24,18 @@ from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestStockAgeingSnapshot(ERPNextTestSuite):
+	def test_generated_histories_stay_pinned(self):
+		"""The seeded histories are fixtures. A different sequence must fail here, not silently
+		change what the FIFO tests cover."""
+		digest = hashlib.sha256()
+		for seed in range(20):
+			for row in self.make_rows(seed):
+				digest.update(json.dumps(row, default=str, sort_keys=True).encode())
+
+		self.assertEqual(
+			digest.hexdigest(), "c0d6222b7c07fb59a5f43f7186e2236ae574f83646453a11f1bd6321992abf33"
+		)
+
 	def test_randomized_fifo_layers_match_replay(self):
 		for seed in range(20):
 			with self.subTest(seed=seed):

--- a/erpnext/stock/report/stock_balance/stock_balance.json
+++ b/erpnext/stock/report/stock_balance/stock_balance.json
@@ -5,6 +5,12 @@
  "disabled": 0,
  "docstatus": 0,
  "doctype": "Report",
+ "doctype_to_sync": [
+  {
+   "doc_type": "Stock Ledger Entry"
+  }
+ ],
+ "snapshot_report": 0,
  "idx": 2,
  "is_standard": "Yes",
  "modified": "2020-04-30 13:46:14.680354",

--- a/erpnext/stock/report/stock_balance/stock_balance.json
+++ b/erpnext/stock/report/stock_balance/stock_balance.json
@@ -13,7 +13,7 @@
  "snapshot_report": 0,
  "idx": 2,
  "is_standard": "Yes",
- "modified": "2020-04-30 13:46:14.680354",
+ "modified": "2026-09-11 22:10:00.000000",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Balance",

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -3,6 +3,7 @@
 
 
 import json
+from contextlib import nullcontext
 from operator import itemgetter
 from typing import Any, TypedDict
 
@@ -21,6 +22,7 @@ from erpnext.stock.report.stock_ageing.stock_ageing import (
 	get_average_age,
 	normalize_fifo_queue,
 )
+from erpnext.stock.report.stock_report_snapshot import StockReportSnapshot, run_stock_query
 from erpnext.stock.utils import add_additional_uom_columns
 
 
@@ -45,9 +47,15 @@ def execute(filters: StockBalanceFilter | None = None):
 	return StockBalanceReport(filters).run()
 
 
+def execute_snapshot_report(filters):
+	with StockReportSnapshot("Stock Balance", filters) as snapshot:
+		return StockBalanceReport(filters, snapshot).run()
+
+
 class StockBalanceReport:
-	def __init__(self, filters: StockBalanceFilter | None) -> None:
+	def __init__(self, filters: StockBalanceFilter | None, snapshot=None) -> None:
 		self.filters = filters
+		self.snapshot = snapshot
 		self.from_date = getdate(filters.get("from_date"))
 		self.to_date = getdate(filters.get("to_date"))
 
@@ -65,6 +73,8 @@ class StockBalanceReport:
 
 	def run(self):
 		self.float_precision = cint(frappe.db.get_default("float_precision")) or 3
+		self.rounding_method = frappe.get_system_settings("rounding_method") or "Banker's Rounding (legacy)"
+		self.rounding_unit = 10**-self.float_precision
 
 		self.item_warehouse_map = frappe._dict({})
 		self.inventory_dimensions = self.get_inventory_dimension_fields()
@@ -194,16 +204,21 @@ class StockBalanceReport:
 	def prepare_item_warehouse_map_for_current_period(self):
 		self.opening_vouchers = self.get_opening_vouchers()
 
-		if self.filters.get("show_stock_ageing_data"):
-			self.sle_entries = self.sle_query.run(as_dict=True)
+		if self.snapshot:
+			from erpnext.stock.report.stock_balance.stock_balance_snapshot import prepare_aggregated_balances
+
+			if prepare_aggregated_balances(self):
+				self.item_warehouse_map = filter_items_with_no_transactions(
+					self.item_warehouse_map, self.float_precision, self.inventory_dimensions
+				)
+				return
 
 		self.prepare_stock_reco_voucher_wise_count()
 
 		# HACK: This is required to avoid causing db query in flt
 		_system_settings = frappe.get_cached_doc("System Settings")
-		with frappe.db.unbuffered_cursor():
-			if not self.filters.get("show_stock_ageing_data"):
-				self.sle_entries = self.sle_query.run(as_dict=True, as_iterator=True)
+		with nullcontext() if self.snapshot else frappe.db.unbuffered_cursor():
+			self.sle_entries = run_stock_query(self.sle_query, self.snapshot, as_dict=True, as_iterator=True)
 
 			for entry in self.sle_entries:
 				group_by_key = self.get_group_by_key(entry)
@@ -266,7 +281,7 @@ class StockBalanceReport:
 			if childrens:
 				query = query.where(doctype.warehouse.isin(childrens))
 
-		data = query.run(as_dict=True)
+		data = run_stock_query(query, self.snapshot, as_dict=True)
 		if not data:
 			return
 
@@ -284,7 +299,7 @@ class StockBalanceReport:
 	def prepare_new_data(self):
 		if self.filters.get("show_stock_ageing_data"):
 			self.filters["show_warehouse_wise_stock"] = True
-			item_wise_fifo_queue = FIFOSlots(self.filters).generate()
+			item_wise_fifo_queue = FIFOSlots(self.filters, snapshot=self.snapshot).generate()
 
 		del self.sle_entries
 
@@ -368,12 +383,12 @@ class StockBalanceReport:
 			qty_dict.opening_val += value_diff
 
 		elif entry.posting_date >= self.from_date and entry.posting_date <= self.to_date:
-			if flt(qty_diff, self.float_precision) >= 0:
+			if self.is_incoming(qty_diff):
 				qty_dict.in_qty += qty_diff
 			else:
 				qty_dict.out_qty += abs(qty_diff)
 
-			if flt(value_diff, self.float_precision) >= 0:
+			if self.is_incoming(value_diff):
 				qty_dict.in_val += value_diff
 			else:
 				qty_dict.out_val += abs(value_diff)
@@ -381,6 +396,14 @@ class StockBalanceReport:
 		qty_dict.val_rate = entry.valuation_rate
 		qty_dict.bal_qty += qty_diff
 		qty_dict.bal_val += value_diff
+
+	def is_incoming(self, value):
+		# Only a negative amount smaller than one rounding unit can round to zero.
+		if value >= 0:
+			return True
+		if value <= -self.rounding_unit:
+			return False
+		return flt(value, self.float_precision, self.rounding_method) >= 0
 
 	def initialize_data(self, group_by_key, entry):
 		self.item_warehouse_map[group_by_key] = frappe._dict(

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -765,24 +765,23 @@ class StockBalanceReport:
 		se = frappe.qb.DocType("Stock Entry")
 		sr = frappe.qb.DocType("Stock Reconciliation")
 
+		entry_query = (
+			frappe.qb.from_(se)
+			.select(se.name, Coalesce("Stock Entry").as_("voucher_type"))
+			.where((se.docstatus == 1) & (se.posting_date <= self.to_date) & (se.is_opening == "Yes"))
+		)
+		reco_query = (
+			frappe.qb.from_(sr)
+			.select(sr.name, Coalesce("Stock Reconciliation").as_("voucher_type"))
+			.where((sr.docstatus == 1) & (sr.posting_date <= self.to_date) & (sr.purpose == "Opening Stock"))
+		)
+		if company := self.filters.get("company"):
+			entry_query = entry_query.where(se.company == company)
+			reco_query = reco_query.where(sr.company == company)
+
 		vouchers_data = (
-			frappe.qb.from_(
-				(
-					frappe.qb.from_(se)
-					.select(se.name, Coalesce("Stock Entry").as_("voucher_type"))
-					.where((se.docstatus == 1) & (se.posting_date <= self.to_date) & (se.is_opening == "Yes"))
-				)
-				+ (
-					frappe.qb.from_(sr)
-					.select(sr.name, Coalesce("Stock Reconciliation").as_("voucher_type"))
-					.where(
-						(sr.docstatus == 1)
-						& (sr.posting_date <= self.to_date)
-						& (sr.purpose == "Opening Stock")
-					)
-				)
-			).select("voucher_type", "name")
-		).run(as_dict=True)
+			frappe.qb.from_(entry_query + reco_query).select("voucher_type", "name").run(as_dict=True)
+		)
 
 		if vouchers_data:
 			for d in vouchers_data:

--- a/erpnext/stock/report/stock_balance/stock_balance_snapshot.py
+++ b/erpnext/stock/report/stock_balance/stock_balance_snapshot.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+from frappe.query_builder.functions import Abs, Min, Sum
+from pypika import Case, CustomFunction
+from pypika.analytics import CURRENT_ROW, Preceding, RowNumber
+from pypika.analytics import Sum as WindowSum
+
+ArgMaxNull = CustomFunction("arg_max_null", ["value", "order"])
+
+
+def prepare_aggregated_balances(report):
+	"""Aggregate movements between balance resets, then apply each reset in ledger order."""
+	if report.filters.get("show_dimension_wise_stock") or any(
+		report.filters.get(field) for field in report.inventory_dimensions
+	):
+		return False
+
+	query = get_balance_query(report)
+	for row in report.snapshot.run(query, as_dict=True, as_iterator=True):
+		apply_segment(report, row)
+	return True
+
+
+def get_balance_query(report):
+	entries = frappe.qb.Table("snapshot_entries")
+	segments = frappe.qb.Table("snapshot_segments")
+	segment_query = frappe.qb.from_(entries).select(
+		entries.star,
+		WindowSum(entries.snapshot_detail)
+		.over(entries.item_code, entries.warehouse)
+		.orderby(entries.snapshot_row)
+		.rows(Preceding(), CURRENT_ROW)
+		.as_("snapshot_segment"),
+	)
+	# Each detail row starts a segment and forms its own group, separate from ordinary movements.
+	return (
+		frappe.qb.with_(get_segment_query(report), "snapshot_entries")
+		.with_(segment_query, "snapshot_segments")
+		.from_(segments)
+		.select(
+			segments.item_code,
+			segments.warehouse,
+			segments.snapshot_detail,
+			Min(segments.snapshot_row).as_("snapshot_row"),
+			*get_latest_columns(report, segments),
+			*get_movement_columns(segments),
+		)
+		.groupby(segments.item_code, segments.warehouse, segments.snapshot_segment, segments.snapshot_detail)
+		.orderby("snapshot_row")
+	)
+
+
+def get_movement_columns(segments):
+	columns = []
+	for field, suffix in ((segments.actual_qty, "qty"), (segments.stock_value_difference, "val")):
+		columns.extend(
+			[
+				Sum(Case().when(segments.snapshot_opening == 1, field).else_(0)).as_(f"opening_{suffix}"),
+				Sum(Case().when((segments.snapshot_opening == 0) & (field >= 0), field).else_(0)).as_(
+					f"in_{suffix}"
+				),
+				Sum(Case().when((segments.snapshot_opening == 0) & (field < 0), -field).else_(0)).as_(
+					f"out_{suffix}"
+				),
+				Sum(field).as_(f"bal_{suffix}"),
+			]
+		)
+	return columns
+
+
+def get_segment_query(report):
+	ledger = frappe.qb.DocType("Stock Ledger Entry")
+	opening = ledger.posting_date < report.from_date
+	for voucher_type, vouchers in report.opening_vouchers.items():
+		if vouchers:
+			opening |= (ledger.voucher_type == voucher_type) & ledger.voucher_no.isin(vouchers)
+
+	# flt() can classify tiny negative amounts as incoming. Preserve its exact rounding rules.
+	detail = ledger.voucher_type == "Stock Reconciliation"
+	for field in (ledger.actual_qty, ledger.stock_value_difference):
+		detail |= (field < 0) & (Abs(field) < 10**-report.float_precision)
+
+	return report.sle_query.select(
+		RowNumber().orderby(ledger.posting_datetime, ledger.creation).as_("snapshot_row"),
+		Case().when(opening, 1).else_(0).as_("snapshot_opening"),
+		Case().when(detail, 1).else_(0).as_("snapshot_detail"),
+	)
+
+
+def get_latest_columns(report, segments):
+	fields = [
+		"company",
+		"item_group",
+		"stock_uom",
+		"item_name",
+		"valuation_rate",
+		*report.inventory_dimensions,
+		"posting_date",
+		"actual_qty",
+		"stock_value_difference",
+		"voucher_type",
+		"voucher_no",
+		"batch_no",
+		"serial_no",
+		"serial_and_batch_bundle",
+		"qty_after_transaction",
+		"stock_value",
+		"voucher_detail_no",
+	]
+	return [ArgMaxNull(segments[field], segments.snapshot_row).as_(field) for field in fields]
+
+
+def apply_segment(report, row):
+	key = report.get_group_by_key(row)
+	if key not in report.item_warehouse_map:
+		report.initialize_data(key, row)
+
+	if row.snapshot_detail:
+		if row.voucher_type == "Stock Reconciliation" and not hasattr(
+			report, "stock_reco_voucher_wise_count"
+		):
+			report.prepare_stock_reco_voucher_wise_count()
+		report.prepare_item_warehouse_map(row, key)
+		return
+
+	balance = report.item_warehouse_map[key]
+	for field in (
+		"opening_qty",
+		"opening_val",
+		"in_qty",
+		"in_val",
+		"out_qty",
+		"out_val",
+		"bal_qty",
+		"bal_val",
+	):
+		balance[field] += row[field]
+	balance.val_rate = row.valuation_rate
+	for field in report.inventory_dimensions:
+		balance[field] = row.get(field)

--- a/erpnext/stock/report/stock_balance/stock_balance_snapshot.py
+++ b/erpnext/stock/report/stock_balance/stock_balance_snapshot.py
@@ -9,6 +9,10 @@ from pypika.analytics import Sum as WindowSum
 
 ArgMaxNull = CustomFunction("arg_max_null", ["value", "order"])
 
+MOVEMENT_PREFIXES = ("opening", "in", "out", "bal")
+MOVEMENT_SUFFIXES = ("qty", "val")
+MOVEMENT_FIELDS = tuple(f"{prefix}_{suffix}" for suffix in MOVEMENT_SUFFIXES for prefix in MOVEMENT_PREFIXES)
+
 
 def prepare_aggregated_balances(report):
 	"""Aggregate movements between balance resets, then apply each reset in ledger order."""
@@ -53,20 +57,18 @@ def get_balance_query(report):
 
 
 def get_movement_columns(segments):
+	opening = segments.snapshot_opening
+	amounts = {"qty": segments.actual_qty, "val": segments.stock_value_difference}
 	columns = []
-	for field, suffix in ((segments.actual_qty, "qty"), (segments.stock_value_difference, "val")):
-		columns.extend(
-			[
-				Sum(Case().when(segments.snapshot_opening == 1, field).else_(0)).as_(f"opening_{suffix}"),
-				Sum(Case().when((segments.snapshot_opening == 0) & (field >= 0), field).else_(0)).as_(
-					f"in_{suffix}"
-				),
-				Sum(Case().when((segments.snapshot_opening == 0) & (field < 0), -field).else_(0)).as_(
-					f"out_{suffix}"
-				),
-				Sum(field).as_(f"bal_{suffix}"),
-			]
-		)
+	for suffix in MOVEMENT_SUFFIXES:
+		field = amounts[suffix]
+		bodies = {
+			"opening": Case().when(opening == 1, field).else_(0),
+			"in": Case().when((opening == 0) & (field >= 0), field).else_(0),
+			"out": Case().when((opening == 0) & (field < 0), -field).else_(0),
+			"bal": field,
+		}
+		columns.extend(Sum(bodies[prefix]).as_(f"{prefix}_{suffix}") for prefix in MOVEMENT_PREFIXES)
 	return columns
 
 
@@ -126,16 +128,7 @@ def apply_segment(report, row):
 		return
 
 	balance = report.item_warehouse_map[key]
-	for field in (
-		"opening_qty",
-		"opening_val",
-		"in_qty",
-		"in_val",
-		"out_qty",
-		"out_val",
-		"bal_qty",
-		"bal_val",
-	):
+	for field in MOVEMENT_FIELDS:
 		balance[field] += row[field]
 	balance.val_rate = row.valuation_rate
 	for field in report.inventory_dimensions:

--- a/erpnext/stock/report/stock_balance/stock_balance_snapshot.py
+++ b/erpnext/stock/report/stock_balance/stock_balance_snapshot.py
@@ -2,8 +2,8 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
+from frappe.query_builder import Case, CustomFunction
 from frappe.query_builder.functions import Abs, Min, Sum
-from pypika import Case, CustomFunction
 from pypika.analytics import CURRENT_ROW, Preceding, RowNumber
 from pypika.analytics import Sum as WindowSum
 

--- a/erpnext/stock/report/stock_balance/test_stock_balance.py
+++ b/erpnext/stock/report/stock_balance/test_stock_balance.py
@@ -2,11 +2,15 @@ from typing import Any
 
 import frappe
 from frappe import _dict
-from frappe.utils import today
+from frappe.utils import flt, today
 
 from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
-from erpnext.stock.report.stock_balance.stock_balance import execute, get_stock_ageing_data
+from erpnext.stock.report.stock_balance.stock_balance import (
+	StockBalanceReport,
+	execute,
+	get_stock_ageing_data,
+)
 from erpnext.tests.utils import ERPNextTestSuite
 
 
@@ -50,7 +54,7 @@ class TestStockBalance(ERPNextTestSuite):
 		# Latest balance per (item_code, warehouse): first row wins because of the desc ordering.
 		for line in frappe.get_all(
 			"Stock Ledger Entry",
-			filters={"is_cancelled": 0},
+			filters={"is_cancelled": 0, "item_code": ("in", [row.item_code for row in rows])},
 			fields=["item_code", "warehouse", "stock_value", "qty_after_transaction"],
 			order_by="posting_datetime desc, creation desc",
 		):
@@ -75,6 +79,18 @@ class TestStockBalance(ERPNextTestSuite):
 			self.assertAlmostEqual(row.val_rate, row.bal_val / row.bal_qty, 3, msg)
 
 	# ----------- tests
+
+	def test_movement_sign_preserves_rounding_methods(self):
+		report = StockBalanceReport(self.filters)
+		for method in ("Banker's Rounding", "Banker's Rounding (legacy)", "Commercial Rounding"):
+			for precision in (-2, 0, 3, 9):
+				report.float_precision = precision
+				report.rounding_unit = 10**-precision
+				report.rounding_method = method
+				for multiplier in (-2, -1, -0.51, -0.5, -0.49, -0.00001, 0, 0.5, 2):
+					value = multiplier * report.rounding_unit
+					with self.subTest(method=method, precision=precision, value=value):
+						self.assertEqual(report.is_incoming(value), flt(value, precision, method) >= 0)
 
 	def test_basic_stock_balance(self):
 		"""Check very basic functionality and item info"""

--- a/erpnext/stock/report/stock_ledger/stock_ledger.json
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.json
@@ -5,6 +5,12 @@
  "disabled": 0, 
  "docstatus": 0, 
  "doctype": "Report", 
+ "doctype_to_sync": [
+  {
+   "doc_type": "Stock Ledger Entry"
+  }
+ ],
+ "snapshot_report": 0,
  "idx": 3, 
  "is_standard": "Yes", 
  "modified": "2017-02-24 20:14:07.626391", 

--- a/erpnext/stock/report/stock_ledger/stock_ledger.json
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.json
@@ -13,7 +13,7 @@
  "snapshot_report": 0,
  "idx": 3, 
  "is_standard": "Yes", 
- "modified": "2017-02-24 20:14:07.626391", 
+ "modified": "2026-09-11 22:10:00.000000", 
  "modified_by": "Administrator", 
  "module": "Stock", 
  "name": "Stock Ledger", 

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -7,9 +7,9 @@ from functools import lru_cache, partial
 
 import frappe
 from frappe import _
+from frappe.query_builder import CustomFunction, Order
 from frappe.query_builder.functions import Cast, IfNull, Sum
 from frappe.utils import cint, flt, get_datetime
-from pypika import CustomFunction, Order
 from pypika.analytics import RowNumber
 
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -3,18 +3,20 @@
 
 
 import copy
+from functools import lru_cache, partial
 
 import frappe
 from frappe import _
-from frappe.query_builder.functions import IfNull, Sum
+from frappe.query_builder.functions import Cast, IfNull, Sum
 from frappe.utils import cint, flt, get_datetime
-from pypika import Order
+from pypika import CustomFunction, Order
 from pypika.analytics import RowNumber
 
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
 from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 from erpnext.stock.doctype.stock_reconciliation.stock_reconciliation import get_stock_balance_for
 from erpnext.stock.doctype.warehouse.warehouse import apply_warehouse_filter
+from erpnext.stock.report.stock_report_snapshot import StockReportSnapshot, run_stock_query
 from erpnext.stock.utils import (
 	is_reposting_item_valuation_in_progress,
 	update_included_uom_in_report,
@@ -22,11 +24,20 @@ from erpnext.stock.utils import (
 
 
 def execute(filters=None):
+	return _execute(filters)
+
+
+def execute_snapshot_report(filters):
+	with StockReportSnapshot("Stock Ledger", filters) as snapshot:
+		return _execute(filters, snapshot)
+
+
+def _execute(filters, snapshot=None):
 	is_reposting_item_valuation_in_progress()
 	include_uom = filters.get("include_uom")
 	columns = get_columns(filters)
 	items = get_items(filters)
-	sl_entries = get_stock_ledger_entries(filters, items)
+	sl_entries = get_stock_ledger_entries(filters, items, snapshot)
 	item_details = get_item_details(items, sl_entries, include_uom)
 
 	inv_dimension_key = []
@@ -40,13 +51,17 @@ def execute(filters=None):
 				inv_dimension_key.append(value)
 
 	if filters.get("batch_no"):
-		opening_row = get_opening_balance_from_batch(filters, columns, sl_entries)
+		opening_row = get_opening_balance_from_batch(filters, columns, sl_entries, snapshot)
 	elif inv_dimension_wise_value:
-		opening_row = get_opening_balance_for_inv_dimension(filters, inv_dimension_wise_value)
+		opening_row = get_opening_balance_for_inv_dimension(filters, inv_dimension_wise_value, snapshot)
 	else:
-		opening_row = get_opening_balance(filters, columns, sl_entries, inv_dimension_wise_value)
+		opening_row = get_opening_balance(filters, columns, sl_entries, inv_dimension_wise_value, snapshot)
 
 	precision = cint(frappe.db.get_single_value("System Settings", "float_precision"))
+	rounding_method = frappe.get_system_settings("rounding_method") or "Banker's Rounding (legacy)"
+	# Repeated valuation rates share rounding work without retaining every ledger row.
+	round_rate = lru_cache(maxsize=1024)(partial(flt, precision=precision, rounding_method=rounding_method))
+	batch_no = filters.get("batch_no")
 	bundle_details = {}
 
 	if filters.get("segregate_serial_batch_bundle"):
@@ -87,8 +102,8 @@ def execute(filters=None):
 		if inv_dimension_key:
 			set_balance_value_for_inv_dimesion(inv_dimension_key, inv_dimension_wise_dict, sle)
 
-		if filters.get("batch_no"):
-			actual_qty += flt(sle.actual_qty, precision)
+		if batch_no:
+			actual_qty += flt(sle.actual_qty, precision, rounding_method)
 			stock_value += sle.stock_value_difference
 			if sle.batch_no:
 				if not batch_balance_dict.get(sle.batch_no):
@@ -106,13 +121,15 @@ def execute(filters=None):
 
 			sle.update({"qty_after_transaction": actual_qty, "stock_value": stock_value})
 
-		sle.update({"in_qty": max(sle.actual_qty, 0), "out_qty": min(sle.actual_qty, 0)})
+		qty = sle.actual_qty
+		sle.in_qty = qty if qty >= 0 else 0
+		sle.out_qty = qty if qty <= 0 else 0
 
 		if sle.serial_no:
 			update_available_serial_nos(available_serial_nos, sle)
 
 		if sle.actual_qty < 0:
-			sle["in_out_rate"] = flt(sle.stock_value_difference / sle.actual_qty, precision)
+			sle["in_out_rate"] = round_rate(sle.stock_value_difference / qty)
 			sle["incoming_rate"] = 0
 
 		elif sle.voucher_type == "Stock Reconciliation" and sle.actual_qty < 0:
@@ -453,33 +470,36 @@ def get_columns(filters):
 	return columns
 
 
-def get_stock_ledger_entries(filters, items):
+def get_stock_ledger_entries(filters, items, snapshot=None):
 	from_date = get_datetime(filters.from_date + " 00:00:00")
 	to_date = get_datetime(filters.to_date + " 23:59:59")
 
 	sle = frappe.qb.DocType("Stock Ledger Entry")
+	fields = [
+		sle.item_code,
+		sle.posting_datetime.as_("date"),
+		sle.warehouse,
+		sle.posting_date,
+		sle.posting_time,
+		sle.actual_qty,
+		sle.incoming_rate,
+		sle.valuation_rate,
+		sle.company,
+		sle.voucher_type,
+		sle.qty_after_transaction,
+		sle.stock_value_difference,
+		sle.serial_and_batch_bundle,
+		sle.voucher_no,
+		sle.stock_value,
+		sle.batch_no,
+		sle.serial_no,
+		sle.project,
+	]
+	if snapshot:
+		fields = get_snapshot_fields(fields)
 	query = (
 		frappe.qb.from_(sle)
-		.select(
-			sle.item_code,
-			sle.posting_datetime.as_("date"),
-			sle.warehouse,
-			sle.posting_date,
-			sle.posting_time,
-			sle.actual_qty,
-			sle.incoming_rate,
-			sle.valuation_rate,
-			sle.company,
-			sle.voucher_type,
-			sle.qty_after_transaction,
-			sle.stock_value_difference,
-			sle.serial_and_batch_bundle,
-			sle.voucher_no,
-			sle.stock_value,
-			sle.batch_no,
-			sle.serial_no,
-			sle.project,
-		)
+		.select(*fields)
 		.where((sle.docstatus < 2) & (sle.is_cancelled == 0) & (sle.posting_datetime[from_date:to_date]))
 		.orderby(sle.posting_datetime)
 		.orderby(sle.creation)
@@ -511,7 +531,29 @@ def get_stock_ledger_entries(filters, items):
 
 	query = apply_warehouse_filter(query, sle, filters)
 
-	return query.run(as_dict=True)
+	return run_stock_query(query, snapshot, as_dict=True)
+
+
+def get_snapshot_fields(fields):
+	"""Convert ledger decimals and times in DuckDB before creating Python rows."""
+	float_fields = {
+		"actual_qty",
+		"incoming_rate",
+		"valuation_rate",
+		"qty_after_transaction",
+		"stock_value_difference",
+		"stock_value",
+	}
+	to_microseconds = CustomFunction("to_microseconds", ["value"])
+	epoch_us = CustomFunction("epoch_us", ["value"])
+	result = []
+	for field in fields:
+		if field.name in float_fields:
+			field = Cast(field, "DOUBLE").as_(field.name)
+		elif field.name == "posting_time":
+			field = to_microseconds(epoch_us(field)).as_(field.name)
+		result.append(field)
+	return result
 
 
 def get_serial_and_batch_bundles(filters):
@@ -617,7 +659,7 @@ def get_sle_conditions(filters):
 	return "and {}".format(" and ".join(conditions)) if conditions else ""
 
 
-def get_opening_balance_from_batch(filters, columns, sl_entries):
+def get_opening_balance_from_batch(filters, columns, sl_entries, snapshot=None):
 	query_filters = {
 		"batch_no": filters.batch_no,
 		"docstatus": 1,
@@ -630,14 +672,15 @@ def get_opening_balance_from_batch(filters, columns, sl_entries):
 		if value := filters.get(fields):
 			query_filters[fields] = ("in", value)
 
-	opening_data = frappe.get_all(
+	opening_query = frappe.qb.get_query(
 		"Stock Ledger Entry",
 		fields=[
 			{"SUM": "actual_qty", "as": "qty_after_transaction"},
 			{"SUM": "stock_value_difference", "as": "stock_value"},
 		],
 		filters=query_filters,
-	)[0]
+	)
+	opening_data = run_stock_query(opening_query, snapshot, as_dict=True)[0]
 
 	for field in ["qty_after_transaction", "stock_value", "valuation_rate"]:
 		if opening_data.get(field) is None:
@@ -673,7 +716,7 @@ def get_opening_balance_from_batch(filters, columns, sl_entries):
 		else:
 			query = query.where(table[field] == value)
 
-	bundle_data = query.run(as_dict=True)
+	bundle_data = run_stock_query(query, snapshot, as_dict=True)
 
 	if bundle_data:
 		opening_data.qty_after_transaction += flt(bundle_data[0].qty)
@@ -691,7 +734,7 @@ def get_opening_balance_from_batch(filters, columns, sl_entries):
 	}
 
 
-def get_opening_balance(filters, columns, sl_entries, inv_dimension_wise_value=None):
+def get_opening_balance(filters, columns, sl_entries, inv_dimension_wise_value=None, snapshot=None):
 	if not (filters.item_code and filters.warehouse and filters.from_date):
 		return
 
@@ -720,14 +763,12 @@ def get_opening_balance(filters, columns, sl_entries, inv_dimension_wise_value=N
 		.where(sr_doctype.purpose == "Opening Stock")
 	)
 
-	opening_reco_vouchers = set(opening_reco_query.run(pluck=True))
+	opening_reco_vouchers = set(run_stock_query(opening_reco_query, snapshot, pluck=True))
 
 	if opening_reco_vouchers:
 		sl_entries[:] = [sle for sle in sl_entries if sle.get("voucher_no") not in opening_reco_vouchers]
 
-	sle_cond = (sle_doctype.posting_date < filters.from_date) | (
-		(sle_doctype.posting_date == filters.from_date) & (sle_doctype.posting_time == "00:00:00")
-	)
+	sle_cond = sle_doctype.posting_datetime <= get_datetime(filters.from_date)
 	if opening_reco_vouchers:
 		sle_cond = sle_cond | (
 			(sle_doctype.posting_date == filters.from_date)
@@ -770,7 +811,7 @@ def get_opening_balance(filters, columns, sl_entries, inv_dimension_wise_value=N
 		.where(subq.rn == 1)
 	)
 
-	res = query.run(as_dict=True)
+	res = run_stock_query(query, snapshot, as_dict=True)
 
 	total_qty = flt(res[0].total_qty) if res else 0.0
 	total_stock_value = flt(res[0].total_stock_value) if res else 0.0
@@ -860,7 +901,7 @@ def get_item_group_condition(item_group, item_table=None):
 				where ig.lft >= {item_group_details.lft} and ig.rgt <= {item_group_details.rgt} and item.item_group = ig.name)"
 
 
-def get_opening_balance_for_inv_dimension(filters, inv_dimension_wise_value):
+def get_opening_balance_for_inv_dimension(filters, inv_dimension_wise_value, snapshot=None):
 	if not filters.item_code or not filters.warehouse or not filters.from_date:
 		return
 
@@ -906,7 +947,7 @@ def get_opening_balance_for_inv_dimension(filters, inv_dimension_wise_value):
 
 	query = query.groupby(sl_doctype.item_code, sl_doctype.warehouse)
 
-	opening_data = query.run(as_dict=True)
+	opening_data = run_stock_query(query, snapshot, as_dict=True)
 
 	if opening_data:
 		return frappe._dict(

--- a/erpnext/stock/report/stock_ledger/test_stock_ledger_report.py
+++ b/erpnext/stock/report/stock_ledger/test_stock_ledger_report.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
-from frappe.utils import add_days, today
+from frappe.utils import add_days, cint, flt, today
 
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.report.stock_ledger.stock_ledger import execute
@@ -52,6 +54,31 @@ class TestStockLedgerReport(ERPNextTestSuite):
 		self.assertEqual(receipt["qty_after_transaction"], 10)
 		self.assertEqual(issue["out_qty"], -4)
 		self.assertEqual(issue["qty_after_transaction"], 6)
+
+	def test_repeated_rates_respect_each_reports_rounding_method(self):
+		item = "_Test Item"
+		self.make_movements(item, [{"qty": 10, "to_warehouse": WAREHOUSE, "basic_rate": 100}])
+		for value in (1.2345, 1.2345, 2.3455):
+			entry = make_stock_entry(item_code=item, qty=1, from_warehouse=WAREHOUSE)
+			frappe.db.set_value(
+				"Stock Ledger Entry", {"voucher_no": entry.name}, "stock_value_difference", -value
+			)
+
+		precision = cint(frappe.db.get_single_value("System Settings", "float_precision"))
+		get_setting = frappe.get_system_settings
+		for method in ("Banker's Rounding", "Commercial Rounding", "Banker's Rounding (legacy)"):
+			with patch(
+				"frappe.get_system_settings",
+				side_effect=lambda key, rounding=method: rounding
+				if key == "rounding_method"
+				else get_setting(key),
+			):
+				issues = [row for row in self.run_report(item) if row.get("out_qty")]
+			self.assertEqual(len(issues), 3)
+			for row in issues:
+				self.assertEqual(
+					row.in_out_rate, flt(row.stock_value_difference / row.actual_qty, precision, method)
+				)
 
 	def test_opening_balance_reflects_movements_before_from_date(self):
 		item = "_Test Item"

--- a/erpnext/stock/report/stock_report_snapshot.py
+++ b/erpnext/stock/report/stock_report_snapshot.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from datetime import timedelta
+
+import frappe
+from frappe import _
+from frappe.query_builder.terms import NamedParameterWrapper
+
+
+def run_stock_query(query, snapshot=None, **kwargs):
+	if snapshot is not None:
+		return snapshot.run(query, **kwargs)
+	return query.run(**kwargs)
+
+
+class StockReportSnapshot:
+	"""Run stock queries against synced ledger entries and live supporting records."""
+
+	def __init__(self, report_name, filters=None):
+		self.conn = self.get_connection(report_name)
+		self.live_tables = {}
+		self.filters = filters or {}
+
+	def __enter__(self):
+		return self
+
+	def __exit__(self, *exc):
+		self.conn.close()
+
+	@staticmethod
+	def get_connection(report_name):
+		sync = frappe.qb.DocType("DuckDB Sync")
+		item = frappe.qb.DocType("DuckDB Sync Item")
+		latest = (
+			frappe.qb.from_(sync)
+			.join(item)
+			.on(item.parent == sync.name)
+			.select(sync.name, item.synced)
+			.where(
+				(sync.doc_type == "Stock Ledger Entry")
+				& (sync.docstatus == 1)
+				& (item.table == "Stock Ledger Entry")
+			)
+			.orderby(sync.creation, order=frappe.qb.desc)
+			.limit(1)
+			.run(as_dict=True)
+		)
+		# The report's snapshot timestamp refers to the latest submitted sync.
+		if not latest or not latest[0].synced:
+			frappe.throw(
+				_("{0} requires a completed Stock Ledger Entry sync to DuckDB").format(_(report_name))
+			)
+		return frappe.get_doc("DuckDB Sync", latest[0].name).get_duckdb_conn()
+
+	def run(self, query, as_dict=False, as_iterator=False, pluck=False):
+		sql, parameters = self.compile(query)
+		cursor = self.conn.cursor()
+		try:
+			for doctype in LIVE_TABLES:
+				table_name = f"tab{doctype}"
+				if f'"{table_name}"' in sql:
+					cursor.register(table_name, self.get_live_table(doctype))
+			cursor.execute(sql, parameters)
+		except Exception:
+			cursor.close()
+			raise
+
+		rows = self.iter_rows(cursor, as_dict, pluck)
+		return rows if as_iterator else list(rows)
+
+	@staticmethod
+	def compile(query):
+		parameters = DuckDBParameters()
+		sql = query.get_sql(quote_char='"', alias_quote_char='"', param_wrapper=parameters)
+		return sql, parameters.get_parameters()
+
+	def get_live_table(self, doctype):
+		import pyarrow as pa
+
+		if doctype in self.live_tables:
+			return self.live_tables[doctype]
+
+		ledger_field, link_field, fields = LIVE_TABLES[doctype]
+		names = self.get_ledger_values(ledger_field, doctype)
+		rows = []
+		for offset in range(0, len(names), 1000):
+			rows.extend(
+				frappe.get_all(
+					doctype,
+					filters={link_field: ("in", names[offset : offset + 1000])},
+					fields=list(fields),
+				)
+			)
+
+		# Explicit types also preserve the schema when a supporting table has no matching rows.
+		schema = pa.schema([(field, getattr(pa, dtype)()) for field, dtype in fields.items()])
+		self.live_tables[doctype] = pa.Table.from_pylist(rows, schema=schema)
+		return self.live_tables[doctype]
+
+	def get_ledger_values(self, field, doctype):
+		ledger = frappe.qb.DocType("Stock Ledger Entry")
+		query = frappe.qb.from_(ledger).select(ledger[field]).distinct().where(ledger[field].notnull())
+		if field == "voucher_no":
+			query = query.where(ledger.voucher_type == doctype)
+		for key in ("company", "item_code"):
+			if value := self.filters.get(key):
+				values = value if isinstance(value, list | tuple) else [value]
+				query = query.where(ledger[key].isin(values))
+		if to_date := self.filters.get("to_date"):
+			query = query.where(ledger.posting_date <= to_date)
+		return [value for value in self.run(query, pluck=True) if value]
+
+	@staticmethod
+	def iter_rows(cursor, as_dict, pluck):
+		columns = [column[0] for column in cursor.description]
+		# Resolve conversions once per column, rather than inspecting every value in Python.
+		converters = [
+			(index, converter)
+			for index, column in enumerate(cursor.description)
+			if (converter := VALUE_CONVERTERS.get(column[1].id))
+		]
+		try:
+			while rows := cursor.fetchmany(1000):
+				for row in rows:
+					if converters:
+						row = list(row)
+						for index, converter in converters:
+							if row[index] is not None:
+								row[index] = converter(row[index])
+					if pluck:
+						yield row[0]
+					elif as_dict:
+						yield frappe._dict(zip(columns, row, strict=True))
+					else:
+						yield tuple(row)
+		finally:
+			cursor.close()
+
+
+def time_to_timedelta(value):
+	return timedelta(
+		hours=value.hour, minutes=value.minute, seconds=value.second, microseconds=value.microsecond
+	)
+
+
+VALUE_CONVERTERS = {"decimal": float, "time": time_to_timedelta, "time_tz": time_to_timedelta}
+
+
+class DuckDBParameters(NamedParameterWrapper):
+	def get_sql(self, param_value, **kwargs):
+		key = f"param{len(self.parameters) + 1}"
+		self.parameters[key] = param_value
+		return f"${key}"
+
+
+LIVE_TABLES = {
+	"Item": (
+		"item_code",
+		"name",
+		{
+			"name": "string",
+			"item_code": "string",
+			"item_name": "string",
+			"description": "string",
+			"stock_uom": "string",
+			"brand": "string",
+			"item_group": "string",
+			"has_serial_no": "int64",
+			"has_batch_no": "int64",
+			"valuation_method": "string",
+		},
+	),
+	"Warehouse": (
+		"warehouse",
+		"name",
+		{"name": "string", "lft": "int64", "rgt": "int64", "warehouse_type": "string"},
+	),
+	"Batch": ("batch_no", "name", {"name": "string", "use_batchwise_valuation": "int64"}),
+	"Stock Reconciliation": ("voucher_no", "name", {"name": "string", "purpose": "string"}),
+	"Serial and Batch Entry": (
+		"serial_and_batch_bundle",
+		"parent",
+		{
+			"parent": "string",
+			"qty": "float64",
+			"stock_value_difference": "float64",
+			"docstatus": "int64",
+			"batch_no": "string",
+		},
+	),
+}

--- a/erpnext/stock/report/stock_report_snapshot.py
+++ b/erpnext/stock/report/stock_report_snapshot.py
@@ -7,6 +7,8 @@ import frappe
 from frappe import _
 from frappe.query_builder.terms import NamedParameterWrapper
 
+BATCH_SIZE = 1000
+
 
 def run_stock_query(query, snapshot=None, **kwargs):
 	if snapshot is not None:
@@ -15,11 +17,17 @@ def run_stock_query(query, snapshot=None, **kwargs):
 
 
 class StockReportSnapshot:
-	"""Run stock queries against synced ledger entries and live supporting records."""
+	"""Run stock queries against synced ledger entries and live supporting records.
+
+	Only Stock Ledger Entry comes from the snapshot. Every doctype in LIVE_TABLES is read from
+	the live database the first time a query needs it, so a report combines a frozen ledger with
+	current master data. Those rows cover the ledger keys under the report's company, item and
+	to_date filters, so a query that joins one of them must stay inside the same ledger scope.
+	"""
 
 	def __init__(self, report_name, filters=None):
 		self.conn = self.get_connection(report_name)
-		self.live_tables = {}
+		self.tables = {}
 		self.filters = filters or {}
 
 	def __enter__(self):
@@ -30,37 +38,26 @@ class StockReportSnapshot:
 
 	@staticmethod
 	def get_connection(report_name):
-		sync = frappe.qb.DocType("DuckDB Sync")
-		item = frappe.qb.DocType("DuckDB Sync Item")
-		latest = (
-			frappe.qb.from_(sync)
-			.join(item)
-			.on(item.parent == sync.name)
-			.select(sync.name, item.synced)
-			.where(
-				(sync.doc_type == "Stock Ledger Entry")
-				& (sync.docstatus == 1)
-				& (item.table == "Stock Ledger Entry")
-			)
-			.orderby(sync.creation, order=frappe.qb.desc)
-			.limit(1)
-			.run(as_dict=True)
+		"""Open the latest submitted sync. An older complete sync is not served because the desk
+		labels snapshot results with the latest submitted sync's timestamp."""
+		sync = frappe.db.get_value(
+			"DuckDB Sync",
+			{"doc_type": "Stock Ledger Entry", "docstatus": 1},
+			"name",
+			order_by="creation desc",
 		)
-		# The report's snapshot timestamp refers to the latest submitted sync.
-		if not latest or not latest[0].synced:
+		if not sync or frappe.db.exists("DuckDB Sync Item", {"parent": sync, "synced": 0}):
 			frappe.throw(
 				_("{0} requires a completed Stock Ledger Entry sync to DuckDB").format(_(report_name))
 			)
-		return frappe.get_doc("DuckDB Sync", latest[0].name).get_duckdb_conn()
+		return frappe.get_doc("DuckDB Sync", sync).get_duckdb_conn()
 
 	def run(self, query, as_dict=False, as_iterator=False, pluck=False):
 		sql, parameters = self.compile(query)
 		cursor = self.conn.cursor()
 		try:
-			for doctype in LIVE_TABLES:
-				table_name = f"tab{doctype}"
-				if f'"{table_name}"' in sql:
-					cursor.register(table_name, self.get_live_table(doctype))
+			for name in self.get_referenced_tables(sql):
+				cursor.register(name, self.get_table(name))
 			cursor.execute(sql, parameters)
 		except Exception:
 			cursor.close()
@@ -75,30 +72,44 @@ class StockReportSnapshot:
 		sql = query.get_sql(quote_char='"', alias_quote_char='"', param_wrapper=parameters)
 		return sql, parameters.get_parameters()
 
-	def get_live_table(self, doctype):
+	def get_referenced_tables(self, sql):
+		names = dict.fromkeys([*self.tables, *(f"tab{doctype}" for doctype in LIVE_TABLES)])
+		return [name for name in names if f'"{name}"' in sql]
+
+	def register(self, name, rows, fields):
+		"""Expose a lookup table built in Python to the queries that follow."""
+		self.tables[name] = build_arrow_table(rows, fields)
+
+	def get_table(self, name):
+		if name not in self.tables:
+			self.tables[name] = self.build_live_table(name.removeprefix("tab"))
+		return self.tables[name]
+
+	def build_live_table(self, doctype):
+		"""Read a supporting doctype in batches so a large table never lands in Python at once."""
 		import pyarrow as pa
 
-		if doctype in self.live_tables:
-			return self.live_tables[doctype]
-
 		ledger_field, link_field, fields = LIVE_TABLES[doctype]
+		schema = arrow_schema(fields)
 		names = self.get_ledger_values(ledger_field, doctype)
-		rows = []
-		for offset in range(0, len(names), 1000):
-			rows.extend(
-				frappe.get_all(
-					doctype,
-					filters={link_field: ("in", names[offset : offset + 1000])},
-					fields=list(fields),
-				)
-			)
+		filters = self.get_live_filters(doctype)
+
+		batches = []
+		for offset in range(0, len(names), BATCH_SIZE):
+			filters[link_field] = ("in", names[offset : offset + BATCH_SIZE])
+			rows = frappe.get_all(doctype, filters=filters, fields=list(fields))
+			batches.append(pa.RecordBatch.from_pylist(rows, schema=schema))
 
 		# Explicit types also preserve the schema when a supporting table has no matching rows.
-		schema = pa.schema([(field, getattr(pa, dtype)()) for field, dtype in fields.items()])
-		self.live_tables[doctype] = pa.Table.from_pylist(rows, schema=schema)
-		return self.live_tables[doctype]
+		return pa.Table.from_batches(batches, schema=schema)
+
+	def get_live_filters(self, doctype):
+		"""Report filters that narrow a supporting table beyond the ledger keys it covers."""
+		scope = LIVE_TABLE_SCOPE.get(doctype) or {}
+		return {field: value for key, field in scope.items() if (value := self.filters.get(key))}
 
 	def get_ledger_values(self, field, doctype):
+		"""Ledger keys a supporting table has to cover, under the report's own ledger scope."""
 		ledger = frappe.qb.DocType("Stock Ledger Entry")
 		query = frappe.qb.from_(ledger).select(ledger[field]).distinct().where(ledger[field].notnull())
 		if field == "voucher_no":
@@ -136,6 +147,18 @@ class StockReportSnapshot:
 						yield tuple(row)
 		finally:
 			cursor.close()
+
+
+def arrow_schema(fields):
+	import pyarrow as pa
+
+	return pa.schema([(field, getattr(pa, dtype)()) for field, dtype in fields.items()])
+
+
+def build_arrow_table(rows, fields):
+	import pyarrow as pa
+
+	return pa.Table.from_pylist(rows, schema=arrow_schema(fields))
 
 
 def time_to_timedelta(value):
@@ -190,3 +213,5 @@ LIVE_TABLES = {
 		},
 	),
 }
+
+LIVE_TABLE_SCOPE = {"Serial and Batch Entry": {"batch_no": "batch_no"}}

--- a/erpnext/stock/report/stock_report_snapshot.py
+++ b/erpnext/stock/report/stock_report_snapshot.py
@@ -2,6 +2,8 @@
 # License: GNU General Public License v3. See license.txt
 
 from datetime import timedelta
+from operator import itemgetter
+from typing import NamedTuple
 
 import frappe
 from frappe import _
@@ -78,7 +80,9 @@ class StockReportSnapshot:
 
 	def register(self, name, rows, fields):
 		"""Expose a lookup table built in Python to the queries that follow."""
-		self.tables[name] = build_arrow_table(rows, fields)
+		import pyarrow as pa
+
+		self.tables[name] = pa.Table.from_pylist(rows, schema=arrow_schema(fields))
 
 	def get_table(self, name):
 		if name not in self.tables:
@@ -89,24 +93,20 @@ class StockReportSnapshot:
 		"""Read a supporting doctype in batches so a large table never lands in Python at once."""
 		import pyarrow as pa
 
-		ledger_field, link_field, fields = LIVE_TABLES[doctype]
-		schema = arrow_schema(fields)
-		names = self.get_ledger_values(ledger_field, doctype)
-		filters = self.get_live_filters(doctype)
+		table = LIVE_TABLES[doctype]
+		schema = arrow_schema(table.fields)
+		names = self.get_ledger_values(table.ledger_field, doctype)
+		scope = (table.scope or {}).items()
+		filters = {field: value for key, field in scope if (value := self.filters.get(key))}
 
 		batches = []
 		for offset in range(0, len(names), BATCH_SIZE):
-			filters[link_field] = ("in", names[offset : offset + BATCH_SIZE])
-			rows = frappe.get_all(doctype, filters=filters, fields=list(fields))
+			filters[table.link_field] = ("in", names[offset : offset + BATCH_SIZE])
+			rows = frappe.get_all(doctype, filters=filters, fields=list(table.fields))
 			batches.append(pa.RecordBatch.from_pylist(rows, schema=schema))
 
 		# Explicit types also preserve the schema when a supporting table has no matching rows.
 		return pa.Table.from_batches(batches, schema=schema)
-
-	def get_live_filters(self, doctype):
-		"""Report filters that narrow a supporting table beyond the ledger keys it covers."""
-		scope = LIVE_TABLE_SCOPE.get(doctype) or {}
-		return {field: value for key, field in scope.items() if (value := self.filters.get(key))}
 
 	def get_ledger_values(self, field, doctype):
 		"""Ledger keys a supporting table has to cover, under the report's own ledger scope."""
@@ -131,6 +131,15 @@ class StockReportSnapshot:
 			for index, column in enumerate(cursor.description)
 			if (converter := VALUE_CONVERTERS.get(column[1].id))
 		]
+		if pluck:
+			shape = itemgetter(0)
+		elif as_dict:
+
+			def shape(row):
+				return frappe._dict(zip(columns, row, strict=True))
+		else:
+			shape = tuple
+
 		try:
 			while rows := cursor.fetchmany(1000):
 				for row in rows:
@@ -139,12 +148,7 @@ class StockReportSnapshot:
 						for index, converter in converters:
 							if row[index] is not None:
 								row[index] = converter(row[index])
-					if pluck:
-						yield row[0]
-					elif as_dict:
-						yield frappe._dict(zip(columns, row, strict=True))
-					else:
-						yield tuple(row)
+					yield shape(row)
 		finally:
 			cursor.close()
 
@@ -153,12 +157,6 @@ def arrow_schema(fields):
 	import pyarrow as pa
 
 	return pa.schema([(field, getattr(pa, dtype)()) for field, dtype in fields.items()])
-
-
-def build_arrow_table(rows, fields):
-	import pyarrow as pa
-
-	return pa.Table.from_pylist(rows, schema=arrow_schema(fields))
 
 
 def time_to_timedelta(value):
@@ -177,8 +175,21 @@ class DuckDBParameters(NamedParameterWrapper):
 		return f"${key}"
 
 
+class LiveTable(NamedTuple):
+	"""A supporting doctype read from the live database for the queries that need it.
+
+	`ledger_field` is the Stock Ledger Entry column holding its keys and `link_field` the column
+	those keys match. `scope` names report filters that narrow it further than those keys.
+	"""
+
+	ledger_field: str
+	link_field: str
+	fields: dict[str, str]
+	scope: dict[str, str] | None = None
+
+
 LIVE_TABLES = {
-	"Item": (
+	"Item": LiveTable(
 		"item_code",
 		"name",
 		{
@@ -194,14 +205,14 @@ LIVE_TABLES = {
 			"valuation_method": "string",
 		},
 	),
-	"Warehouse": (
+	"Warehouse": LiveTable(
 		"warehouse",
 		"name",
 		{"name": "string", "lft": "int64", "rgt": "int64", "warehouse_type": "string"},
 	),
-	"Batch": ("batch_no", "name", {"name": "string", "use_batchwise_valuation": "int64"}),
-	"Stock Reconciliation": ("voucher_no", "name", {"name": "string", "purpose": "string"}),
-	"Serial and Batch Entry": (
+	"Batch": LiveTable("batch_no", "name", {"name": "string", "use_batchwise_valuation": "int64"}),
+	"Stock Reconciliation": LiveTable("voucher_no", "name", {"name": "string", "purpose": "string"}),
+	"Serial and Batch Entry": LiveTable(
 		"serial_and_batch_bundle",
 		"parent",
 		{
@@ -211,7 +222,6 @@ LIVE_TABLES = {
 			"docstatus": "int64",
 			"batch_no": "string",
 		},
+		{"batch_no": "batch_no"},
 	),
 }
-
-LIVE_TABLE_SCOPE = {"Serial and Batch Entry": {"batch_no": "batch_no"}}

--- a/erpnext/stock/report/stock_report_snapshot.py
+++ b/erpnext/stock/report/stock_report_snapshot.py
@@ -58,7 +58,7 @@ class StockReportSnapshot:
 		sql, parameters = self.compile(query)
 		cursor = self.conn.cursor()
 		try:
-			for name in self.get_referenced_tables(sql):
+			for name in self.get_referenced_tables(query):
 				cursor.register(name, self.get_table(name))
 			cursor.execute(sql, parameters)
 		except Exception:
@@ -74,9 +74,13 @@ class StockReportSnapshot:
 		sql = query.get_sql(quote_char='"', alias_quote_char='"', param_wrapper=parameters)
 		return sql, parameters.get_parameters()
 
-	def get_referenced_tables(self, sql):
+	def get_referenced_tables(self, query) -> list[str]:
+		# DuckDB's dependency parser does not accept prepared parameters. Only inspection uses
+		# literal values rendered by the query builder; run() executes with bound parameters.
+		sql = query.get_sql(quote_char='"', alias_quote_char='"')
+		referenced = self.conn.get_table_names(sql)
 		names = dict.fromkeys([*self.tables, *(f"tab{doctype}" for doctype in LIVE_TABLES)])
-		return [name for name in names if f'"{name}"' in sql]
+		return [name for name in names if name in referenced]
 
 	def register(self, name, rows, fields):
 		"""Expose a lookup table built in Python to the queries that follow."""

--- a/erpnext/stock/report/test_stock_report_snapshot.py
+++ b/erpnext/stock/report/test_stock_report_snapshot.py
@@ -79,7 +79,7 @@ class TestStockReportSnapshot(ERPNextTestSuite):
 		with patch.object(StockReportSnapshot, "get_connection", return_value=conn):
 			with StockReportSnapshot("Stock Ledger", self.filters) as snapshot:
 				with patch.object(frappe, "get_all", wraps=frappe.get_all) as get_all:
-					self.assertEqual(snapshot.get_live_table("Stock Reconciliation").num_rows, 0)
+					self.assertEqual(snapshot.get_table("tabStock Reconciliation").num_rows, 0)
 					get_all.assert_not_called()
 
 		reconciliation = create_stock_reconciliation(
@@ -89,11 +89,56 @@ class TestStockReportSnapshot(ERPNextTestSuite):
 		with patch.object(StockReportSnapshot, "get_connection", return_value=conn):
 			with StockReportSnapshot("Stock Ledger", self.filters) as snapshot:
 				with patch.object(frappe, "get_all", wraps=frappe.get_all) as get_all:
-					self.assertEqual(snapshot.get_live_table("Stock Reconciliation").num_rows, 1)
+					self.assertEqual(snapshot.get_table("tabStock Reconciliation").num_rows, 1)
 					get_all.assert_called_once()
 					self.assertEqual(
 						get_all.call_args.kwargs["filters"], {"name": ("in", [reconciliation.name])}
 					)
+
+	def test_supporting_tables_are_read_in_batches(self):
+		items = [self.item, make_item("_Test DuckDB Batched Item").name]
+		self.filters.item_code = items
+		for item in items:
+			self.make_movement(item_code=item, qty=1, basic_rate=100)
+		conn = self.connect(self.capture_ledger(items))
+		with (
+			patch.object(StockReportSnapshot, "get_connection", return_value=conn),
+			patch("erpnext.stock.report.stock_report_snapshot.BATCH_SIZE", 1),
+			patch.object(frappe, "get_all", wraps=frappe.get_all) as get_all,
+		):
+			with StockReportSnapshot("Stock Balance", self.filters) as snapshot:
+				self.assertEqual(snapshot.get_table("tabItem").num_rows, 2)
+
+		self.assertEqual(get_all.call_count, 2)
+		for call in get_all.call_args_list:
+			self.assertEqual(len(call.kwargs["filters"]["name"][1]), 1)
+
+	def test_batch_filter_scopes_serial_and_batch_entries(self):
+		self.set_item(
+			"_Test DuckDB Scoped Batch Item",
+			{"has_batch_no": 1, "create_new_batch": 1, "batch_number_series": "DUCKS-.#####"},
+		)
+		batches = [
+			frappe.get_value(
+				"Serial and Batch Entry",
+				{
+					"parent": self.make_movement(qty=5, basic_rate=100, posting_date=day)
+					.items[0]
+					.serial_and_batch_bundle
+				},
+				"batch_no",
+			)
+			for day in (add_days(today(), -2), add_days(today(), -1))
+		]
+		filters = deepcopy(self.filters)
+		filters.batch_no = batches[0]
+		conn = self.connect(self.capture_ledger())
+		with patch.object(StockReportSnapshot, "get_connection", return_value=conn):
+			with StockReportSnapshot("Stock Ledger", filters) as snapshot:
+				entries = snapshot.get_table("tabSerial and Batch Entry")
+
+		self.assertEqual(set(entries.column("batch_no").to_pylist()), {batches[0]})
+		self.assert_snapshot_matches(stock_ledger, batch_no=batches[0], segregate_serial_batch_bundle=1)
 
 	def test_snapshot_result_types_and_nulls(self):
 		self.make_movement(qty=1, basic_rate=100.25)
@@ -370,7 +415,7 @@ class TestStockReportSnapshot(ERPNextTestSuite):
 		report_filters = deepcopy(self.filters)
 		report_filters.update(filters)
 		expected = report.execute(deepcopy(report_filters))
-		actual = self.run_snapshot(report, self.capture_ledger(), report_filters)
+		actual = self.run_snapshot(report, self.capture_ledger(report_filters.item_code), report_filters)
 		self.assertEqual(expected, actual)
 
 	def run_snapshot(self, report, table, filters=None):

--- a/erpnext/stock/report/test_stock_report_snapshot.py
+++ b/erpnext/stock/report/test_stock_report_snapshot.py
@@ -411,6 +411,19 @@ class TestStockReportSnapshot(ERPNextTestSuite):
 						query = builder.from_(sle).select(sle.name).where(sle.item_code == "x' OR 1=1 -- `")
 						self.assertEqual(snapshot.run(query), [])
 
+	def test_cte_named_after_live_table_does_not_load_that_doctype(self):
+		self.make_movement(qty=1, basic_rate=100)
+		ledger = frappe.qb.DocType("Stock Ledger Entry")
+		item = frappe.qb.DocType("Item")
+		entries = frappe.qb.from_(ledger).select(ledger.item_code.as_("name"))
+		query = frappe.qb.with_(entries, "tabItem").from_(item).select(item.name)
+		conn = self.connect(self.capture_ledger())
+		with patch.object(StockReportSnapshot, "get_connection", return_value=conn):
+			with StockReportSnapshot("Stock Ledger", self.filters) as snapshot:
+				with patch.object(snapshot, "build_live_table") as build_live_table:
+					self.assertEqual(snapshot.run(query, pluck=True), [self.item])
+					build_live_table.assert_not_called()
+
 	def assert_snapshot_matches(self, report, **filters):
 		report_filters = deepcopy(self.filters)
 		report_filters.update(filters)

--- a/erpnext/stock/report/test_stock_report_snapshot.py
+++ b/erpnext/stock/report/test_stock_report_snapshot.py
@@ -1,0 +1,434 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from copy import deepcopy
+from datetime import time, timedelta
+from decimal import Decimal
+from random import Random
+from unittest.mock import patch
+
+import duckdb
+import frappe
+import pyarrow as pa
+from frappe.core.doctype.duckdb_sync.duckdb_sync import DuckDBSync
+from frappe.database.duckdb.schema import DuckDBTable
+from frappe.query_builder.builder import MariaDB, Postgres
+from frappe.query_builder.functions import Cast
+from frappe.utils import add_days, today
+
+from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+from erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation import create_stock_reconciliation
+from erpnext.stock.report.stock_ageing import stock_ageing
+from erpnext.stock.report.stock_balance import stock_balance
+from erpnext.stock.report.stock_ledger import stock_ledger
+from erpnext.stock.report.stock_report_snapshot import StockReportSnapshot
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestStockReportSnapshot(ERPNextTestSuite):
+	def setUp(self):
+		self.item = make_item("_Test DuckDB Stock Item").name
+		self.filters = frappe._dict(
+			company="_Test Company",
+			item_code=[self.item],
+			warehouse=["Stores - _TC"],
+			from_date=add_days(today(), -5),
+			to_date=today(),
+			range="30, 60, 90",
+		)
+
+	def test_reports_match_with_opening_receipts_and_issues(self):
+		self.make_movement(qty=10, basic_rate=100, posting_date=add_days(today(), -10))
+		self.make_movement(qty=5, basic_rate=150)
+		self.make_movement(qty=3, from_warehouse="Stores - _TC", to_warehouse=None)
+		for report in (stock_ledger, stock_balance, stock_ageing):
+			with self.subTest(report=report.__name__):
+				self.assert_snapshot_matches(report)
+		self.assert_snapshot_matches(stock_balance, show_stock_ageing_data=1)
+		self.assert_snapshot_matches(stock_ageing, show_warehouse_wise_stock=1)
+
+	def test_snapshot_does_not_read_live_ledger_changes(self):
+		self.make_movement(qty=10, basic_rate=100)
+		snapshot = self.capture_ledger()
+		expected = {report: report.execute(deepcopy(self.filters)) for report in self.reports}
+		self.make_movement(qty=5, basic_rate=100)
+		for report in self.reports:
+			with self.subTest(report=report.__name__):
+				self.assertEqual(expected[report], self.run_snapshot(report, snapshot))
+				self.assertNotEqual(expected[report][1], report.execute(deepcopy(self.filters))[1])
+
+	def test_stock_reconciliation_matches(self):
+		self.make_movement(qty=10, basic_rate=100, posting_date=add_days(today(), -10))
+		create_stock_reconciliation(
+			item_code=self.item,
+			warehouse="Stores - _TC",
+			qty=7,
+			valuation_rate=120,
+			posting_date=add_days(today(), -2),
+			posting_time="12:00:00",
+		)
+		self.make_movement(qty=2, basic_rate=130, posting_date=add_days(today(), -1))
+		for report in self.reports:
+			with self.subTest(report=report.__name__):
+				self.assert_snapshot_matches(report)
+
+	def test_reconciliation_lookup_ignores_other_vouchers(self):
+		self.make_movement(qty=10, basic_rate=100, posting_date=add_days(today(), -1))
+		conn = self.connect(self.capture_ledger())
+		with patch.object(StockReportSnapshot, "get_connection", return_value=conn):
+			with StockReportSnapshot("Stock Ledger", self.filters) as snapshot:
+				with patch.object(frappe, "get_all", wraps=frappe.get_all) as get_all:
+					self.assertEqual(snapshot.get_live_table("Stock Reconciliation").num_rows, 0)
+					get_all.assert_not_called()
+
+		reconciliation = create_stock_reconciliation(
+			item_code=self.item, warehouse="Stores - _TC", qty=7, valuation_rate=100
+		)
+		conn = self.connect(self.capture_ledger())
+		with patch.object(StockReportSnapshot, "get_connection", return_value=conn):
+			with StockReportSnapshot("Stock Ledger", self.filters) as snapshot:
+				with patch.object(frappe, "get_all", wraps=frappe.get_all) as get_all:
+					self.assertEqual(snapshot.get_live_table("Stock Reconciliation").num_rows, 1)
+					get_all.assert_called_once()
+					self.assertEqual(
+						get_all.call_args.kwargs["filters"], {"name": ("in", [reconciliation.name])}
+					)
+
+	def test_snapshot_result_types_and_nulls(self):
+		self.make_movement(qty=1, basic_rate=100.25)
+		ledger = frappe.qb.DocType("Stock Ledger Entry")
+		query = (
+			frappe.qb.from_(ledger)
+			.select(
+				ledger.incoming_rate,
+				ledger.posting_time,
+				ledger.posting_date,
+				Cast(None, "DECIMAL(21,9)").as_("empty_qty"),
+				Cast(None, "TIME").as_("empty_time"),
+				ledger.item_code,
+			)
+			.where(ledger.item_code == self.item)
+		)
+		expected = [tuple(row) for row in query.run()]
+		expected_dicts = query.run(as_dict=True)
+		conn = self.connect(self.capture_ledger())
+		with patch.object(StockReportSnapshot, "get_connection", return_value=conn):
+			with StockReportSnapshot("Stock Ledger", self.filters) as snapshot:
+				self.assertEqual(snapshot.run(query), expected)
+				self.assertEqual(snapshot.run(query, as_dict=True), expected_dicts)
+				self.assertEqual(list(snapshot.run(query, as_iterator=True)), expected)
+				self.assertEqual(snapshot.run(query, pluck=True), [100.25])
+
+	def test_ledger_native_conversions_preserve_python_values(self):
+		random = Random(42)
+		values = [None, Decimal("999999999999.999999999"), Decimal("-0.000000001"), Decimal("0.1")]
+		values.extend(Decimal(random.randrange(-(10**21), 10**21)).scaleb(-9) for _ in range(1000))
+		times = [None, time(), time(23, 59, 59, 999999), time(12, 30, 45, 123456)] * 251
+		table = pa.table(
+			{
+				"actual_qty": pa.array(values, type=pa.decimal128(21, 9)),
+				"posting_time": pa.array(times, type=pa.time64("us")),
+			}
+		)
+		with duckdb.connect(":memory:") as conn:
+			conn.register("native_values", table)
+			source = frappe.qb.Table("native_values")
+			query = frappe.qb.from_(source).select(
+				*stock_ledger.get_snapshot_fields([source.actual_qty, source.posting_time])
+			)
+			actual = conn.execute(*StockReportSnapshot.compile(query)).fetchall()
+		expected = [
+			(
+				float(value) if value is not None else None,
+				timedelta(
+					hours=clock.hour,
+					minutes=clock.minute,
+					seconds=clock.second,
+					microseconds=clock.microsecond,
+				)
+				if clock is not None
+				else None,
+			)
+			for value, clock in zip(values, times, strict=True)
+		]
+		self.assertEqual(actual, expected)
+
+	def test_ageing_calculates_remaining_layers_before_python(self):
+		self.make_movement(qty=10, basic_rate=100, posting_date=add_days(today(), -2))
+		self.make_movement(qty=5, basic_rate=200, posting_date=add_days(today(), -1))
+		self.make_movement(qty=12, from_warehouse="Stores - _TC", to_warehouse=None)
+		expected = stock_ageing.execute(deepcopy(self.filters))
+		with patch.object(
+			stock_ageing.FIFOSlots,
+			"_process_stock_ledger_entry",
+			side_effect=AssertionError("Unexpected ledger replay"),
+		):
+			self.assertEqual(expected, self.run_snapshot(stock_ageing, self.capture_ledger()))
+
+	def test_unfiltered_valuation_prefetch_uses_report_ledger_scope(self):
+		company = frappe.get_doc(
+			doctype="Company",
+			company_name="_Test Valuation Prefetch Company",
+			abbr="VPF",
+			country="India",
+			default_currency="INR",
+			default_warehouse="",
+		).insert()
+		brand = frappe.get_doc(doctype="Brand", brand="_Test Valuation Prefetch Brand").insert().name
+		warehouse_type = (
+			frappe.get_doc(doctype="Warehouse Type", name="_Test Valuation Prefetch").insert().name
+		)
+		warehouse = "Stores - VPF"
+		frappe.db.set_value("Warehouse", warehouse, "warehouse_type", warehouse_type)
+		items = {}
+		for case in (
+			"relevant",
+			"default_one",
+			"default_two",
+			"no_ledger",
+			"future",
+			"cancelled",
+			"other_company",
+			"other_warehouse",
+			"other_brand",
+		):
+			self.set_item(
+				f"_Test Valuation Prefetch {case}",
+				{"valuation_method": "" if case.startswith("default") else "FIFO", "brand": brand},
+			)
+			items[case] = self.item
+			if case == "no_ledger":
+				continue
+			entry = self.make_movement(
+				qty=1,
+				basic_rate=100,
+				company="_Test Company" if case == "other_company" else company.name,
+				to_warehouse="Stores - _TC"
+				if case == "other_company"
+				else ("Work In Progress - VPF" if case == "other_warehouse" else warehouse),
+				posting_date=today() if case == "future" else add_days(today(), -2),
+			)
+			if case == "cancelled":
+				entry.cancel()
+			if case == "other_brand":
+				frappe.db.set_value("Item", self.item, "brand", None)
+		filters = frappe._dict(
+			company=company.name, to_date=add_days(today(), -1), warehouse=[warehouse], item_code=None
+		)
+		expected = {
+			items["relevant"]: "FIFO",
+			items["default_one"]: "Moving Average",
+			items["default_two"]: "Moving Average",
+			items["other_brand"]: "FIFO",
+		}
+		cases = [
+			(filters, expected),
+			(
+				frappe._dict(filters, brand=brand),
+				{key: value for key, value in expected.items() if key != items["other_brand"]},
+			),
+			(frappe._dict(filters, warehouse=None, warehouse_type=warehouse_type), expected),
+			(frappe._dict(filters, brand="No matching prefetch brand"), {}),
+		]
+		for report_filters, methods in cases:
+			self.assert_prefetched_valuation_methods(report_filters, methods)
+		table = self.capture_ledger(list(items.values()))
+		self.item = items["no_ledger"]
+		self.make_movement(
+			qty=1,
+			basic_rate=100,
+			company=company.name,
+			to_warehouse=warehouse,
+			posting_date=add_days(today(), -2),
+		)
+		for report_filters, methods in cases:
+			with patch.object(StockReportSnapshot, "get_connection", return_value=self.connect(table)):
+				with StockReportSnapshot("Stock Ageing", report_filters) as snapshot:
+					self.assert_prefetched_valuation_methods(report_filters, methods, snapshot)
+
+	def assert_prefetched_valuation_methods(self, filters, expected, snapshot=None):
+		with patch("erpnext.stock.utils.get_valuation_method", return_value="Moving Average") as default:
+			slots = stock_ageing.FIFOSlots(filters, snapshot=snapshot)
+			slots._prefetch_valuation_methods()
+			self.assertEqual(slots.valuation_method_by_item, expected)
+			self.assertEqual(default.call_count, int("Moving Average" in expected.values()))
+
+	def test_stock_closing_balance_matches(self):
+		self.make_movement(qty=10, basic_rate=100, posting_date=add_days(today(), -10))
+		with patch("erpnext.stock.doctype.stock_closing_entry.stock_closing_entry.enqueue"):
+			closing = frappe.get_doc(
+				doctype="Stock Closing Entry",
+				company=self.filters.company,
+				from_date=add_days(today(), -10),
+				to_date=add_days(today(), -6),
+			).submit()
+		closing.create_stock_closing_balance_entries()
+		closing.db_set("status", "Completed")
+		self.make_movement(qty=5, basic_rate=100)
+		self.assert_snapshot_matches(stock_balance)
+		self.assert_snapshot_matches(stock_balance, show_stock_ageing_data=1)
+
+	def test_small_negative_amounts_use_existing_rounding(self):
+		self.make_movement(qty=10, basic_rate=100)
+		entry = self.make_movement(qty=1, from_warehouse="Stores - _TC", to_warehouse=None)
+		frappe.db.set_value(
+			"Stock Ledger Entry",
+			{"voucher_no": entry.name},
+			{"actual_qty": -0.00001, "stock_value_difference": -0.00001},
+		)
+		self.assert_snapshot_matches(stock_balance)
+
+	def test_empty_snapshot_preserves_columns(self):
+		for report in self.reports:
+			with self.subTest(report=report.__name__):
+				self.assert_snapshot_matches(report)
+
+	def test_stock_balance_aggregates_before_python(self):
+		self.make_movement(qty=10, basic_rate=100, posting_date=add_days(today(), -10))
+		self.make_movement(qty=5, basic_rate=150)
+		expected = stock_balance.execute(deepcopy(self.filters))
+		with patch.object(stock_balance.StockBalanceReport, "prepare_item_warehouse_map") as process_entry:
+			self.assertEqual(expected, self.run_snapshot(stock_balance, self.capture_ledger()))
+			process_entry.assert_not_called()
+
+	def test_batch_opening_and_bundle_details_match(self):
+		self.set_item(
+			"_Test DuckDB Batch Item",
+			{"has_batch_no": 1, "create_new_batch": 1, "batch_number_series": "DUCK-.#####"},
+		)
+		receipt = self.make_movement(qty=10, basic_rate=100, posting_date=add_days(today(), -10))
+		batch = frappe.get_value(
+			"Serial and Batch Entry", {"parent": receipt.items[0].serial_and_batch_bundle}, "batch_no"
+		)
+		self.make_movement(qty=3, batch_no=batch, from_warehouse="Stores - _TC", to_warehouse=None)
+		self.assert_snapshot_matches(stock_ledger, batch_no=batch, segregate_serial_batch_bundle=1)
+		self.assert_snapshot_matches(stock_balance, show_stock_ageing_data=1)
+		self.assert_snapshot_matches(stock_ageing)
+
+	def test_serial_bundle_details_match(self):
+		self.set_item("_Test DuckDB Serial Item", {"has_serial_no": 1, "serial_no_series": "DUCK-SN-.#####"})
+		self.make_movement(qty=3, basic_rate=100)
+		self.assert_snapshot_matches(stock_ledger, segregate_serial_batch_bundle=1)
+		self.assert_snapshot_matches(stock_balance, show_stock_ageing_data=1)
+		self.assert_snapshot_matches(stock_ageing)
+
+	def test_inventory_dimension_opening_and_grouping_match(self):
+		opening = self.make_movement(qty=10, basic_rate=100, posting_date=add_days(today(), -10))
+		current = self.make_movement(qty=5, basic_rate=100)
+		for entry in (opening, current):
+			frappe.db.set_value("Stock Ledger Entry", {"voucher_no": entry.name}, "project", "DuckDB Project")
+		dimensions = [frappe._dict(fieldname="project", doctype="Project")]
+		with (
+			patch.object(stock_ledger, "get_inventory_dimensions", return_value=dimensions),
+			patch.object(stock_balance, "get_inventory_dimensions", return_value=dimensions),
+		):
+			self.assert_snapshot_matches(stock_ledger, project=["DuckDB Project"])
+			self.assert_snapshot_matches(
+				stock_balance, project=["DuckDB Project"], show_dimension_wise_stock=1
+			)
+
+	def test_filters_and_cancelled_entries_match(self):
+		self.make_movement(qty=10, basic_rate=100)
+		cancelled = self.make_movement(qty=2, basic_rate=100)
+		cancelled.cancel()
+		for report in self.reports:
+			with self.subTest(report=report.__name__):
+				self.assert_snapshot_matches(report)
+		parent = frappe.get_value("Warehouse", "Stores - _TC", "parent_warehouse")
+		self.assert_snapshot_matches(stock_balance, warehouse=[parent], item_group="Products")
+		self.assert_snapshot_matches(stock_ledger, warehouse=[parent])
+		self.assert_snapshot_matches(stock_ageing, warehouse=[parent])
+		self.assert_snapshot_matches(stock_balance, brand="No matching brand")
+
+	def test_requires_latest_submitted_sync_to_be_complete(self):
+		complete = frappe.get_doc(doctype="DuckDB Sync", doc_type="Stock Ledger Entry").insert()
+		complete.db_set("docstatus", 1)
+		complete.db_tables[0].db_set("synced", 1)
+		pending = frappe.get_doc(doctype="DuckDB Sync", doc_type="Stock Ledger Entry").insert()
+		pending.db_set("docstatus", 1)
+		frappe.get_doc(doctype="DuckDB Sync", doc_type="Stock Ledger Entry").insert()
+		with patch.object(DuckDBSync, "get_duckdb_conn", autospec=True, side_effect=lambda doc: doc.name):
+			self.assertRaises(frappe.ValidationError, StockReportSnapshot.get_connection, "Stock Ledger")
+			pending.db_tables[0].db_set("synced", 1)
+			self.assertEqual(StockReportSnapshot.get_connection("Stock Ledger"), pending.name)
+
+	def test_query_parameters_and_dialects(self):
+		self.make_movement(qty=1, basic_rate=100)
+		table = self.capture_ledger()
+		with patch.object(StockReportSnapshot, "get_connection", side_effect=lambda _: self.connect(table)):
+			with StockReportSnapshot("Stock Ledger") as snapshot:
+				for builder in (MariaDB, Postgres):
+					with self.subTest(builder=builder.__name__):
+						sle = builder.DocType("Stock Ledger Entry")
+						query = builder.from_(sle).select(sle.item_code).where(sle.item_code == self.item)
+						self.assertEqual(snapshot.run(query, pluck=True), [self.item])
+						query = builder.from_(sle).select(sle.name).where(sle.item_code == "x' OR 1=1 -- `")
+						self.assertEqual(snapshot.run(query), [])
+
+	def assert_snapshot_matches(self, report, **filters):
+		report_filters = deepcopy(self.filters)
+		report_filters.update(filters)
+		expected = report.execute(deepcopy(report_filters))
+		actual = self.run_snapshot(report, self.capture_ledger(), report_filters)
+		self.assertEqual(expected, actual)
+
+	def run_snapshot(self, report, table, filters=None):
+		conn = self.connect(table)
+		original_sql = frappe.db.sql
+
+		def reject_live_ledger(query, *args, **kwargs):
+			self.assertNotIn("tabStock Ledger Entry", str(query))
+			return original_sql(query, *args, **kwargs)
+
+		with (
+			patch.object(StockReportSnapshot, "get_connection", return_value=conn),
+			patch.object(frappe.db, "sql", side_effect=reject_live_ledger),
+		):
+			return report.execute_snapshot_report(deepcopy(filters or self.filters))
+
+	def capture_ledger(self, items=None):
+		rows = frappe.get_all(
+			"Stock Ledger Entry",
+			filters={"item_code": ("in", items or [self.item])},
+			fields=frappe.get_meta("Stock Ledger Entry").get_valid_columns(),
+		)
+		for row in rows:
+			if isinstance(row.posting_time, timedelta):
+				seconds = row.posting_time.seconds
+				row.posting_time = time(seconds // 3600, seconds % 3600 // 60, seconds % 60)
+		return pa.Table.from_pylist(rows, schema=DuckDBTable("Stock Ledger Entry").get_arrow_schema())
+
+	@staticmethod
+	def connect(table):
+		conn = duckdb.connect(":memory:")
+		DuckDBTable("Stock Ledger Entry").sync(conn)
+		conn.register("snapshot_data", table)
+		source = frappe.qb.Table("snapshot_data")
+		query = (
+			frappe.qb.into(frappe.qb.DocType("Stock Ledger Entry"))
+			.columns(*table.column_names)
+			.from_(source)
+			.select(*(source[field] for field in table.column_names))
+		)
+		conn.execute(*StockReportSnapshot.compile(query))
+		conn.unregister("snapshot_data")
+		return conn
+
+	def make_movement(self, **kwargs):
+		args = dict(
+			item_code=self.item,
+			to_warehouse="Stores - _TC",
+			posting_date=today(),
+			posting_time="12:00:00",
+		)
+		args.update(kwargs)
+		return make_stock_entry(**args)
+
+	def set_item(self, name, properties):
+		self.item = make_item(name, properties).name
+		self.filters.item_code = [self.item]
+
+	@property
+	def reports(self):
+		return stock_ledger, stock_balance, stock_ageing


### PR DESCRIPTION
Superseded by the following stacked PRs. Merge them in order:

1. [Shared snapshot query support](https://github.com/frappe/erpnext/pull/59028)
2. [Stock Ledger snapshot execution](https://github.com/frappe/erpnext/pull/59029)
3. [Stock Ageing snapshot execution](https://github.com/frappe/erpnext/pull/59030)
4. [Stock Balance snapshot execution](https://github.com/frappe/erpnext/pull/59031)
5. [Serial and batch ageing calculations](https://github.com/frappe/erpnext/pull/59032)
6. [Dimension balance aggregation](https://github.com/frappe/erpnext/pull/59033)
7. [Ledger opening-balance aggregation](https://github.com/frappe/erpnext/pull/59034)

---

Stock Ledger, Stock Balance, and Stock Ageing can now read a completed DuckDB ledger snapshot through their existing Report records. This reduces ledger transfer and Python processing for large reports.

All three Report definitions keep snapshot execution disabled by default, matching the accounts reports. Enabling Snapshot Report on a Report record selects DuckDB execution and requires the latest submitted Stock Ledger Entry sync to be complete.

Implementation:

- Add a shared snapshot adapter that renders query-builder expressions with DuckDB identifiers and bound parameters. Supporting records remain live through temporary Arrow views. Each supporting table is read one batch at a time, and a report can narrow one further than its ledger keys, so Stock Ledger with a batch filter reads only that batch's Serial and Batch Entry rows.
- Aggregate Stock Balance movements between reconciliations in DuckDB. Preserve the existing handling of reconciliation rows, tiny negative amounts, and inventory dimensions.
- Calculate surviving Stock Ageing FIFO layers in DuckDB. Reuse this calculation for the optional ageing columns in Stock Balance. The aggregated groups are published to DuckDB as a table, so separating them from replayed groups costs no parameter per group.
- Convert Stock Ledger decimals and times in DuckDB before Python creates report rows.
- Reduce normal-path overhead by prefetching lookups before streaming, avoiding unnecessary rounding, and caching repeated rates within each report execution.
- Limit unfiltered Stock Ageing valuation lookups to items in the report's ledger scope. Use the snapshot ledger for DuckDB execution and preserve direct Item lookups for explicit item filters.
- Read Stock Entry and Stock Reconciliation opening vouchers for the report's company. Vouchers of another company can never match a ledger entry in scope.
- Keep FIFO state and replay in the existing report. The DuckDB calculation returns aggregated groups and an optional replay query through a typed result. Both paths share their field definitions.
- Use DuckDB's dependency parser to discover supporting tables. A CTE named after a live DocType does not cause an unrelated database read. Query execution still binds parameters.

The reports create no persistent tables. All new queries use Frappe/PyPika expressions. The existing report behavior is described in the [Stock Ledger manual][stock-ledger-manual].

[stock-ledger-manual]: https://docs.frappe.io/erpnext/stock-ledger

The FIFO optimization selects eligible item/warehouse groups independently. It requires exact binary fractions when quantities and movement values are scaled by 1,024, with bounded sums. Other fractions, including 0.1, retain the existing replay. Negative stock, reconciliations, serial/batch histories, repeated vouchers, LIFO, and ambiguous ordering also retain replay. Shared code still applies ageing buckets and moving-average revaluation.

Validation:

- Latest refactor: 21 snapshot tests and 8 FIFO snapshot tests passed on both PostgreSQL and MariaDB.
- Earlier validation: 39 Ageing tests, 14 Balance tests, and 10 Ledger tests passed on both databases. The MariaDB site contains over 10.1 million ledger entries.
- The FIFO summary, layer, and replay queries retain identical compiled SQL and parameters for both database query builders.
- Snapshot parity tests reject live Stock Ledger Entry reads and compare complete report results.
- Valuation prefetch coverage excludes unrelated, future, cancelled, and out-of-scope items. It also checks empty results, shared default valuation methods, and ledger changes after snapshot creation.
- Deterministic generated histories cover FIFO exhaustion, signed values, moving-average valuation, mixed optimized/replayed groups, and numeric bounds.
- Supporting-table coverage checks batched reads, that a batch filter keeps unrelated Serial and Batch Entry rows out of the live table, and that the FIFO group split binds no parameters.
- A CTE with a live DocType's table name does not trigger a supporting-table read.
- The generated FIFO histories are hashed against a fixed digest, so a change in the generator fails loudly instead of altering coverage.
- Native conversion tests cover 1,004 decimal inputs and time boundaries.
- All applicable pre-commit hooks passed, including Ruff, JSON validation, and the PostgreSQL compatibility check.

Two datasets were measured: a synthetic one sized for throughput, and a restored production database. Read the restored results first, because the synthetic set flatters Stock Ageing.

The same 10,100,000 synthetic ledger entries were tested on all three engines. Complete output hashes matched for every report.

| Report | PostgreSQL | MariaDB | DuckDB | Output rows |
| --- | ---: | ---: | ---: | ---: |
| Stock Balance | 65.87 s | 221.23 s | 17.03 s | 500 |
| Stock Ageing | 71.93 s | 342.09 s | 12.88 s | 100 |
| Stock Ledger | 62.80 s | 118.25 s | 38.72 s | 10,100,001 |

The same three reports were also run on a 10,100,003-row MariaDB site against the same DuckDB snapshot, recording peak worker memory. Output hashes matched on every pair.

| Report | MariaDB | DuckDB | MariaDB peak RSS | DuckDB peak RSS |
| --- | ---: | ---: | ---: | ---: |
| Stock Balance | 239.20 s | 11.99 s | 0.10 GiB | 5.78 GiB |
| Stock Ageing | 237.81 s | 12.80 s | 3.74 GiB | 7.78 GiB |
| Stock Ledger | 110.70 s | 34.40 s | 7.41 GiB | 11.86 GiB |

DuckDB execution trades memory for time. Peak RSS is the worker lifetime high-water mark sampled five times a second and includes output hashing, so it overstates what a report alone holds. Stock Ageing needs well above a 2 GB DuckDB memory limit at this row count.

These are single executions in fresh workers with identical filters and unflushed caches. Timings include queries, decoding, and Python processing. They exclude data loading, snapshot creation, initialization, hashing, and response serialization. Balance used its standard columns without optional ageing columns.

The dataset contains 100 items and five warehouses, with alternating receipts of 10 and issues of 9. It has no serial/batch or reconciliation histories. The DuckDB snapshot uses the production DECIMAL(21,9) schema.

One production database of 693,917 ledger entries was then restored on PostgreSQL and on MariaDB and measured through the same entry points, with the snapshot discovered from each site's own DuckDB Sync record rather than a supplied connection. It holds 1,001 items, 15 warehouses, 100 Stock Reconciliations, and real batch history. Each report produced one hash across all four executions.

| Report | PostgreSQL | MariaDB | DuckDB | Output rows |
| --- | ---: | ---: | ---: | ---: |
| Stock Balance | 4.25 s | 4.72 s | 0.86 s | 11,001 |
| Stock Ageing | 5.35 s | 5.62 s | 4.11 s to 5.27 s | 1,001 |
| Stock Ledger | 3.48 s | 3.81 s | 1.69 s to 2.14 s | 693,917 |

DuckDB reads the same snapshot from either site, so its column gives the range across the two executions. Against PostgreSQL that is 4.9x, 1.0x and 1.6x; against MariaDB 5.5x, 1.4x and 2.3x. The two live engines are within about ten per cent of each other here, so the difference between those pairs is mostly the live engine rather than DuckDB.

| Report | PostgreSQL peak RSS | MariaDB peak RSS | DuckDB peak RSS |
| --- | ---: | ---: | ---: |
| Stock Balance | 0.11 GiB | 0.11 GiB | 1.07 to 1.10 GiB |
| Stock Ageing | 0.47 GiB | 0.47 GiB | 1.14 to 1.16 GiB |
| Stock Ledger | 1.78 GiB | 1.72 GiB | 1.55 to 1.56 GiB |

**Stock Ageing gains little on this data, and the synthetic figure does not carry over.** Counting eligibility on the restored site, DuckDB aggregated 1,000 of 11,001 item and warehouse groups, or 9.1 per cent. The rest fell back to the existing replay: 10,001 groups hold a reconciliation or another unsupported history, 10,000 go negative at some point, and 619 repeat a voucher or an ordering key. The synthetic set reaches 18.6x because it contains no reconciliations and never goes negative, so every group qualifies. Expect the replay to carry most real ledgers, and expect this report to be worth enabling only where stock stays positive and reconciliations are rare.

Stock Balance keeps its advantage on real data because it aggregates movements whether or not a group is eligible. DuckDB also carries a memory floor of roughly one gigabyte, which for the smaller two reports is several times what either live engine needs on its own.

The host has an Apple M5, ten logical CPUs, and 24 GiB RAM. PostgreSQL 18.4 used 128 MB shared buffers, 4 MB work memory, and two parallel workers per gather. MariaDB 11.8.8 used a 128 MiB InnoDB buffer pool and a 2 MiB sort buffer. DuckDB 1.4.5 used its defaults of 19.1 GiB and ten threads, with insertion-order preservation disabled. These results compare the recorded configurations, not equally tuned servers.



