### PR TITLE
fix(stock): do not rebuild the Warehouse tree on an account map miss

### DIFF
--- a/erpnext/stock/__init__.py
+++ b/erpnext/stock/__init__.py
@@ -57,12 +57,8 @@ def get_warehouse_account(warehouse, warehouse_account=None, *, raise_error=True
 	account = warehouse.account
 	if not account and warehouse.parent_warehouse:
 		if warehouse_account:
-			if warehouse_account.get(warehouse.parent_warehouse):
-				account = warehouse_account.get(warehouse.parent_warehouse).account
-			else:
-				from frappe.utils.nestedset import rebuild_tree
-
-				rebuild_tree("Warehouse")
+			if parent := warehouse_account.get(warehouse.parent_warehouse):
+				account = parent.account
 		else:
 			account = frappe.get_all(
 				"Warehouse",


### PR DESCRIPTION
`get_warehouse_account_map` builds its map in preorder, so a parent is always visited before its children. When a child's parent was missing from the accumulated map, `get_warehouse_account` treated that as a corrupt nested set and called `rebuild_tree("Warehouse")`.

A miss is not evidence of corruption. The map only records warehouses that resolved an account, so a parent with no own account, no company default inventory account and no unambiguous Stock account is legitimately absent. #58036 made map construction skip unresolvable warehouses instead of throwing, so that condition now reaches the branch on every lookup, including every Warehouse insert (`before_insert` calls `get_warehouse_account` with the map).

The rebuild did nothing for the caller either. It repaired `lft` and `rgt`, then fell through with the account still unset. It also writes in a read path that runs during stock GL composition, and `rebuild_tree` sets `auto_commit_on_many_writes`, so a large tree can commit mid-submit.

### Why removing it is safe

In a healthy tree the ancestor lookup finds nothing anyway. If any ancestor has an account set, the parent inherits it during its own iteration and lands in the map. So a parent absent from the map means no ancestor has an account, and falling through to the company default gives the same answer. A warehouse that stays unresolved still throws where a transaction uses it.

No change in resolved accounts, so no new test. `test_warehouse.py` passes (13/13).
