### PR TITLE
fix(accounts): stop counting received qty on non-stock invoice returns

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -78,7 +78,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 		const me = this;
 		super.refresh();
 
-		hide_fields(this.frm.doc);
+		hide_fields(this.frm);
 		// Show / Hide button
 		this.show_general_ledger();
 		erpnext.accounts.ledger_preview.show_accounting_ledger_preview(this.frm);
@@ -418,7 +418,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 	}
 
 	is_paid() {
-		hide_fields(this.frm.doc);
+		hide_fields(this.frm);
 		if (cint(this.frm.doc.is_paid)) {
 			this.frm.set_value("allocate_advances_automatically", 0);
 			this.frm.set_value("payment_terms_template", "");
@@ -482,28 +482,29 @@ cur_frm.script_manager.make(erpnext.accounts.PurchaseInvoice);
 
 // Hide Fields
 // ------------
-function hide_fields(doc) {
-	var parent_fields = ["due_date", "is_opening", "advances_section", "from_date", "to_date"];
+function hide_fields(frm) {
+	const doc = frm.doc;
+	const parent_fields = ["due_date", "is_opening", "advances_section", "from_date", "to_date"];
 
 	if (cint(doc.is_paid) == 1) {
-		hide_field(parent_fields);
+		frm.toggle_display(parent_fields, false);
 	} else {
-		for (var i in parent_fields) {
-			var docfield = frappe.meta.docfield_map[doc.doctype][parent_fields[i]];
-			if (!docfield.hidden) unhide_field(parent_fields[i]);
+		for (const fieldname of parent_fields) {
+			const docfield = frappe.meta.docfield_map[doc.doctype][fieldname];
+			if (!docfield.hidden) frm.toggle_display(fieldname, true);
 		}
 	}
 
-	var item_fields_stock = ["warehouse_section", "received_qty", "rejected_qty"];
+	const item_fields_stock = ["warehouse_section", "received_qty", "rejected_qty"];
 
-	if (cur_frm.fields_dict["items"]) {
-		cur_frm.fields_dict["items"].grid.set_column_disp(
+	if (frm.fields_dict["items"]) {
+		frm.fields_dict["items"].grid.set_column_disp(
 			item_fields_stock,
-			cint(doc.update_stock) == 1 || cint(doc.is_return) == 1 ? true : false
+			cint(doc.update_stock) == 1 || cint(doc.is_return) == 1
 		);
 	}
 
-	cur_frm.refresh_fields();
+	frm.refresh_fields();
 }
 
 cur_frm.fields_dict.cash_bank_account.get_query = function (doc) {
@@ -712,7 +713,7 @@ frappe.ui.form.on("Purchase Invoice", {
 	},
 
 	update_stock: function (frm) {
-		hide_fields(frm.doc);
+		hide_fields(frm);
 		frm.fields_dict.items.grid.toggle_reqd("item_code", frm.doc.update_stock ? true : false);
 	},
 

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -498,10 +498,7 @@ function hide_fields(frm) {
 	const item_fields_stock = ["warehouse_section", "received_qty", "rejected_qty"];
 
 	if (frm.fields_dict["items"]) {
-		frm.fields_dict["items"].grid.set_column_disp(
-			item_fields_stock,
-			cint(doc.update_stock) == 1 || cint(doc.is_return) == 1
-		);
+		frm.fields_dict["items"].grid.set_column_disp(item_fields_stock, cint(doc.update_stock) == 1);
 	}
 
 	frm.refresh_fields();

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -3061,6 +3061,23 @@ class TestPurchaseInvoice(ERPNextTestSuite, StockTestMixin):
 
 		self.assertRaises(StockOverReturnError, return_doc.save)
 
+	def test_partial_returns_ignore_received_qty_without_update_stock(self):
+		from erpnext.controllers.sales_and_purchase_return import make_return_doc
+
+		invoice = make_purchase_invoice(qty=10, received_qty=10)
+
+		first_return = make_return_doc(invoice.doctype, invoice.name)
+		first_return.items[0].qty = -4
+		first_return.save().submit()
+
+		self.assertEqual(first_return.items[0].received_qty, -10)
+
+		second_return = make_return_doc(invoice.doctype, invoice.name)
+		second_return.items[0].qty = -6
+		second_return.save().submit()
+
+		self.assertEqual(second_return.docstatus, 1)
+
 	def test_apply_discount_on_grand_total(self):
 		"""
 		To test if after applying discount on grand total,

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -194,7 +194,12 @@ def validate_quantity(doc, key, args, ref, valid_items, already_returned_items):
 	if (doc.doctype == "Purchase Invoice" or doc.doctype == "Sales Invoice") and not doc.update_stock:
 		fields = ["qty"]
 
-	if doc.doctype in ["Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"]:
+	tracks_accepted_rejected_split = doc.doctype in (
+		"Purchase Receipt",
+		"Subcontracting Receipt",
+	) or (doc.doctype == "Purchase Invoice" and doc.update_stock)
+
+	if tracks_accepted_rejected_split:
 		if not args.get("return_qty_from_rejected_warehouse"):
 			fields.extend(["received_qty", "rejected_qty"])
 		else:


### PR DESCRIPTION
Fixes #58906. Alternative to #58919.

A Purchase Invoice without Update Stock writes no Stock Ledger Entry, and `validate_accepted_rejected_qty` never runs for it, so nothing derives or validates `received_qty` / `rejected_qty` on its rows. `validate_quantity` counted both against the source invoice anyway, so whatever the form last wrote to the read-only `received_qty` was tallied as returned — a partial return that lowered qty locked out the rest of the invoice with `StockOverReturnError`.

Both columns now count only where an accepted/rejected split actually exists: Purchase Receipt, Subcontracting Receipt, and a Purchase Invoice with Update Stock. `qty` stays validated everywhere, so a return is still capped at what the invoice billed.

The desk form also stops showing the stock column group — Received Qty, Rejected Qty and the warehouse section — when Update Stock is off, which is what an ordinary Purchase Invoice already does. Only returns were exempted from that rule, and nothing on those rows needs a warehouse: `validate_warehouse` checks only the warehouses that are set. `hide_fields` is refactored first to take `frm` rather than reaching for `cur_frm`, in a separate no-op commit.

On #58919: it fixes the desk form only, so every other write path still saves the stale value. It also assumes `received_qty = qty + rejected_qty`, which does not hold without Update Stock — the Purchase Receipt mapper maps PR `qty` into PI `received_qty`, so on an invoice billed from a receipt with rejected qty the recomputation overstates the returned quantity.

Reported on v15, so this needs a backport.