### PR TITLE
fix(manufacturing): handle empty raw materials in workstation

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/mapper.py
+++ b/erpnext/manufacturing/doctype/job_card/mapper.py
@@ -102,6 +102,9 @@ def make_stock_entry(source_name: str, target_doc: str | dict | Document | None 
 			target.qty = pending_rm_qty
 
 	def set_missing_values(source, target):
+		if not source.items:
+			frappe.throw(_("This Job Card has no raw materials to transfer."))
+
 		if source.finished_good and not source.target_warehouse:
 			frappe.throw(_("Please set the Target Warehouse in the Job Card"))
 

--- a/erpnext/manufacturing/doctype/workstation/test_workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/test_workstation.py
@@ -3,18 +3,95 @@
 import frappe
 from frappe import _
 
+from erpnext.manufacturing.doctype.job_card.mapper import make_stock_entry
 from erpnext.manufacturing.doctype.operation.test_operation import make_operation
 from erpnext.manufacturing.doctype.routing.test_routing import create_routing, setup_bom
 from erpnext.manufacturing.doctype.workstation.workstation import (
 	NotInWorkingHoursError,
 	WorkstationHolidayError,
 	check_if_within_operating_hours,
+	get_raw_materials,
 	update_job_card,
 )
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestWorkstation(ERPNextTestSuite):
+	def test_get_raw_materials_without_items(self):
+		for skip_transfer, backflush_from_wip in ((0, 0), (1, 0), (1, 1)):
+			with self.subTest(skip_transfer=skip_transfer, backflush_from_wip=backflush_from_wip):
+				job_card = frappe.get_doc(
+					{
+						"doctype": "Job Card",
+						"company": "_Test Company",
+						"skip_material_transfer": skip_transfer,
+						"backflush_from_wip_warehouse": backflush_from_wip,
+						"wip_warehouse": "_Test Warehouse 1 - _TC",
+					}
+				).insert(ignore_mandatory=True)
+
+				for method in (get_raw_materials, make_stock_entry):
+					with self.subTest(method=method.__name__):
+						with self.assertRaisesRegex(
+							frappe.ValidationError, "This Job Card has no raw materials to transfer"
+						):
+							method(job_card.name)
+
+				job_card.reload()
+				self.assertFalse(job_card.items)
+				self.assertFalse(frappe.db.exists("Stock Entry", {"job_card": job_card.name}))
+
+	def test_get_raw_materials_availability(self):
+		for skip_transfer, backflush_from_wip, transferred_qty in (
+			(0, 0, 2),
+			(0, 0, 5),
+			(1, 0, 0),
+			(1, 1, 0),
+		):
+			with self.subTest(
+				skip_transfer=skip_transfer,
+				backflush_from_wip=backflush_from_wip,
+				transferred_qty=transferred_qty,
+			):
+				job_card = frappe.get_doc(
+					{
+						"doctype": "Job Card",
+						"company": "_Test Company",
+						"skip_material_transfer": skip_transfer,
+						"backflush_from_wip_warehouse": backflush_from_wip,
+						"wip_warehouse": "_Test Warehouse 1 - _TC",
+						"items": [
+							{
+								"item_code": "_Test Item",
+								"source_warehouse": "_Test Warehouse - _TC",
+								"required_qty": 5,
+								"transferred_qty": transferred_qty,
+							},
+						],
+					}
+				).insert(ignore_mandatory=True)
+
+				materials = get_raw_materials(job_card.name)
+
+				self.assertEqual(len(materials), 1)
+				material = materials[0]
+				warehouse = "_Test Warehouse 1 - _TC" if backflush_from_wip else "_Test Warehouse - _TC"
+				stock_qty = (
+					frappe.db.get_value(
+						"Bin", {"item_code": "_Test Item", "warehouse": warehouse}, "actual_qty"
+					)
+					or 0
+				)
+				self.assertEqual(material.item_code, "_Test Item")
+				self.assertEqual(material.required_qty, 5)
+				self.assertEqual(material.transferred_qty, transferred_qty)
+				self.assertEqual(material.warehouse, warehouse)
+				self.assertEqual(material.stock_qty, stock_qty)
+				self.assertEqual(
+					material.material_availability_status,
+					int(stock_qty >= 5) if skip_transfer else int(transferred_qty >= 5),
+				)
+
 	def test_update_job_card_rejects_disallowed_method(self):
 		# The whitelisted update_job_card endpoint must only run an allowlisted set of Job Card
 		# methods. An arbitrary method name must be rejected (PermissionError) before the document

--- a/erpnext/manufacturing/doctype/workstation/workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/workstation.py
@@ -287,8 +287,8 @@ def get_raw_materials(job_card: str):
 		filters={"name": job_card},
 	)
 
-	if not raw_materials:
-		return []
+	if not raw_materials or not raw_materials[0].item_code:
+		frappe.throw(_("This Job Card has no raw materials to transfer."))
 
 	for row in raw_materials:
 		warehouse = row.source_warehouse

--- a/erpnext/public/js/templates/shop_floor_template.html
+++ b/erpnext/public/js/templates/shop_floor_template.html
@@ -727,7 +727,7 @@
 										<button class="btn btn-primary mes-btn-start" data-job-card="{{ frappe.utils.escape_html(slot.name) }}">
 											{{ __("Start Job") }} &rarr;
 										</button>
-									{% } else { %}
+									{% } else if (slot.materials && slot.materials.length) { %}
 										<button class="btn btn-default mes-btn-transfer" data-job-card="{{ frappe.utils.escape_html(slot.name) }}">
 											{{ __("Transfer Materials") }}
 										</button>
@@ -990,7 +990,7 @@
 						<button class="btn btn-default btn-sm mes-btn-start" data-job-card="{{ frappe.utils.escape_html(jc.name) }}">
 							{{ __("Start") }}
 						</button>
-					{% } else { %}
+					{% } else if (jc.materials && jc.materials.length) { %}
 						<button class="btn btn-default btn-sm mes-btn-transfer" data-job-card="{{ frappe.utils.escape_html(jc.name) }}">
 							{{ __("Transfer") }}
 						</button>


### PR DESCRIPTION
### Issue

  Fixes #58910

 - Selecting Transfer Materials from Workstation causes a server error when the Job Card’s Raw Materials table is empty.

  ### Steps to reproduce

 1. Create a BOM with raw materials and an operation assigned to a Workstation.
  2. Set Transfer Material Against to Work Order and leave Track Semi-Finished Goods disabled.
  3. Create and submit a Work Order using this BOM.
  4. Open the generated Job Card and confirm its Raw Materials table is empty.
  5. Open the assigned Workstation and select the Job Cards tab.
  6. Open the three-dot menu beside the Job Card and select Transfer Materials.

  **Actual behaviour:** 

- A server error occurs: '>=' not supported between instances of 'NoneType' and 'NoneType'.

  **Expected behaviour:** 
- The Raw Materials dialog opens without an error, and Make Transfer Entry opens a draft Stock Entry.

### Before 

[Screencast from 2026-09-09 16-11-01.webm](https://github.com/user-attachments/assets/083f7cc9-7cb4-4906-a5d3-92f65687dc5a)

### After

[Screencast from 2026-09-09 16-13-53.webm](https://github.com/user-attachments/assets/ccf0fa0a-e7fb-41d0-8923-ae2302e2ec18)

  ### Backport needed for v16