### PR TITLE
fix(mrp): align monthly bucket labels with demand dates 

### DIFF
--- a/erpnext/manufacturing/report/material_requirements_planning_report/material_requirements_planning_report.py
+++ b/erpnext/manufacturing/report/material_requirements_planning_report/material_requirements_planning_report.py
@@ -1113,7 +1113,7 @@ class MaterialRequirementsPlanningReport:
 			args["to_date"] = add_days(from_date, -1)
 
 			if bucket_size == "Monthly":
-				args["label"] = formatdate(from_date, "MMM YYYY")
+				args["label"] = formatdate(args["from_date"], "MMM YYYY")
 			else:
 				if bucket_size == "Weekly":
 					args["label"] = (


### PR DESCRIPTION
## Issue:
The Material Requirements Planning report displays monthly bucket labels one month ahead of the actual demand date. For example, Sales Forecast demand dated in November appears under December, and December demand appears under January.

## Root Cause
The monthly bucket label was generated after advancing the internal date to the next month.

Ref: [#78053](https://support.frappe.io/helpdesk/tickets/78053)