### PR TITLE
fix(stock): prevent duplicate quality inspection parameters

### DIFF
--- a/erpnext/stock/doctype/quality_inspection_template/quality_inspection_template.py
+++ b/erpnext/stock/doctype/quality_inspection_template/quality_inspection_template.py
@@ -3,6 +3,7 @@
 
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -23,7 +24,10 @@ class QualityInspectionTemplate(Document):
 		quality_inspection_template_name: DF.Data
 	# end: auto-generated types
 
-	pass
+	def validate(self):
+		parameters = [row.specification for row in self.item_quality_inspection_parameter]
+		if len(parameters) != len(set(parameters)):
+			frappe.throw(_("Quality Inspection Parameters must be unique"))
 
 
 def get_template_details(template):

--- a/erpnext/stock/doctype/quality_inspection_template/test_quality_inspection_template.py
+++ b/erpnext/stock/doctype/quality_inspection_template/test_quality_inspection_template.py
@@ -1,8 +1,21 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+import frappe
+
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestQualityInspectionTemplate(ERPNextTestSuite):
-	pass
+	def test_duplicate_parameters(self):
+		template = frappe.get_doc(
+			{
+				"doctype": "Quality Inspection Template",
+				"item_quality_inspection_parameter": [
+					{"specification": "Length"},
+					{"specification": "Length"},
+				],
+			}
+		)
+
+		self.assertRaisesRegex(frappe.ValidationError, "must be unique", template.validate)


### PR DESCRIPTION
Quality Inspection Templates allow duplicate parameters, which can make downstream readings ambiguous. This prevents duplicate parameters from being saved.

Fixes https://github.com/frappe/erpnext/issues/58870