### PR TITLE
feat(setup): restrict naming series to a company

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -388,6 +388,7 @@ doc_events = {
 			"erpnext.support.doctype.service_level_agreement.service_level_agreement.apply",
 			"erpnext.setup.doctype.transaction_deletion_record.transaction_deletion_record.check_for_running_deletion_job",
 			"erpnext.stock.doctype.company_restriction.company_restriction.validate_transaction_company",
+			"erpnext.setup.doctype.company_naming_series.company_naming_series.validate_naming_series",
 		],
 	},
 	tuple(period_closing_doctypes): {

--- a/erpnext/public/js/erpnext.bundle.js
+++ b/erpnext/public/js/erpnext.bundle.js
@@ -3,6 +3,7 @@ import "./stock_reservation";
 import "./queries";
 import "./sms_manager";
 import "./utils/party";
+import "./utils/naming_series";
 import "./utils/draft_link_guard";
 import "./controllers/stock_controller";
 import "./utils/serial_no_batch_selector";

--- a/erpnext/public/js/utils/naming_series.js
+++ b/erpnext/public/js/utils/naming_series.js
@@ -11,7 +11,7 @@ function get_full_options(doctype) {
 function apply_options(frm, options) {
 	frm.set_df_property("naming_series", "options", options.join("\n"));
 	if (!options.includes(frm.doc.naming_series)) {
-		frm.set_value("naming_series", options[0]);
+		frm.set_value("naming_series", options[0] || "");
 	}
 }
 
@@ -29,10 +29,7 @@ function set_naming_series_options(frm) {
 		.then((allowed) => {
 			if (frm.doc.company !== company) return;
 
-			const options = allowed.length ? allowed : fallback;
-			if (options.length) {
-				apply_options(frm, options);
-			}
+			apply_options(frm, allowed ?? fallback);
 		});
 }
 

--- a/erpnext/public/js/utils/naming_series.js
+++ b/erpnext/public/js/utils/naming_series.js
@@ -18,14 +18,17 @@ function apply_options(frm, options) {
 function set_naming_series_options(frm) {
 	if (!frm.is_new() || !frm.fields_dict.naming_series || !frm.doc.company) return;
 
+	const company = frm.doc.company;
 	const fallback = get_full_options(frm.doctype);
 
 	frappe
 		.xcall(
 			"erpnext.setup.doctype.company_naming_series.company_naming_series.get_naming_series_options",
-			{ company: frm.doc.company, doctype: frm.doctype }
+			{ company: company, doctype: frm.doctype }
 		)
 		.then((allowed) => {
+			if (frm.doc.company !== company) return;
+
 			const options = allowed.length ? allowed : fallback;
 			if (options.length) {
 				apply_options(frm, options);

--- a/erpnext/public/js/utils/naming_series.js
+++ b/erpnext/public/js/utils/naming_series.js
@@ -1,0 +1,39 @@
+const full_options = {};
+
+function get_full_options(doctype) {
+	if (!(doctype in full_options)) {
+		const df = frappe.meta.get_docfield(doctype, "naming_series");
+		full_options[doctype] = (df?.options || "").split("\n").filter(Boolean);
+	}
+	return full_options[doctype];
+}
+
+function apply_options(frm, options) {
+	frm.set_df_property("naming_series", "options", options.join("\n"));
+	if (!options.includes(frm.doc.naming_series)) {
+		frm.set_value("naming_series", options[0]);
+	}
+}
+
+function set_naming_series_options(frm) {
+	if (!frm.is_new() || !frm.fields_dict.naming_series || !frm.doc.company) return;
+
+	const fallback = get_full_options(frm.doctype);
+
+	frappe
+		.xcall(
+			"erpnext.setup.doctype.company_naming_series.company_naming_series.get_naming_series_options",
+			{ company: frm.doc.company, doctype: frm.doctype }
+		)
+		.then((allowed) => {
+			const options = allowed.length ? allowed : fallback;
+			if (options.length) {
+				apply_options(frm, options);
+			}
+		});
+}
+
+frappe.ui.form.on("*", {
+	onload: set_naming_series_options,
+	company: set_naming_series_options,
+});

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -26,6 +26,8 @@
   "default_letter_head",
   "column_break_zqmp",
   "default_letter_head_report",
+  "document_naming_section",
+  "document_naming_series",
   "company_info",
   "company_logo",
   "date_of_incorporation",
@@ -655,6 +657,19 @@
   },
   {
    "collapsible": 1,
+   "fieldname": "document_naming_section",
+   "fieldtype": "Section Break",
+   "label": "Document Naming"
+  },
+  {
+   "description": "Restrict the naming series offered for a document type to this company. Leave a document type out to offer every series set up for it.",
+   "fieldname": "document_naming_series",
+   "fieldtype": "Table",
+   "label": "Document Naming Series",
+   "options": "Company Naming Series"
+  },
+  {
+   "collapsible": 1,
    "depends_on": "eval: doc.docstatus == 0 && doc.__islocal != 1",
    "fieldname": "company_info",
    "fieldtype": "Section Break",
@@ -1159,7 +1174,7 @@
  "image_field": "company_logo",
  "is_tree": 1,
  "links": [],
- "modified": "2026-09-06 12:00:00.000000",
+ "modified": "2026-09-10 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Company",

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -42,6 +42,10 @@ class Company(NestedSet):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		from erpnext.setup.doctype.company_naming_series.company_naming_series import (
+			CompanyNamingSeries,
+		)
+
 		abbr: DF.Data
 		accounts_frozen_till_date: DF.Date | None
 		accumulated_depreciation_account: DF.Link | None
@@ -97,6 +101,7 @@ class Company(NestedSet):
 		depreciation_expense_account: DF.Link | None
 		disable_sdbnb_in_sr: DF.Check
 		disposal_account: DF.Link | None
+		document_naming_series: DF.Table[CompanyNamingSeries]
 		domain: DF.Data | None
 		email: DF.Data | None
 		enable_item_wise_inventory_account: DF.Check
@@ -196,6 +201,7 @@ class Company(NestedSet):
 		self.cant_change_valuation_method()
 		self.validate_pending_reposts(old_doc)
 		self.validate_sdbnb_configuration()
+		self.validate_document_naming_series()
 
 	def validate_outstanding_sdbnb_transactions(self, account):
 		GLEntry = frappe.qb.DocType("GL Entry")
@@ -340,6 +346,30 @@ class Company(NestedSet):
 					),
 					title=_("Incorrect Warehouse"),
 				)
+
+	def validate_document_naming_series(self):
+		"""Every restricted series has to be one the document type actually offers."""
+		seen = set()
+		for row in self.document_naming_series:
+			if row.document_type in seen:
+				frappe.throw(
+					_("Document Type {0} is listed more than once in Document Naming Series").format(
+						bold(row.document_type)
+					)
+				)
+			seen.add(row.document_type)
+
+			available = frappe.get_meta(row.document_type).get_naming_series_options()
+			if not available:
+				frappe.throw(_("{0} is not named by a Naming Series").format(bold(row.document_type)))
+
+			for series in row.get_options():
+				if series not in available:
+					frappe.throw(
+						_("Naming Series {0} is not set up for {1}").format(
+							bold(series), bold(row.document_type)
+						)
+					)
 
 	def validate_abbr(self):
 		if not self.abbr:

--- a/erpnext/setup/doctype/company_naming_series/company_naming_series.json
+++ b/erpnext/setup/doctype/company_naming_series/company_naming_series.json
@@ -1,0 +1,44 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-09-10 12:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "document_type",
+  "naming_series_options"
+ ],
+ "fields": [
+  {
+   "columns": 3,
+   "fieldname": "document_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Document Type",
+   "options": "DocType",
+   "reqd": 1
+  },
+  {
+   "columns": 7,
+   "description": "One series per line. Only these are offered for this company.",
+   "fieldname": "naming_series_options",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Naming Series Options",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-09-10 12:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Setup",
+ "name": "Company Naming Series",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext/setup/doctype/company_naming_series/company_naming_series.py
+++ b/erpnext/setup/doctype/company_naming_series/company_naming_series.py
@@ -26,21 +26,23 @@ class CompanyNamingSeries(Document):
 		return [option.strip() for option in (self.naming_series_options or "").split("\n") if option.strip()]
 
 
-def get_allowed_naming_series(company: str, doctype: str) -> list[str]:
-	"""Naming series this company may use for a doctype. An empty list means no restriction.
+def get_allowed_naming_series(company: str, doctype: str) -> list[str] | None:
+	"""Naming series this company may use for a doctype, or None when it restricts none.
 
 	The stored options are intersected with the ones the document type currently offers, so a
-	series dropped from Document Naming Settings stops being offered without a Company edit.
+	series dropped from Document Naming Settings stops being offered without a Company edit. A
+	restriction whose every series has been dropped returns an empty list, not None: the company
+	was never approved for the rest, so it may not fall back to them.
 	"""
 	if not company or not frappe.db.exists("Company", company):
-		return []
+		return None
 
 	for row in frappe.get_cached_doc("Company", company).get("document_naming_series") or []:
 		if row.document_type == doctype:
 			available = frappe.get_meta(doctype).get_naming_series_options()
 			return [series for series in row.get_options() if series in available]
 
-	return []
+	return None
 
 
 def validate_naming_series(doc, method=None):
@@ -49,18 +51,26 @@ def validate_naming_series(doc, method=None):
 		return
 
 	allowed = get_allowed_naming_series(doc.company, doc.doctype)
-	if not allowed or doc.naming_series in allowed:
+	if allowed is None or doc.naming_series in allowed:
 		return
 
+	if allowed:
+		frappe.throw(
+			_("Naming Series {0} is not available for Company {1}. Available: {2}").format(
+				frappe.bold(doc.naming_series), frappe.bold(doc.company), frappe.bold(", ".join(allowed))
+			),
+			title=_("Invalid Naming Series"),
+		)
+
 	frappe.throw(
-		_("Naming Series {0} is not available for Company {1}. Available: {2}").format(
-			frappe.bold(doc.naming_series), frappe.bold(doc.company), frappe.bold(", ".join(allowed))
-		),
+		_(
+			"Company {0} has no Naming Series left for {1}. Every series listed on the Company has been removed from the document type."
+		).format(frappe.bold(doc.company), frappe.bold(_(doc.doctype))),
 		title=_("Invalid Naming Series"),
 	)
 
 
 @frappe.whitelist()
-def get_naming_series_options(company: str, doctype: str) -> list[str]:
+def get_naming_series_options(company: str, doctype: str) -> list[str] | None:
 	frappe.has_permission(doctype, throw=True)
 	return get_allowed_naming_series(company, doctype)

--- a/erpnext/setup/doctype/company_naming_series/company_naming_series.py
+++ b/erpnext/setup/doctype/company_naming_series/company_naming_series.py
@@ -27,13 +27,18 @@ class CompanyNamingSeries(Document):
 
 
 def get_allowed_naming_series(company: str, doctype: str) -> list[str]:
-	"""Naming series this company may use for a doctype. An empty list means no restriction."""
+	"""Naming series this company may use for a doctype. An empty list means no restriction.
+
+	The stored options are intersected with the ones the document type currently offers, so a
+	series dropped from Document Naming Settings stops being offered without a Company edit.
+	"""
 	if not company or not frappe.db.exists("Company", company):
 		return []
 
 	for row in frappe.get_cached_doc("Company", company).get("document_naming_series") or []:
 		if row.document_type == doctype:
-			return row.get_options()
+			available = frappe.get_meta(doctype).get_naming_series_options()
+			return [series for series in row.get_options() if series in available]
 
 	return []
 

--- a/erpnext/setup/doctype/company_naming_series/company_naming_series.py
+++ b/erpnext/setup/doctype/company_naming_series/company_naming_series.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class CompanyNamingSeries(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		document_type: DF.Link
+		naming_series_options: DF.SmallText
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
+	def get_options(self) -> list[str]:
+		return [option.strip() for option in (self.naming_series_options or "").split("\n") if option.strip()]
+
+
+def get_allowed_naming_series(company: str, doctype: str) -> list[str]:
+	"""Naming series this company may use for a doctype. An empty list means no restriction."""
+	if not company or not frappe.db.exists("Company", company):
+		return []
+
+	for row in frappe.get_cached_doc("Company", company).get("document_naming_series") or []:
+		if row.document_type == doctype:
+			return row.get_options()
+
+	return []
+
+
+def validate_naming_series(doc, method=None):
+	"""Keep a company from using another company's naming series."""
+	if not doc.is_new() or not doc.get("company") or not doc.get("naming_series"):
+		return
+
+	allowed = get_allowed_naming_series(doc.company, doc.doctype)
+	if not allowed or doc.naming_series in allowed:
+		return
+
+	frappe.throw(
+		_("Naming Series {0} is not available for Company {1}. Available: {2}").format(
+			frappe.bold(doc.naming_series), frappe.bold(doc.company), frappe.bold(", ".join(allowed))
+		),
+		title=_("Invalid Naming Series"),
+	)
+
+
+@frappe.whitelist()
+def get_naming_series_options(company: str, doctype: str) -> list[str]:
+	frappe.has_permission(doctype, throw=True)
+	return get_allowed_naming_series(company, doctype)

--- a/erpnext/setup/doctype/company_naming_series/test_company_naming_series.py
+++ b/erpnext/setup/doctype/company_naming_series/test_company_naming_series.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+
+from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+from erpnext.setup.doctype.company_naming_series.company_naming_series import (
+	get_allowed_naming_series,
+)
+from erpnext.tests.utils import ERPNextTestSuite
+
+COMPANY = "_Test Company"
+ALLOWED_SERIES = "ACC-JV-.YYYY.-"
+SERIES = "TEST-NAMING-.YYYY.-"
+
+
+class TestCompanyNamingSeries(ERPNextTestSuite):
+	def setUp(self):
+		self.company = frappe.get_doc("Company", COMPANY)
+		self.company.set("document_naming_series", [])
+
+	def restrict(self, document_type, options):
+		self.company.append(
+			"document_naming_series",
+			{"document_type": document_type, "naming_series_options": options},
+		)
+		self.company.save()
+
+	def test_no_rows_means_every_series_is_offered(self):
+		self.company.save()
+
+		self.assertEqual(get_allowed_naming_series(COMPANY, "Journal Entry"), [])
+
+	def test_allowed_series_are_read_off_the_company(self):
+		self.restrict("Journal Entry", "ACC-JV-.YYYY.-")
+
+		self.assertEqual(get_allowed_naming_series(COMPANY, "Journal Entry"), ["ACC-JV-.YYYY.-"])
+		self.assertEqual(get_allowed_naming_series(COMPANY, "Sales Invoice"), [])
+
+	def test_series_must_be_one_the_document_type_offers(self):
+		self.assertRaises(frappe.ValidationError, self.restrict, "Journal Entry", SERIES)
+
+	def test_document_type_must_use_a_naming_series(self):
+		self.assertRaises(frappe.ValidationError, self.restrict, "Company", "ANY-.####.")
+
+	def test_document_type_cannot_repeat(self):
+		self.company.append(
+			"document_naming_series",
+			{"document_type": "Journal Entry", "naming_series_options": "ACC-JV-.YYYY.-"},
+		)
+		self.assertRaises(frappe.ValidationError, self.restrict, "Journal Entry", "ACC-JV-.YYYY.-")
+
+	def test_disallowed_series_is_rejected_on_insert(self):
+		self.restrict("Journal Entry", ALLOWED_SERIES)
+
+		entry = build_journal_entry(SERIES)
+		self.assertRaises(frappe.ValidationError, entry.insert)
+
+		entry = build_journal_entry(ALLOWED_SERIES)
+		entry.insert()
+		self.assertTrue(entry.name.startswith("ACC-JV-"))
+
+	def test_an_unrestricted_document_type_keeps_every_series(self):
+		self.restrict("Journal Entry", ALLOWED_SERIES)
+
+		invoice = create_sales_invoice(do_not_save=True)
+		invoice.insert()
+		self.assertTrue(invoice.name.startswith("T-SINV-"))
+
+
+def build_journal_entry(naming_series):
+	entry = make_journal_entry("_Test Cash - _TC", "_Test Bank - _TC", 100, save=False)
+	entry.naming_series = naming_series
+	return entry

--- a/erpnext/setup/doctype/company_naming_series/test_company_naming_series.py
+++ b/erpnext/setup/doctype/company_naming_series/test_company_naming_series.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+from unittest.mock import patch
+
 import frappe
 
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
@@ -37,6 +39,16 @@ class TestCompanyNamingSeries(ERPNextTestSuite):
 
 		self.assertEqual(get_allowed_naming_series(COMPANY, "Journal Entry"), ["ACC-JV-.YYYY.-"])
 		self.assertEqual(get_allowed_naming_series(COMPANY, "Sales Invoice"), [])
+
+	def test_a_series_dropped_from_the_doctype_stops_being_allowed(self):
+		self.restrict("Journal Entry", ALLOWED_SERIES)
+		self.assertEqual(get_allowed_naming_series(COMPANY, "Journal Entry"), [ALLOWED_SERIES])
+
+		with self.patch_naming_series_options("Journal Entry", []):
+			self.assertEqual(get_allowed_naming_series(COMPANY, "Journal Entry"), [])
+
+	def patch_naming_series_options(self, doctype, options):
+		return patch.object(frappe.get_meta(doctype), "get_naming_series_options", return_value=options)
 
 	def test_series_must_be_one_the_document_type_offers(self):
 		self.assertRaises(frappe.ValidationError, self.restrict, "Journal Entry", SERIES)

--- a/erpnext/setup/doctype/company_naming_series/test_company_naming_series.py
+++ b/erpnext/setup/doctype/company_naming_series/test_company_naming_series.py
@@ -32,13 +32,13 @@ class TestCompanyNamingSeries(ERPNextTestSuite):
 	def test_no_rows_means_every_series_is_offered(self):
 		self.company.save()
 
-		self.assertEqual(get_allowed_naming_series(COMPANY, "Journal Entry"), [])
+		self.assertIsNone(get_allowed_naming_series(COMPANY, "Journal Entry"))
 
 	def test_allowed_series_are_read_off_the_company(self):
 		self.restrict("Journal Entry", "ACC-JV-.YYYY.-")
 
 		self.assertEqual(get_allowed_naming_series(COMPANY, "Journal Entry"), ["ACC-JV-.YYYY.-"])
-		self.assertEqual(get_allowed_naming_series(COMPANY, "Sales Invoice"), [])
+		self.assertIsNone(get_allowed_naming_series(COMPANY, "Sales Invoice"))
 
 	def test_a_series_dropped_from_the_doctype_stops_being_allowed(self):
 		self.restrict("Journal Entry", ALLOWED_SERIES)
@@ -46,6 +46,7 @@ class TestCompanyNamingSeries(ERPNextTestSuite):
 
 		with self.patch_naming_series_options("Journal Entry", []):
 			self.assertEqual(get_allowed_naming_series(COMPANY, "Journal Entry"), [])
+			self.assertRaises(frappe.ValidationError, build_journal_entry(ALLOWED_SERIES).insert)
 
 	def patch_naming_series_options(self, doctype, options):
 		return patch.object(frappe.get_meta(doctype), "get_naming_series_options", return_value=options)


### PR DESCRIPTION
Naming series options live in a Property Setter on the doctype, so every company sees every series set up for a document type. In a multi company install one company's clerk can pick another company's series, and nothing stops them.

## What changes

Company gets a **Document Naming Series** table — a document type and the series that company may use for it, in the same newline separated shape Document Naming Settings already uses.

A document type left out of the table keeps every series, so an install that configures nothing behaves exactly as before.

Enforced in two places:

- a `doc_events["*"]` validate hook, on insert only, so documents that predate a restriction still save
- a form event on every doctype that narrows the `naming_series` select when the form loads and whenever the company changes

The series listed on Company are checked against the ones the document type actually offers, so a typo cannot lock a company out of a document type entirely.

## Notes

The global superset stays where it is — this only says which of those each company may use, so there is one owner for the series themselves.