### PR TITLE
fix(subcontracting): cannot select Against Finished Good on customer receipt

### DIFF
--- a/erpnext/controllers/subcontracting_inward_controller.py
+++ b/erpnext/controllers/subcontracting_inward_controller.py
@@ -1161,7 +1161,11 @@ def get_fg_reference_names(
 		"Subcontracting Inward Order Item",
 		limit_start=start,
 		limit_page_length=page_len,
-		filters={"parent": filters.get("parent"), "item_code": ("like", f"%{txt}%"), "docstatus": 1},
+		filters={"parent": filters.get("parent"), "docstatus": 1},
+		or_filters=[
+			["name", "like", f"%{txt}%"],
+			["item_code", "like", f"%{txt}%"],
+		],
 		fields=["name", "item_code", "delivery_warehouse"],
 		as_list=True,
 		order_by="idx",

--- a/erpnext/subcontracting/doctype/subcontracting_inward_order_item/subcontracting_inward_order_item.json
+++ b/erpnext/subcontracting/doctype/subcontracting_inward_order_item/subcontracting_inward_order_item.json
@@ -197,8 +197,10 @@
  "quick_entry": 1,
  "row_format": "Dynamic",
  "search_fields": "item_name",
+ "show_title_field_in_link": 1,
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],
+ "title_field": "item_code",
  "track_changes": 1
 }


### PR DESCRIPTION
Selecting a value in **Against Finished Good** on a "Receive from Customer" Stock Entry failed with `<name> did not match any results`, even though the row was listed in the dropdown.

Link validation re-runs the custom query with `txt` set to the docname, and for custom queries the framework does not add its own `name = txt` filter. `get_fg_reference_names` only searched `item_code`, so validating a Subcontracting Inward Order Item hash name returned nothing and the desk rejected the selection.

The query now matches on `name` or `item_code`, keeping `parent` and `docstatus` as hard filters.

Also sets `item_code` as the link title for Subcontracting Inward Order Item, so the field shows the item instead of the row hash.
