### PR TITLE
fix: validate shelf life for automatically created expiring batches

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -219,6 +219,7 @@ class Item(Document):
 		self.validate_conversion_factor()
 		self.validate_item_type()
 		self.validate_naming_series()
+		self.validate_shelf_life()
 		self.check_for_active_boms()
 		self.fill_customer_code()
 		self.check_item_tax()
@@ -396,6 +397,19 @@ class Item(Document):
 				_(
 					"{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 				).format(self.item_code)
+			)
+
+	def validate_shelf_life(self):
+		if (
+			self.has_batch_no
+			and self.has_expiry_date
+			and self.create_new_batch
+			and cint(self.shelf_life_in_days) <= 0
+		):
+			frappe.throw(
+				_("{0} must be greater than zero.").format(
+					self.get_label_from_fieldname("shelf_life_in_days")
+				)
 			)
 
 	def clear_retain_sample(self):


### PR DESCRIPTION
 ### Issue

-  Items with automatic batch creation and expiry dates enabled can be saved with zero shelf life. Inward transactions then fail because the batch expiry date cannot be calculated.

  Fixes #58884

  ### Steps to reproduce

  1. Create an Item and enable **Has Batch No**, **Has Expiry Date**, and **Automatically Create New Batch**.
  2. Set **Shelf Life In Days** to `0` and save.
  3. Create a Stock Entry with purpose **Material Receipt** for this Item.
  4. Submit the Stock Entry.


**After:**

[after shelf.webm](https://github.com/user-attachments/assets/c473cfe7-82bc-4079-9950-835784f61fdd)


  ### Actual behaviour

 - The Item saves successfully, but submitting the Stock Entry fails with an “Expiry Date Mandatory” error.

  ### Expected behaviour

-  Saving the Item should require a shelf life greater than zero when automatic batch creation and expiry dates are enabled. Manual batches should continue to support explicitly entered expiry dates.

**Backport Needed For v15 and V16**