### PR TITLE
fix(manufacturing): handle empty bom cost allocation

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -529,6 +529,7 @@ class BOM(WebsiteGenerator):
 		doc.set_status(save=True)
 
 	def set_fg_cost_allocation(self):
+		self.cost_allocation_per = flt(self.cost_allocation_per)
 		total_secondary_items_per = 0
 		own_cost = 0
 		for item in self.secondary_items:


### PR DESCRIPTION
### Issue

Fixes #58936.

Clearing the BOM's Cost Allocation Per field causes a TypeError during cost calculation. Normalize the empty percentage to zero so the existing allocation validation can run.

### Steps to reproduce

1. Create a draft BOM with raw materials and Cost Allocation Per set to 100.
2. Save the BOM.
3. Clear Cost Allocation Per and save again.

### Before 

[Screencast from 2026-09-09 16-31-41.webm](https://github.com/user-attachments/assets/fccb3c0d-241a-4798-a1fb-7143fad551f7)


### After 

[Screencast from 2026-09-09 16-34-08.webm](https://github.com/user-attachments/assets/78d26c67-6302-4e52-8487-6c0abaf20ec0)


### Actual behaviour

- Saving raises `TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'`.

### Expected behaviour

- Show the existing validation message when allocation between finished goods and secondary items does not total 100%. If secondary items receive the full allocation, allow an empty finished-good percentage to save as zero.

### Backport needed for V16 
