### PR TITLE
refactor(setup): drop the Default Company type row's label key

### DIFF
--- a/erpnext/setup/navigation_item_type/default_company/default_company.json
+++ b/erpnext/setup/navigation_item_type/default_company/default_company.json
@@ -3,7 +3,6 @@
  "docstatus": 0,
  "doctype": "Navigation Item Type",
  "idx": 0,
- "label": "Default Company",
  "modified": "2026-09-03 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Setup",


### PR DESCRIPTION
`Navigation Item Type` loses its `label` and `icon` columns in frappe/frappe#42718: nothing read them, and a kind names itself in its renderer's `label()`. The `Default Company` type row still carried `"label": "Default Company"`, which the import now discards as an unknown key. This removes the dead text. No behaviour change; `default_company/frontend/item.js` already supplies the label.

Merge after frappe#42718, since ERPNext CI builds its bench from frappe's `desk-v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
