### PR TITLE
feat(stock): support alternate UOMs in stock reconciliation

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
@@ -9,12 +9,17 @@ frappe.ui.form.on("Stock Reconciliation", {
 		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle", "Item Standard Cost"];
 		frm.barcode_scanner = new erpnext.utils.BarcodeScanner({
 			frm: frm,
-			uom_field: "stock_uom",
+			uom_field: "uom",
+			qty_field: "counted_qty",
 		});
 	},
 
 	onload: function (frm) {
 		frm.add_fetch("item_code", "item_name", "item_name");
+		frm.set_query("uom", "items", (doc, cdt, cdn) => ({
+			query: "erpnext.stock.doctype.stock_reconciliation.stock_reconciliation.get_reconciliation_uom_query",
+			filters: { item_code: locals[cdt][cdn].item_code },
+		}));
 
 		// end of life
 		frm.set_query("item_code", "items", function (doc, cdt, cdn) {
@@ -82,6 +87,15 @@ frappe.ui.form.on("Stock Reconciliation", {
 	},
 
 	set_fields_onload_for_line_item(frm) {
+		if (frm.doc.docstatus === 0) {
+			(frm.doc.items || []).forEach((item) => {
+				if (!item.uom) {
+					item.uom = item.stock_uom;
+					item.conversion_factor = 1;
+					item.counted_qty = item.qty;
+				}
+			});
+		}
 		if (frm.is_new() && frm.doc?.items && cint(frappe.user_defaults?.use_serial_batch_fields) === 1) {
 			frm.doc.items.forEach((item) => {
 				if (!item.serial_and_batch_bundle) {
@@ -161,6 +175,9 @@ frappe.ui.form.on("Stock Reconciliation", {
 							$.extend(item, row);
 
 							item.qty = item.qty || 0;
+							item.uom = item.stock_uom;
+							item.conversion_factor = 1;
+							item.counted_qty = item.qty;
 							item.valuation_rate = item.valuation_rate || 0;
 							item.use_serial_batch_fields = cint(
 								frappe.user_defaults?.use_serial_batch_fields
@@ -193,7 +210,7 @@ frappe.ui.form.on("Stock Reconciliation", {
 		var d = frappe.model.get_doc(cdt, cdn);
 
 		if (d.item_code && d.warehouse) {
-			frappe.call({
+			return frappe.call({
 				method: "erpnext.stock.doctype.stock_reconciliation.stock_reconciliation.get_stock_balance_for",
 				args: {
 					item_code: d.item_code,
@@ -206,7 +223,7 @@ frappe.ui.form.on("Stock Reconciliation", {
 				},
 				callback: function (r) {
 					const row = frappe.model.get_doc(cdt, cdn);
-					if (!frm.doc.scan_mode) {
+					if (!frm.doc.scan_mode && !frappe.flags.trigger_from_barcode_scanner) {
 						frappe.model.set_value(cdt, cdn, "qty", r.message.qty);
 					}
 					frappe.model.set_value(cdt, cdn, "valuation_rate", r.message.rate);
@@ -232,11 +249,11 @@ frappe.ui.form.on("Stock Reconciliation", {
 
 	set_amount_quantity: function (doc, cdt, cdn) {
 		var d = frappe.model.get_doc(cdt, cdn);
-		if (d.qty && d.valuation_rate) {
-			frappe.model.set_value(cdt, cdn, "amount", flt(d.qty) * flt(d.valuation_rate));
-			frappe.model.set_value(cdt, cdn, "quantity_difference", flt(d.qty) - flt(d.current_qty));
-			frappe.model.set_value(cdt, cdn, "amount_difference", flt(d.amount) - flt(d.current_amount));
-		}
+		return frappe.model.set_value(cdt, cdn, {
+			amount: flt(d.qty) * flt(d.valuation_rate),
+			quantity_difference: flt(d.qty) - flt(d.current_qty),
+			amount_difference: flt(d.qty) * flt(d.valuation_rate) - flt(d.current_amount),
+		});
 	},
 	toggle_display_account_head: function (frm) {
 		frm.toggle_display(
@@ -275,13 +292,44 @@ frappe.ui.form.on("Stock Reconciliation Item", {
 		frm.events.set_valuation_rate_and_qty(frm, cdt, cdn);
 	},
 
-	item_code: function (frm, cdt, cdn) {
+	item_code: async function (frm, cdt, cdn) {
 		var child = locals[cdt][cdn];
+		if (!child.item_code) return;
+		const item_code = child.item_code;
+		const { message } = await frappe.call({
+			method: "erpnext.stock.doctype.stock_reconciliation.stock_reconciliation.get_reconciliation_uom_details",
+			args: { item_code },
+		});
+		if (child.item_code !== item_code) return;
+		await frappe.model.set_value(cdt, cdn, message);
 		if (child.batch_no && !frm.doc.scan_mode) {
 			frappe.model.set_value(cdt, cdn, "batch_no", "");
 		}
 
-		frm.events.set_valuation_rate_and_qty(frm, cdt, cdn);
+		return frm.events.set_valuation_rate_and_qty(frm, cdt, cdn);
+	},
+
+	uom: async function (frm, cdt, cdn) {
+		const row = locals[cdt][cdn];
+		if (!row.item_code) return;
+		const { item_code, uom } = row;
+		const { message } = await frappe.call({
+			method: "erpnext.stock.doctype.stock_reconciliation.stock_reconciliation.get_reconciliation_uom_details",
+			args: { item_code, uom },
+		});
+		if (row.item_code !== item_code || row.uom !== uom) return;
+		await frappe.model.set_value(cdt, cdn, message);
+		return frm.script_manager.trigger("counted_qty", cdt, cdn);
+	},
+
+	counted_qty: function (frm, cdt, cdn) {
+		const row = locals[cdt][cdn];
+		return frappe.model.set_value(
+			cdt,
+			cdn,
+			"qty",
+			flt(flt(row.counted_qty) * (flt(row.conversion_factor) || 1), precision("qty", row))
+		);
 	},
 
 	batch_no(frm, cdt, cdn) {
@@ -296,10 +344,20 @@ frappe.ui.form.on("Stock Reconciliation Item", {
 		}
 	},
 
-	qty: function (frm, cdt, cdn) {
-		frm.events.set_amount_quantity(frm, cdt, cdn);
-
+	qty: async function (frm, cdt, cdn) {
 		let row = locals[cdt][cdn];
+		const conversion_factor = flt(row.conversion_factor) || 1;
+		const qty_precision = precision("qty", row);
+		// Stock balances, serial numbers and the bundle selector supply Stock UOM quantities.
+		// Keep the entered count if it already converts to this rounded quantity.
+		if (
+			row.counted_qty == null ||
+			row.counted_qty === "" ||
+			flt(flt(row.counted_qty) * conversion_factor, qty_precision) !== flt(row.qty, qty_precision)
+		) {
+			await frappe.model.set_value(cdt, cdn, "counted_qty", flt(row.qty) / conversion_factor);
+		}
+		frm.events.set_amount_quantity(frm, cdt, cdn);
 		if (row.use_serial_batch_fields && !row.qty && row.serial_no) {
 			frappe.model.set_value(cdt, cdn, "serial_no", "");
 		}

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -3,6 +3,7 @@
 
 
 from datetime import timedelta
+from math import isfinite
 
 import frappe
 from frappe import _, bold, json, msgprint
@@ -71,8 +72,15 @@ class StockReconciliation(StockController):
 
 		sbb = SerialBatchBundleService(self)
 
-		self.validate_standard_cost_items()
 		self.validate_items_exist()
+		self._reconciliation_item_cache = {
+			item_code: frappe.get_cached_doc("Item", item_code)
+			for item_code in {row.item_code for row in self.items if row.item_code}
+		}
+		for item in self._reconciliation_item_cache.values():
+			item.check_permission("read")
+		self.set_stock_uom_quantities()
+		self.validate_standard_cost_items()
 		if not self.expense_account:
 			self.expense_account = frappe.get_cached_value(
 				"Company", self.company, "stock_adjustment_account"
@@ -97,6 +105,31 @@ class StockReconciliation(StockController):
 
 		if self._action == "submit":
 			self.validate_reserved_stock()
+
+	def set_stock_uom_quantities(self):
+		# Keep qty in Stock UOM for the ledger, valuation, bundles and existing integrations.
+		if not hasattr(self, "_reconciliation_item_cache"):
+			self._reconciliation_item_cache = {
+				item_code: frappe.get_cached_doc("Item", item_code)
+				for item_code in {row.item_code for row in self.items if row.item_code}
+			}
+		for row in self.items:
+			item = self._reconciliation_item_cache[row.item_code]
+			details = _get_reconciliation_uom_details(item, row.get("uom"))
+			row.stock_uom = details.stock_uom
+			row.uom = details.uom
+			row.conversion_factor = details.conversion_factor
+			if row.uom != row.stock_uom:
+				row.qty = (
+					flt(flt(row.counted_qty) * row.conversion_factor, row.precision("qty"))
+					if row.counted_qty not in (None, "")
+					else None
+				)
+			else:
+				row.counted_qty = row.qty
+
+		self.validate_uom_is_integer("uom", "counted_qty")
+		self.validate_uom_is_integer("stock_uom", "qty")
 
 	def on_update(self):
 		super().on_update()
@@ -801,9 +834,7 @@ class StockReconciliation(StockController):
 		)
 
 		def validate_serial_batch_items():
-			has_batch_no, has_serial_no = frappe.get_value(
-				"Item", item_code, ["has_batch_no", "has_serial_no"]
-			)
+			has_batch_no, has_serial_no = item.has_batch_no, item.has_serial_no
 			if row.use_serial_batch_fields and self.purpose == "Stock Reconciliation":
 				if has_batch_no and not row.batch_no:
 					raise frappe.ValidationError(_("Please enter Batch No"))
@@ -813,7 +844,7 @@ class StockReconciliation(StockController):
 		# using try except to catch all validation msgs and display together
 
 		try:
-			item = frappe.get_cached_doc("Item", item_code)
+			item = self._reconciliation_item_cache.get(item_code) or frappe.get_cached_doc("Item", item_code)
 
 			# end of life and stock item
 			validate_end_of_life(item_code, item.end_of_life, item.disabled)
@@ -1129,6 +1160,13 @@ class StockReconciliation(StockController):
 
 	def set_total_qty_and_amount(self):
 		for d in self.get("items"):
+			conversion_factor = d.conversion_factor or 1
+			qty_precision = d.precision("qty")
+			# Preserve the entered count when its conversion matches the rounded Stock UOM quantity.
+			if d.counted_qty in (None, "") or flt(
+				flt(d.counted_qty) * conversion_factor, qty_precision
+			) != flt(d.qty, qty_precision):
+				d.counted_qty = flt(d.qty) / conversion_factor
 			d.amount = flt(flt(d.qty) * flt(d.valuation_rate), d.precision("amount"))
 			d.current_amount = flt(
 				flt(d.current_qty) * flt(d.current_valuation_rate), d.precision("current_amount")
@@ -1403,6 +1441,54 @@ def get_items_for_stock_reco(warehouse, company):
 	]
 
 	return items
+
+
+@frappe.whitelist()
+def get_reconciliation_uom_details(item_code: str, uom: str | None = None):
+	"""Return the permitted reconciliation UOM and its Stock UOM conversion factor.
+
+	The item must be readable; alternate UOMs must have a positive conversion factor.
+	Returns a dict containing ``stock_uom``, ``uom`` and ``conversion_factor``.
+	"""
+	item = frappe.get_cached_doc("Item", item_code)
+	item.check_permission("read")
+	return _get_reconciliation_uom_details(item, uom)
+
+
+def _get_reconciliation_uom_details(item, uom=None):
+	uom = uom or item.stock_uom
+	conversion_factor = 1.0
+	if uom != item.stock_uom:
+		conversion = next((d for d in item.uoms if d.uom == uom), None)
+		if not conversion:
+			frappe.throw(
+				_("UOM {0} is not defined for item {1}. Please add it under UOM Conversion Detail.").format(
+					bold(uom), bold(item.name)
+				)
+			)
+		conversion_factor = flt(conversion.conversion_factor)
+		if not isfinite(conversion_factor) or conversion_factor <= 0:
+			frappe.throw(
+				_("Conversion factor for UOM {0} in item {1} must be greater than zero.").format(
+					bold(uom), bold(item.name)
+				)
+			)
+
+	return frappe._dict(stock_uom=item.stock_uom, uom=uom, conversion_factor=conversion_factor)
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def get_reconciliation_uom_query(
+	doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: dict
+):
+	"""Return readable Stock UOMs and configured alternate UOMs for an item."""
+	if not filters.get("item_code"):
+		return []
+	item = frappe.get_cached_doc("Item", filters["item_code"])
+	item.check_permission("read")
+	uoms = dict.fromkeys([item.stock_uom, *(d.uom for d in item.uoms if flt(d.conversion_factor) > 0)])
+	return [[uom] for uom in uoms if txt.lower() in uom.lower()][start : start + page_len]
 
 
 def get_item_data(row, qty, valuation_rate, serial_no=None):

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -20,6 +20,8 @@ from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle 
 from erpnext.stock.doctype.stock_reconciliation.stock_reconciliation import (
 	EmptyStockReconciliationItemsError,
 	get_items,
+	get_reconciliation_uom_details,
+	get_reconciliation_uom_query,
 )
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 from erpnext.stock.stock_ledger import get_previous_sle, update_entries_after
@@ -38,6 +40,167 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
 		frappe.local.future_sle = {}
 		frappe.flags.pop("dont_execute_stock_reposts", None)
+
+	def make_alternate_uom_item(self, **properties):
+		return self.make_item(
+			properties={
+				"stock_uom": "Nos",
+				"uoms": [{"uom": "Box", "conversion_factor": 12}],
+				**properties,
+			}
+		)
+
+	def test_alternate_uom_reconciliation(self):
+		transaction_args = {
+			"company": frappe.db.get_value("Warehouse", "Stores - TCP1", "company"),
+			"warehouse": "Stores - TCP1",
+			"expense_account": "Stock Adjustment - TCP1",
+		}
+		for valuation_method in ("FIFO", "Moving Average"):
+			with self.subTest(valuation_method=valuation_method):
+				item = self.make_alternate_uom_item(valuation_method=valuation_method)
+				opening = create_stock_reconciliation(
+					item_code=item.name, qty=20, rate=100, **transaction_args
+				)
+				reco = create_stock_reconciliation(
+					item_code=item.name,
+					uom="Box",
+					counted_qty=2,
+					rate=100,
+					do_not_submit=True,
+					**transaction_args,
+				)
+				# Repeated validation must not multiply an already converted quantity.
+				reco.save()
+				reco.submit()
+				reco.reload()
+				row = reco.items[0]
+				self.assertEqual((row.counted_qty, row.conversion_factor, row.qty), (2, 12, 24))
+				self.assertEqual(row.stock_uom, "Nos")
+				self.assertEqual(flt(row.quantity_difference), 4)
+				self.assertEqual(row.amount, 2400)
+				self.assertEqual(reco.difference_amount, 400)
+				self.assertSLEs(reco, [{"qty_after_transaction": 24, "stock_value": 2400}])
+				self.assertGLEs(reco, [{"debit": 400, "credit": 0}], {"debit": [">", 0]})
+				reco.cancel()
+				self.assertEqual(
+					frappe.db.get_value(
+						"Bin", {"item_code": item.name, "warehouse": row.warehouse}, "actual_qty"
+					),
+					20,
+				)
+				opening.cancel()
+
+	@ERPNextTestSuite.change_settings("System Settings", {"float_precision": 2})
+	def test_alternate_uom_count_preserved_after_rounding(self):
+		item = self.make_alternate_uom_item(
+			stock_uom="Kg", uoms=[{"uom": "Nos", "conversion_factor": 0.333333333}]
+		)
+		reco = create_stock_reconciliation(
+			item_code=item.name, uom="Nos", counted_qty=1, rate=100, do_not_submit=True
+		)
+		for _ in range(2):
+			reco.reload()
+			self.assertEqual(reco.items[0].counted_qty, 1)
+			self.assertEqual(reco.items[0].qty, 0.33)
+			reco.save()
+
+		reco.submit()
+		reco.reload()
+		self.assertEqual(reco.items[0].counted_qty, 1)
+		self.assertSLEs(reco, [{"qty_after_transaction": 0.33, "stock_value": 33}])
+		reco.cancel()
+
+	def test_alternate_uom_valuation_only(self):
+		item = self.make_alternate_uom_item()
+		create_stock_reconciliation(item_code=item.name, qty=24, rate=100)
+		reco = create_stock_reconciliation(item_code=item.name, uom="Box", rate=200)
+		self.assertEqual(reco.items[0].counted_qty, 2)
+		self.assertEqual(reco.items[0].qty, 24)
+		self.assertSLEs(reco, [{"qty_after_transaction": 24, "stock_value": 4800}])
+
+	def test_alternate_uom_zero_count(self):
+		item = self.make_alternate_uom_item()
+		create_stock_reconciliation(item_code=item.name, qty=24, rate=100)
+		reco = create_stock_reconciliation(item_code=item.name, uom="Box", counted_qty=0, rate=100)
+		self.assertEqual(reco.items[0].qty, 0)
+		self.assertEqual(reco.items[0].amount, 0)
+		self.assertEqual(reco.difference_amount, -2400)
+		self.assertSLEs(reco, [{"qty_after_transaction": 0, "stock_value": 0}])
+
+	def test_alternate_uom_unchanged_count(self):
+		item = self.make_alternate_uom_item()
+		create_stock_reconciliation(item_code=item.name, qty=24, rate=100)
+		with self.assertRaises(EmptyStockReconciliationItemsError):
+			create_stock_reconciliation(item_code=item.name, uom="Box", counted_qty=2, rate=100)
+
+	def test_alternate_uom_validation(self):
+		item = self.make_alternate_uom_item()
+		reco = create_stock_reconciliation(
+			item_code=item.name, uom="Box", counted_qty=2, rate=100, do_not_save=True
+		)
+		row = reco.items[0]
+		row.conversion_factor = 99
+		row.stock_uom = "Kg"
+		reco.set_stock_uom_quantities()
+		self.assertEqual((row.qty, row.conversion_factor, row.stock_uom), (24, 12, "Nos"))
+		row.uom = "Kg"
+		with self.assertRaisesRegex(frappe.ValidationError, "UOM Conversion Detail"):
+			reco.set_stock_uom_quantities()
+
+		for factor in (0, -1):
+			with self.subTest(factor=factor):
+				frappe.db.set_value(
+					"UOM Conversion Detail", {"parent": item.name, "uom": "Box"}, "conversion_factor", factor
+				)
+				frappe.clear_document_cache("Item", item.name)
+				with self.assertRaisesRegex(frappe.ValidationError, "must be greater than zero"):
+					get_reconciliation_uom_details(item.name, "Box")
+
+	def test_alternate_uom_whole_number_validation(self):
+		item = self.make_alternate_uom_item()
+		reco = create_stock_reconciliation(
+			item_code=item.name, uom="Box", counted_qty=0.1, rate=100, do_not_save=True
+		)
+		with self.assertRaisesRegex(frappe.ValidationError, "cannot be a fraction"):
+			reco.set_stock_uom_quantities()
+
+		item = self.make_alternate_uom_item(stock_uom="Kg", uoms=[{"uom": "Nos", "conversion_factor": 12}])
+		reco = create_stock_reconciliation(
+			item_code=item.name, uom="Nos", counted_qty=0.5, rate=100, do_not_save=True
+		)
+		with self.assertRaisesRegex(frappe.ValidationError, "cannot be a fraction"):
+			reco.set_stock_uom_quantities()
+
+	def test_alternate_uom_query(self):
+		item = self.make_alternate_uom_item()
+		self.assertEqual(
+			get_reconciliation_uom_query("UOM", "", "name", 0, 20, {"item_code": item.name}),
+			[["Nos"], ["Box"]],
+		)
+
+	def test_alternate_uom_serial_numbers(self):
+		item = self.make_alternate_uom_item(has_serial_no=1, serial_no_series="UOM-SERIAL-.#####")
+		reco = create_stock_reconciliation(
+			item_code=item.name, uom="Box", counted_qty=1, rate=100, purpose="Opening Stock"
+		)
+		self.assertEqual(reco.items[0].qty, 12)
+		bundle = frappe.get_doc("Serial and Batch Bundle", reco.items[0].serial_and_batch_bundle)
+		self.assertEqual(len(bundle.entries), 12)
+		self.assertEqual(bundle.total_qty, 12)
+		reco.cancel()
+
+	def test_alternate_uom_batch(self):
+		item = self.make_alternate_uom_item(
+			has_batch_no=1, create_new_batch=1, batch_number_series="UOM-BATCH-.#####"
+		)
+		reco = create_stock_reconciliation(
+			item_code=item.name, uom="Box", counted_qty=2, rate=100, purpose="Opening Stock"
+		)
+		bundle = frappe.get_doc("Serial and Batch Bundle", reco.items[0].serial_and_batch_bundle)
+		self.assertEqual(bundle.total_qty, 24)
+		self.assertSLEs(reco, [{"qty_after_transaction": 24, "stock_value": 2400}])
+		reco.cancel()
 
 	def test_reco_for_fifo(self):
 		self._test_reco_sle_gle("FIFO")
@@ -2239,6 +2402,8 @@ def create_stock_reconciliation(**args):
 			"warehouse": args.warehouse or "_Test Warehouse - _TC",
 			"qty": args.qty,
 			"reconcile_all_serial_batch": args.reconcile_all_serial_batch,
+			"uom": args.uom,
+			"counted_qty": args.counted_qty,
 			"valuation_rate": args.rate,
 			"serial_no": args.serial_no if args.use_serial_batch_fields else None,
 			"batch_no": args.batch_no if args.use_serial_batch_fields else None,

--- a/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
+++ b/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
@@ -13,6 +13,9 @@
   "item_group",
   "column_break_6",
   "warehouse",
+  "uom",
+  "counted_qty",
+  "conversion_factor",
   "qty",
   "stock_uom",
   "valuation_rate",
@@ -50,7 +53,7 @@
    "print_hide": 1
   },
   {
-   "columns": 3,
+   "columns": 2,
    "fieldname": "item_code",
    "fieldtype": "Link",
    "in_global_search": 1,
@@ -70,7 +73,7 @@
    "read_only": 1
   },
   {
-   "columns": 3,
+   "columns": 2,
    "fieldname": "warehouse",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -83,14 +86,39 @@
    "fieldtype": "Column Break"
   },
   {
-   "columns": 2,
+   "columns": 1,
+   "fieldname": "uom",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "UOM",
+   "options": "UOM"
+  },
+  {
+   "columns": 1,
+   "depends_on": "eval:doc.uom && doc.uom !== doc.stock_uom",
+   "description": "Physical count in the selected UOM.",
+   "fieldname": "counted_qty",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Counted Quantity"
+  },
+  {
+   "depends_on": "eval:doc.uom && doc.uom !== doc.stock_uom",
+   "fieldname": "conversion_factor",
+   "fieldtype": "Float",
+   "label": "Conversion Factor",
+   "read_only": 1
+  },
+  {
+   "columns": 1,
    "fieldname": "qty",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Quantity"
+   "label": "Quantity (Stock UOM)",
+   "read_only_depends_on": "eval:doc.uom && doc.uom !== doc.stock_uom"
   },
   {
-   "columns": 2,
+   "columns": 1,
    "fetch_from": "item_code.stock_uom",
    "fieldname": "stock_uom",
    "fieldtype": "Link",
@@ -101,6 +129,7 @@
   },
   {
    "columns": 2,
+   "description": "Value per Stock UOM.",
    "fieldname": "valuation_rate",
    "fieldtype": "Currency",
    "in_list_view": 1,
@@ -277,7 +306,7 @@
  "grid_page_length": 50,
  "istable": 1,
  "links": [],
- "modified": "2026-07-18 10:00:00.000000",
+ "modified": "2026-09-08 19:10:44.704387",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Reconciliation Item",

--- a/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.py
+++ b/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.py
@@ -19,6 +19,8 @@ class StockReconciliationItem(Document):
 		amount_difference: DF.Currency
 		barcode: DF.Data | None
 		batch_no: DF.Link | None
+		conversion_factor: DF.Float
+		counted_qty: DF.Float
 		current_amount: DF.Currency
 		current_qty: DF.Float
 		current_serial_and_batch_bundle: DF.Link | None
@@ -37,6 +39,7 @@ class StockReconciliationItem(Document):
 		serial_and_batch_bundle: DF.Link | None
 		serial_no: DF.LongText | None
 		stock_uom: DF.Link | None
+		uom: DF.Link | None
 		use_serial_batch_fields: DF.Check
 		valuation_rate: DF.Currency
 		warehouse: DF.Link


### PR DESCRIPTION
**Description**

-  Allows users to enter physical stock counts in an alternate UOM configured on the item. For example, entering 2 Boxes, with 1 Box = 12 Nos, automatically calculates 24 Nos for
  reconciliation.

-  Adds UOM, Counted Quantity, and Conversion Factor fields while keeping stock posting and valuation in the Stock UOM. Undefined UOMs and invalid conversion factors are rejected. The entered
  count is preserved when the converted stock quantity requires rounding.

  Closes: #50321

  **Steps to reproduce**

  1. Create a stock item with Stock UOM = Nos.
  2. Add Box to its UOM Conversion Detail table with conversion factor 12.
  3. Create and submit opening stock of 20 Nos, with valuation rate 100, in a warehouse.
  4. Create a new Stock Reconciliation for that item and warehouse.
  5. Attempt to enter a physical count of 2 Boxes.

  **Before this change**

  Only the Stock UOM quantity can be entered. Users must manually convert 2 Boxes into 24 Nos.

  **After this change**

  1. Select UOM = Box.
  2. Enter Counted Quantity = 2.
  3. Verify the converted quantity is 24 Nos, quantity difference is +4, and amount difference is +400.
  4. Save and submit.
  5. Verify the stock ledger balance is 24 Nos.

  Valuation rate remains 100 per Nos.

**Before:**

[Screencast from 2026-09-09 14-13-30.webm](https://github.com/user-attachments/assets/ec4dcead-e0f3-4090-abd7-05a12c51cc8b)


**After:**

[Screencast from 2026-09-09 14-38-48.webm](https://github.com/user-attachments/assets/d59154bb-6a23-4c37-808b-800151889517)

No-Docs
