### PR TITLE
fix: avoid TypeError on new Work Order when company is not set

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -139,6 +139,10 @@ frappe.ui.form.on("Work Order", {
 		frm.fields_dict["secondary_items"].grid.wrapper?.find("> .control-label").text(label);
 	},
 
+	company: function (frm) {
+		erpnext.work_order.set_default_warehouse(frm);
+	},
+
 	source_warehouse: function (frm) {
 		let transaction_controller = new erpnext.TransactionController();
 		transaction_controller.autofill_warehouse(
@@ -1114,14 +1118,16 @@ erpnext.work_order = {
 	},
 
 	set_default_warehouse: function (frm) {
-		if (!(frm.doc.wip_warehouse || frm.doc.fg_warehouse)) {
+		if (frm.doc.company && !(frm.doc.wip_warehouse || frm.doc.fg_warehouse)) {
+			let company = frm.doc.company;
 			frappe.call({
 				method: "erpnext.manufacturing.doctype.work_order.work_order.get_default_warehouse",
 				args: {
-					company: frm.doc.company,
+					company: company,
 				},
 				callback: function (r) {
-					if (!r.exe) {
+					// ignore stale responses if the company changed while the request was in flight
+					if (!r.exe && frm.doc.company === company) {
 						frm.set_value("wip_warehouse", r.message.wip_warehouse);
 						frm.set_value("fg_warehouse", r.message.fg_warehouse);
 						frm.set_value("scrap_warehouse", r.message.scrap_warehouse);


### PR DESCRIPTION
### Issue

- Opening a new Work Order throws a server error when multiple companies exist and no default company is set:

  TypeError: get_default_warehouse() missing 1 required positional argument: 'company'

Fixes #58964

### Steps to reproduce

1. Set up multiple companies
2. Do not set a default company (Global Defaults company left empty, no user default company)
3. Go to Manufacturing > Work Order > New
4. The Server Error dialog appears immediately, before filling any field

After:

[after wo.webm](https://github.com/user-attachments/assets/12b0cac3-f41c-4768-830a-6dd24ce51271)



### Actual behaviour

- The form fails with a Server Error dialog before any field is filled.

### Expected behaviour

- The form should open normally. Default WIP / FG / Scrap warehouses are already applied server-side on save, so the client fetches them only when a company is set.

Backport Needed for V16 