### PR TITLE
fix: read posting date confirmation setting from boot data

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -222,6 +222,13 @@ class AccountsSettings(Document):
 		set_allow_on_submit_for_dimension_fields(doctypes)
 
 
+@frappe.whitelist(methods=["POST"])
+def get_posting_date_confirmation() -> int:
+	return cint(
+		frappe.db.get_single_value("Accounts Settings", "confirm_before_resetting_posting_date", cache=False)
+	)
+
+
 def toggle_accounting_dimension_sections(hide):
 	accounting_dimension_doctypes = frappe.get_hooks("accounting_dimension_doctypes")
 	for doctype in accounting_dimension_doctypes:

--- a/erpnext/accounts/doctype/accounts_settings/test_accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/test_accounts_settings.py
@@ -1,9 +1,15 @@
 import frappe
 
+from erpnext.accounts.doctype.accounts_settings.accounts_settings import get_posting_date_confirmation
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestAccountsSettings(ERPNextTestSuite):
+	def test_posting_date_confirmation_uses_current_setting(self):
+		for enabled in (0, 1, 0):
+			frappe.db.set_single_value("Accounts Settings", "confirm_before_resetting_posting_date", enabled)
+			self.assertEqual(get_posting_date_confirmation(), enabled)
+
 	def test_stale_days(self):
 		cur_settings = frappe.get_doc("Accounts Settings", "Accounts Settings")
 		cur_settings.allow_stale = 0

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1150,7 +1150,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		if (this.frm.doc.set_posting_time) return;
 		if (frappe.datetime.get_today() == this.frm.doc.posting_date) return;
 
-		if (!frappe.boot.sysdefaults.confirm_before_resetting_posting_date) return;
+		const is_confirmation_reqd = await frappe.xcall(
+			"erpnext.accounts.doctype.accounts_settings.accounts_settings.get_posting_date_confirmation"
+		);
+		if (!is_confirmation_reqd) return;
 
 		return new Promise((resolve, reject) => {
 			frappe.confirm(

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1150,12 +1150,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		if (this.frm.doc.set_posting_time) return;
 		if (frappe.datetime.get_today() == this.frm.doc.posting_date) return;
 
-		let is_confirmation_reqd = await frappe.db.get_single_value(
-			"Accounts Settings",
-			"confirm_before_resetting_posting_date"
-		);
-
-		if (!is_confirmation_reqd) return;
+		if (!frappe.boot.sysdefaults.confirm_before_resetting_posting_date) return;
 
 		return new Promise((resolve, reject) => {
 			frappe.confirm(

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -27,9 +27,6 @@ def boot_session(bootinfo):
 		bootinfo.sysdefaults.disable_include_dimensions = cint(
 			frappe.get_single_value("Accounts Settings", "disable_include_dimensions")
 		)
-		bootinfo.sysdefaults.confirm_before_resetting_posting_date = cint(
-			frappe.get_single_value("Accounts Settings", "confirm_before_resetting_posting_date")
-		)
 
 		bootinfo.sysdefaults.quotation_valid_till = cint(
 			frappe.db.get_single_value("CRM Settings", "default_valid_till")

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -27,6 +27,9 @@ def boot_session(bootinfo):
 		bootinfo.sysdefaults.disable_include_dimensions = cint(
 			frappe.get_single_value("Accounts Settings", "disable_include_dimensions")
 		)
+		bootinfo.sysdefaults.confirm_before_resetting_posting_date = cint(
+			frappe.get_single_value("Accounts Settings", "confirm_before_resetting_posting_date")
+		)
 
 		bootinfo.sysdefaults.quotation_valid_till = cint(
 			frappe.db.get_single_value("CRM Settings", "default_valid_till")


### PR DESCRIPTION
Load the posting date confirmation setting into session boot data and use it during transaction validation, avoiding an extra settings lookup on save.

Internal support ticket: [77791](https://support.frappe.io/helpdesk/tickets/77791?view=VIEW-HD+Ticket-080)