### PR TITLE
fix: recalculate received qty for purchase invoice returns

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -218,10 +218,11 @@ erpnext.buying = {
 			qty(doc, cdt, cdn) {
 				if (
 					doc.doctype == "Purchase Receipt" ||
-					(doc.doctype == "Purchase Invoice" && doc.update_stock)
+					(doc.doctype == "Purchase Invoice" && (doc.update_stock || doc.is_return))
 				) {
 					this.calculate_received_qty(doc, cdt, cdn);
 				}
+
 				super.qty(doc, cdt, cdn);
 			}
 


### PR DESCRIPTION
 ### Issue

  On Purchase Invoice returns, changing the item quantity does not update the Received Quantity when Update Stock is unchecked. The stale quantity can incorrectly block subsequent partial returns.

  Fixes #58906

  ### Steps to reproduce

  1. Create and submit a Purchase Invoice.
  2. Create a return against it with **Update Stock** unchecked.
  3. Reduce the return quantity for an item.
  4. Observe that **Received Quantity** retains its previous value.
  5. Submit the return and attempt another partial return against the same invoice.

  ### Actual behaviour

  Received Quantity is not recalculated when quantity changes. The stale value is saved and can cause a `StockOverReturnError` on subsequent returns.

  ### Expected behaviour

  Received Quantity should update to `qty + rejected_qty` whenever quantity changes, including returns with Update Stock unchecked. Received Stock Quantity should also update using the item's conversion factor.

  ### Backport needed for V15 and V16