### PR TITLE
fix(stock): filter item group defaults by company and non-group records

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.js
+++ b/erpnext/setup/doctype/item_group/item_group.js
@@ -76,7 +76,38 @@ frappe.ui.form.on("Item Group", {
 			};
 		};
 
-		["expenses_added_to_stock_account", "expenses_added_to_stock_contra_account"].forEach((field) => {
+		frm.set_query("default_warehouse", "item_group_defaults", (doc, cdt, cdn) => {
+			const row = locals[cdt][cdn];
+			return {
+				filters: { company: row.company, is_group: 0 },
+			};
+		});
+
+		frm.set_query("default_inventory_account", "item_group_defaults", (doc, cdt, cdn) => {
+			const row = locals[cdt][cdn];
+			return {
+				filters: { company: row.company, account_type: "Stock", is_group: 0 },
+			};
+		});
+
+		frm.set_query("default_provisional_account", "item_group_defaults", (doc, cdt, cdn) => {
+			const row = locals[cdt][cdn];
+			return {
+				filters: {
+					company: row.company,
+					root_type: ["in", ["Liability", "Asset"]],
+					is_group: 0,
+				},
+			};
+		});
+
+		[
+			"purchase_expense_account",
+			"purchase_expense_contra_account",
+			"default_cogs_account",
+			"expenses_added_to_stock_account",
+			"expenses_added_to_stock_contra_account",
+		].forEach((field) => {
 			frm.fields_dict["item_group_defaults"].grid.get_field(field).get_query = function (
 				doc,
 				cdt,


### PR DESCRIPTION
 ### Issue

  Closes #58922

  Item Group is missing company and non-group filters for warehouse, inventory, provisional, purchase expense, purchase expense contra, and COGS defaults.

  ### Steps to reproduce

  1. Open an Item Group and add a defaults row.
  2. Select a Company.
  3. Search one of the affected Warehouse or Account fields.

  ### Actual behaviour

  Records from other companies and group records appear in the suggestions.

  ### Expected behaviour

  Only non-group records belonging to the row’s company should appear, with account restrictions matching Item.

  ### Backport needed for v15 and v16