### PR TITLE
feat(selling): add quotation versions and automatic revision counts

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -417,7 +417,8 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 					],
 					get_query_filters: {
 						docstatus: 1,
-						status: ["!=", "Lost"],
+						is_latest_revision: 1,
+						status: ["not in", ["Lost", "Superseded"]],
 						company: me.frm.doc.company,
 					},
 					allow_child_item_selection: true,

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -5,6 +5,7 @@
 import frappe
 import frappe.utils
 from frappe import _, msgprint, throw
+from frappe.model.base_document import get_controller
 from frappe.query_builder import Case
 from frappe.utils import cint, flt, formatdate, get_link_to_form
 from frappe.utils.data import comma_and
@@ -259,6 +260,10 @@ class SalesInvoice(SellingController):
 		write_off_cost_center: DF.Link | None
 		write_off_outstanding_amount_automatically: DF.Check
 	# end: auto-generated types
+
+	def save(self, *args, **kwargs):
+		get_controller("Quotation").lock_quotation_references(self)
+		return super().save(*args, **kwargs)
 
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
@@ -791,8 +796,10 @@ class SalesInvoice(SellingController):
 		self.party_account_currency = account.account_currency
 
 	def validate_with_previous_doc(self):
+		get_controller("Quotation").validate_quotation_references(self)
 		super().validate_with_previous_doc(
 			{
+				"Quotation": {"ref_dn_field": "quotation", "compare_fields": [["company", "="]]},
 				"Sales Order": {
 					"ref_dn_field": "sales_order",
 					"compare_fields": [

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -105,6 +105,7 @@
   "column_break_ogff",
   "company_total_stock",
   "edit_references",
+  "quotation",
   "sales_order",
   "so_detail",
   "sales_invoice_item",
@@ -726,6 +727,16 @@
    "label": "References"
   },
   {
+   "fieldname": "quotation",
+   "fieldtype": "Link",
+   "label": "Quotation",
+   "no_copy": 1,
+   "options": "Quotation",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
    "fieldname": "sales_order",
    "fieldtype": "Link",
    "label": "Sales Order",
@@ -1068,7 +1079,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-08-11 12:00:00.000000",
+ "modified": "2026-09-10 16:40:49.272195",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
@@ -58,6 +58,7 @@ class SalesInvoiceItem(Document):
 		incoming_rate: DF.Currency
 		is_fixed_asset: DF.Check
 		is_free_item: DF.Check
+		is_product_bundle: DF.Check
 		item_code: DF.Link | None
 		item_group: DF.Link | None
 		item_name: DF.Data
@@ -76,11 +77,13 @@ class SalesInvoiceItem(Document):
 		pos_invoice_item: DF.Data | None
 		price_list_rate: DF.Currency
 		pricing_rules: DF.SmallText | None
+		product_bundle: DF.Link | None
 		project: DF.Link | None
 		purchase_order: DF.Link | None
 		purchase_order_item: DF.Data | None
 		qty: DF.Float
 		quality_inspection: DF.Link | None
+		quotation: DF.Link | None
 		rate: DF.Currency
 		rate_with_margin: DF.Currency
 		sales_invoice_item: DF.Data | None

--- a/erpnext/accounts/services/child_item_update.py
+++ b/erpnext/accounts/services/child_item_update.py
@@ -5,6 +5,7 @@
 
 import frappe
 from frappe import _
+from frappe.model.base_document import get_controller
 from frappe.model.workflow import get_workflow_name
 from frappe.utils import flt, get_link_to_form, getdate
 
@@ -30,7 +31,11 @@ class ChildItemUpdater:
 		self.parent_doctype = parent_doctype
 		self.parent_doctype_name = parent_doctype_name
 		self.child_docname = child_docname
-		self.parent = frappe.get_doc(parent_doctype, parent_doctype_name)
+		if parent_doctype == "Quotation":
+			get_controller("Quotation").lock_quotation(parent_doctype_name)
+		self.parent = frappe.get_doc(
+			parent_doctype, parent_doctype_name, for_update=parent_doctype == "Quotation"
+		)
 		self.allow_zero_qty = get_allow_zero_qty(parent_doctype)
 		self._transacted_stock_qty: dict | None = None
 
@@ -49,6 +54,8 @@ class ChildItemUpdater:
 		self._check_permissions("write")
 
 		if self.parent_doctype == "Quotation":
+			get_controller("Quotation").validate_orderable(self.parent.name)
+			self.quotation_before_update = frappe.get_doc(self.parent.as_dict())
 			self._transacted_stock_qty = get_ordered_items(self.parent.name)
 			items_added_or_removed |= validate_and_delete_children(
 				self.parent, data, self._transacted_stock_qty
@@ -162,6 +169,9 @@ class ChildItemUpdater:
 
 		for idx, row in enumerate(parent.get(self.child_docname), start=1):
 			row.idx = idx
+
+		if self.parent_doctype == "Quotation":
+			parent.flags.quotation_before_update = self.quotation_before_update
 
 		parent.save()
 

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -644,6 +644,7 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None, return_agai
 			target_doc.expense_account = source_doc.expense_account
 
 			if doctype == "Sales Invoice":
+				target_doc.quotation = source_doc.quotation
 				target_doc.sales_invoice_item = source_doc.name
 				target_doc.tax_withholding_category = source_doc.tax_withholding_category
 				target_doc.apply_tds = source_doc.apply_tds

--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -4,6 +4,7 @@
 
 import frappe
 from frappe import _
+from frappe.model.base_document import get_controller
 from frappe.utils import DateTimeLikeObject, getdate, today
 
 import erpnext
@@ -99,6 +100,14 @@ def get_data(filters, conditions):
 
 	if conditions.get("trans") == "Quotation" and filters.get("group_by") == "Customer":
 		cond += " and t1.quotation_to = 'Customer'"
+	if conditions.get("trans") == "Quotation":
+		period_ends = [
+			end for _, end in get_period_date_ranges(filters.get("period"), filters.get("fiscal_year"))
+		]
+		revision_condition = get_controller("Quotation").get_report_revision_condition(
+			frappe.qb.DocType("Quotation").as_("t1"), period_ends
+		)
+		cond += " and " + revision_condition.get_sql(subquery=True)
 
 	year_start_date, year_end_date = frappe.get_cached_value(
 		"Fiscal Year", filters.get("fiscal_year"), ["year_start_date", "year_end_date"]

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -228,7 +228,8 @@ class Lead(SellingController, CRMNote):
 
 	def has_quotation(self):
 		return frappe.db.get_value(
-			"Quotation", {"party_name": self.name, "docstatus": 1, "status": ["!=", "Lost"]}
+			"Quotation",
+			{"party_name": self.name, "docstatus": 1, "status": ["not in", ["Lost", "Superseded"]]},
 		)
 
 	def has_lost_quotation(self):

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -300,7 +300,7 @@ class Opportunity(TransactionBase, CRMNote):
 				"Quotation",
 				{
 					"opportunity": self.name,
-					"status": ("not in", ["Lost", "Cancelled", "Expired"]),
+					"status": ("not in", ["Lost", "Cancelled", "Expired", "Superseded"]),
 					"docstatus": 1,
 				},
 				"name",
@@ -316,7 +316,7 @@ class Opportunity(TransactionBase, CRMNote):
 				.where(
 					(q.docstatus == 1)
 					& (qi.prevdoc_docname == self.name)
-					& q.status.notin(["Lost", "Cancelled", "Expired"])
+					& q.status.notin(["Lost", "Cancelled", "Expired", "Superseded"])
 				)
 				.run()
 			)

--- a/erpnext/crm/report/campaign_efficiency/campaign_efficiency.py
+++ b/erpnext/crm/report/campaign_efficiency/campaign_efficiency.py
@@ -64,7 +64,9 @@ def get_lead_data(filters, based_on):
 
 
 def get_lead_quotation_count(leads):
-	return frappe.db.count("Quotation", {"quotation_to": "Lead", "party_name": ["in", leads]})
+	return frappe.db.count(
+		"Quotation", {"quotation_to": "Lead", "party_name": ["in", leads], "is_latest_revision": 1}
+	)
 
 
 def get_lead_opp_count(leads):

--- a/erpnext/selling/doctype/quotation/mapper.py
+++ b/erpnext/selling/doctype/quotation/mapper.py
@@ -5,6 +5,7 @@ import json
 
 import frappe
 from frappe import _
+from frappe.model.base_document import get_controller
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import cint, flt, getdate, nowdate
@@ -31,6 +32,7 @@ def make_sales_order(
 
 
 def _make_sales_order(source_name, target_doc=None, ignore_permissions=False, args=None):
+	get_controller("Quotation").validate_orderable(source_name)
 	if args is None:
 		args = {}
 	args = frappe.parse_json(args)
@@ -156,6 +158,7 @@ def make_sales_invoice(
 
 
 def _make_sales_invoice(source_name, target_doc=None, ignore_permissions=False, args=None):
+	get_controller("Quotation").validate_orderable(source_name)
 	if args is None:
 		args = {}
 	args = frappe.parse_json(args)
@@ -187,6 +190,7 @@ def _make_sales_invoice(source_name, target_doc=None, ignore_permissions=False, 
 			"Quotation": {"doctype": "Sales Invoice", "validation": {"docstatus": ["=", 1]}},
 			"Quotation Item": {
 				"doctype": "Sales Invoice Item",
+				"field_map": {"parent": "quotation"},
 				"postprocess": update_item,
 				"condition": lambda row: not row.is_alternative and select_item(row),
 			},

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -110,6 +110,39 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 
 		var me = this;
 
+		if (!doc.__islocal) {
+			this.frm.add_custom_button(
+				__("Revisions"),
+				() =>
+					this.frm.call("get_revisions").then((r) => {
+						if (r.message?.length) {
+							frappe.set_route("List", "Quotation", { name: ["in", r.message] });
+						}
+					}),
+				__("View")
+			);
+		}
+
+		if (
+			doc.docstatus === 1 &&
+			doc.is_latest_revision &&
+			["Open", "Expired"].includes(doc.status) &&
+			frappe.model.can_create("Quotation")
+		) {
+			this.frm.add_custom_button(
+				__("Revision"),
+				() => {
+					this.frm.call("make_revision").then((r) => {
+						if (r.message) {
+							const [revision] = frappe.model.sync(r.message);
+							frappe.set_route("Form", revision.doctype, revision.name);
+						}
+					});
+				},
+				__("Create")
+			);
+		}
+
 		if (doc.__islocal && !doc.valid_till) {
 			if (frappe.boot.sysdefaults.quotation_valid_till) {
 				this.frm.set_value(
@@ -124,7 +157,7 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 			}
 		}
 
-		if (doc.docstatus == 1 && !["Lost", "Ordered"].includes(doc.status)) {
+		if (doc.docstatus == 1 && doc.is_latest_revision && !["Lost", "Ordered"].includes(doc.status)) {
 			if (
 				frappe.model.can_create("Sales Order") &&
 				(frappe.boot.sysdefaults.allow_sales_order_creation_for_expired_quotation ||

--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -22,6 +22,11 @@
   "company",
   "has_unit_price_items",
   "amended_from",
+  "original_quotation",
+  "revised_from",
+  "quotation_version",
+  "quote_revision_count",
+  "is_latest_revision",
   "currency_and_price_list",
   "currency",
   "conversion_rate",
@@ -850,10 +855,11 @@
    "no_copy": 1,
    "oldfieldname": "status",
    "oldfieldtype": "Select",
-   "options": "Draft\nOpen\nReplied\nPartially Ordered\nOrdered\nLost\nCancelled\nExpired",
+   "options": "Draft\nOpen\nReplied\nPartially Ordered\nOrdered\nLost\nCancelled\nExpired\nSuperseded",
    "print_hide": 1,
    "read_only": 1,
-   "reqd": 1
+   "reqd": 1,
+   "in_standard_filter": 1
   },
   {
    "fieldname": "enq_det",
@@ -1139,13 +1145,69 @@
    "label": "Title",
    "no_copy": 1,
    "print_hide": 1
+  },
+  {
+   "fieldname": "original_quotation",
+   "fieldtype": "Link",
+   "label": "Original Quotation",
+   "options": "Quotation",
+   "read_only": 1,
+   "no_copy": 1,
+   "search_index": 1,
+   "depends_on": "eval:doc.original_quotation",
+   "in_standard_filter": 1
+  },
+  {
+   "fieldname": "revised_from",
+   "fieldtype": "Link",
+   "label": "Revised From",
+   "options": "Quotation",
+   "read_only": 1,
+   "no_copy": 1,
+   "search_index": 1,
+   "depends_on": "eval:doc.revised_from"
+  },
+  {
+   "fieldname": "quotation_version",
+   "fieldtype": "Int",
+   "label": "Quotation Version",
+   "read_only": 1,
+   "no_copy": 1,
+   "default": "0",
+   "depends_on": "eval:doc.original_quotation",
+   "description": "Number of this separately saved version of the original quotation.",
+   "in_standard_filter": 1,
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "quote_revision_count",
+   "fieldtype": "Int",
+   "label": "Quote Revision Count",
+   "read_only": 1,
+   "no_copy": 1,
+   "allow_on_submit": 1,
+   "default": "0",
+   "description": "Number of saves with commercial changes to this quotation, excluding the initial save.",
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "is_latest_revision",
+   "fieldtype": "Check",
+   "label": "Current Version",
+   "read_only": 1,
+   "no_copy": 1,
+   "allow_on_submit": 1,
+   "default": "1",
+   "in_standard_filter": 1,
+   "search_index": 1,
+   "description": "The current submitted version, or the original draft before submission."
   }
  ],
  "icon": "fa fa-shopping-cart",
  "idx": 82,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-12 12:00:00.000000",
+ "modified": "2026-09-10 19:08:36.924463",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation",
@@ -1243,5 +1305,6 @@
  "sort_order": "DESC",
  "states": [],
  "timeline_field": "party_name",
- "title_field": "customer_name"
+ "title_field": "customer_name",
+ "track_changes": 1
 }

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -9,7 +9,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.model.naming import getseries
 from frappe.query_builder.functions import IfNull, NullIf
-from frappe.utils import add_days, cint, flt, getdate, nowdate
+from frappe.utils import add_days, cint, date_diff, flt, getdate, nowdate
 from pypika import Case, Order
 from pypika.terms import ExistsCriterion
 
@@ -205,6 +205,8 @@ class Quotation(SellingController):
 		"mode_of_payment",
 		"discount",
 		"discount_type",
+		"discount_date",
+		"payment_amount",
 	)
 
 	def save(self, *args, **kwargs):
@@ -228,7 +230,9 @@ class Quotation(SellingController):
 		draft.revised_from = source.name
 		draft.original_quotation = source.original_quotation or source.name
 		draft.is_latest_revision = 0
-		draft.transaction_date = source.transaction_date
+		for row in source.payment_schedule:
+			draft.append("payment_schedule", frappe.copy_doc(row, ignore_no_copy=False))
+		self.renew_revision_dates(source, draft)
 		for source_item, item in zip(source.items, draft.items, strict=True):
 			item.prevdoc_doctype = source_item.prevdoc_doctype
 			item.prevdoc_docname = source_item.prevdoc_docname
@@ -658,6 +662,17 @@ class Quotation(SellingController):
 		if not source.is_latest_revision or source.status not in ("Open", "Expired"):
 			frappe.throw(_("Only the current Open or Expired quotation can be revised."))
 		source.validate_revision_transactions()
+
+	@staticmethod
+	def renew_revision_dates(source: Document, draft: Document) -> None:
+		shift = date_diff(nowdate(), source.transaction_date)
+		draft.transaction_date = nowdate()
+		if source.valid_till:
+			draft.valid_till = add_days(source.valid_till, shift)
+		for row in draft.payment_schedule:
+			for fieldname in ("due_date", "discount_date"):
+				if row.get(fieldname):
+					row.set(fieldname, add_days(row.get(fieldname), shift))
 
 	def validate_revision_party(self, source: Document) -> None:
 		if any(self.get(field) != source.get(field) for field in ("company", "quotation_to", "party_name")):

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -3,6 +3,7 @@
 
 
 from collections import Counter
+from hashlib import sha256
 
 import frappe
 from frappe import _
@@ -579,7 +580,13 @@ class Quotation(SellingController):
 		self.validate_revision_source(source)
 		self.validate_revision_party(source)
 		prefix = f"{self.original_quotation}-REV-"
-		self.quotation_version = cint(getseries(prefix, 1))
+		if len(prefix) >= 140:
+			frappe.throw(_("Quotation name is too long to append a revision suffix."))
+		# Series keys are shorter than document names on existing MariaDB sites.
+		series_key = (
+			prefix if len(prefix) <= 100 else f"quotation-revision-{sha256(prefix.encode()).hexdigest()}"
+		)
+		self.quotation_version = cint(getseries(series_key, 1))
 		name = f"{prefix}{self.quotation_version}"
 		if len(name) > 140:
 			frappe.throw(_("Quotation name is too long to append a revision suffix."))

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -2,10 +2,15 @@
 # License: GNU General Public License v3. See license.txt
 
 
+from collections import Counter
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import getdate, nowdate
+from frappe.model.naming import getseries
+from frappe.query_builder.functions import IfNull, NullIf
+from frappe.utils import add_days, cint, flt, getdate, nowdate
+from pypika import Case, Order
 from pypika.terms import ExistsCriterion
 
 from erpnext.controllers.selling_controller import SellingController
@@ -76,6 +81,7 @@ class Quotation(SellingController):
 		ignore_pricing_rule: DF.Check
 		in_words: DF.Data | None
 		incoterm: DF.Link | None
+		is_latest_revision: DF.Check
 		item_wise_tax_details: DF.Table[ItemWiseTaxDetail]
 		items: DF.Table[QuotationItem]
 		language: DF.Link | None
@@ -87,6 +93,7 @@ class Quotation(SellingController):
 		opportunity: DF.Link | None
 		order_lost_reason: DF.SmallText | None
 		order_type: DF.Literal["", "Sales", "Maintenance", "Shopping Cart"]
+		original_quotation: DF.Link | None
 		other_charges_calculation: DF.TextEditor | None
 		packed_items: DF.Table[PackedItem]
 		party_name: DF.DynamicLink | None
@@ -96,7 +103,10 @@ class Quotation(SellingController):
 		price_list_currency: DF.Link
 		pricing_rules: DF.Table[PricingRuleDetail]
 		quotation_to: DF.Link
+		quotation_version: DF.Int
+		quote_revision_count: DF.Int
 		referral_sales_partner: DF.Link | None
+		revised_from: DF.Link | None
 		rounded_total: DF.Currency
 		rounding_adjustment: DF.Currency
 		scan_barcode: DF.Data | None
@@ -106,7 +116,15 @@ class Quotation(SellingController):
 		shipping_address_name: DF.Link | None
 		shipping_rule: DF.Link | None
 		status: DF.Literal[
-			"Draft", "Open", "Replied", "Partially Ordered", "Ordered", "Lost", "Cancelled", "Expired"
+			"Draft",
+			"Open",
+			"Replied",
+			"Partially Ordered",
+			"Ordered",
+			"Lost",
+			"Cancelled",
+			"Expired",
+			"Superseded",
 		]
 		supplier_quotation: DF.Link | None
 		tax_category: DF.Link | None
@@ -128,6 +146,177 @@ class Quotation(SellingController):
 		valid_till: DF.Date | None
 	# end: auto-generated types
 
+	revision_fields = ("original_quotation", "revised_from", "quotation_version")
+	revision_commercial_fields = (
+		"valid_till",
+		"currency",
+		"conversion_rate",
+		"selling_price_list",
+		"price_list_currency",
+		"plc_conversion_rate",
+		"apply_discount_on",
+		"additional_discount_percentage",
+		"discount_amount",
+		"coupon_code",
+		"tax_category",
+		"taxes_and_charges",
+		"shipping_rule",
+		"incoterm",
+		"named_place",
+		"payment_terms_template",
+		"tc_name",
+		"terms",
+	)
+	revision_item_fields = (
+		"item_code",
+		"item_name",
+		"description",
+		"qty",
+		"rate",
+		"uom",
+		"stock_uom",
+		"conversion_factor",
+		"price_list_rate",
+		"discount_percentage",
+		"discount_amount",
+		"margin_type",
+		"margin_rate_or_amount",
+		"is_alternative",
+		"is_free_item",
+		"item_tax_template",
+		"item_tax_rate",
+		"product_bundle",
+		"blanket_order",
+		"blanket_order_rate",
+	)
+	revision_tax_fields = (
+		"charge_type",
+		"account_head",
+		"description",
+		"row_id",
+		"rate",
+		"included_in_print_rate",
+		"cost_center",
+	)
+	revision_payment_fields = (
+		"payment_term",
+		"invoice_portion",
+		"due_date",
+		"mode_of_payment",
+		"discount",
+		"discount_type",
+	)
+
+	def save(self, *args, **kwargs):
+		# Acquire the family lock before Frappe locks this particular version.
+		self.lock_revision_family()
+		return super().save(*args, **kwargs)
+
+	def before_insert(self):
+		self.initialize_revision()
+
+	@frappe.whitelist(methods=["POST"])
+	def make_revision(self) -> Document:
+		source = frappe.get_doc("Quotation", self.name)
+		self.validate_revision_source(source)
+		frappe.has_permission("Quotation", "create", throw=True)
+
+		draft = frappe.copy_doc(source, ignore_no_copy=False)
+		draft.docstatus = 0
+		draft.status = "Draft"
+		draft.naming_series = source.naming_series
+		draft.revised_from = source.name
+		draft.original_quotation = source.original_quotation or source.name
+		draft.is_latest_revision = 0
+		draft.transaction_date = source.transaction_date
+		for source_item, item in zip(source.items, draft.items, strict=True):
+			item.prevdoc_doctype = source_item.prevdoc_doctype
+			item.prevdoc_docname = source_item.prevdoc_docname
+			item.ordered_qty = 0
+			item.has_alternative_item = 0
+		for child in draft.get_all_children():
+			child.docstatus = 0
+			child.parent = None
+		return draft
+
+	@frappe.whitelist()
+	def get_revisions(self) -> list[str]:
+		self.check_permission("read")
+		original = self.original_quotation or self.name
+		return frappe.get_list(
+			"Quotation", or_filters={"name": original, "original_quotation": original}, pluck="name", limit=0
+		)
+
+	def before_update_after_submit(self):
+		self.update_revision_fields()
+
+	def before_cancel(self):
+		self.validate_revision_cancellation()
+		self.lost_reasons = []
+
+	def get_status(self):
+		status = super().get_status()
+		if self.docstatus == 1 and status["status"] not in ("Lost", "Ordered", "Partially Ordered"):
+			if not self.is_latest_revision:
+				status["status"] = "Superseded"
+			elif self.valid_till and getdate(self.valid_till) < getdate(nowdate()):
+				status["status"] = "Expired"
+		return status
+
+	@staticmethod
+	def validate_orderable(name: str) -> None:
+		quotation = frappe.db.get_value(
+			"Quotation", name, ["name", "is_latest_revision", "status"], as_dict=True
+		)
+		Quotation.check_orderable(quotation)
+
+	@staticmethod
+	def check_orderable(quotation) -> None:
+		if quotation and (not quotation.is_latest_revision or quotation.status == "Superseded"):
+			frappe.throw(
+				_("Quotation {0} has been superseded. Use its current revision.").format(quotation.name)
+			)
+		if quotation and quotation.status == "Lost":
+			frappe.throw(
+				_("Quotation {0} is Lost and cannot be used for an order or invoice.").format(quotation.name)
+			)
+
+	@staticmethod
+	def validate_quotation_references(doc: Document) -> None:
+		if getattr(doc, "_action", None) == "update_after_submit" or doc.get("is_return"):
+			return
+		names = Quotation.lock_quotation_references(doc)
+		if not names:
+			return
+		table = frappe.qb.DocType("Quotation")
+		for quotation in (
+			frappe.qb.from_(table)
+			.select(table.name, table.is_latest_revision, table.status)
+			.where(table.name.isin(names))
+			.for_update()
+			.run(as_dict=True)
+		):
+			Quotation.check_orderable(quotation)
+
+	@staticmethod
+	def lock_quotation_references(doc: Document) -> list[str]:
+		fieldname = "quotation" if doc.doctype == "Sales Invoice" else "prevdoc_docname"
+		names = sorted({row.get(fieldname) for row in doc.items if row.get(fieldname)})
+		if not names:
+			return []
+		quotations = frappe.get_all(
+			"Quotation", filters={"name": ["in", names]}, fields=["name", "original_quotation"]
+		)
+		# Lock before Frappe locks the order or invoice, matching revision submission.
+		for original in sorted({row.original_quotation or row.name for row in quotations}):
+			frappe.db.get_value("Quotation", original, "name", for_update=True)
+		return names
+
+	@staticmethod
+	def lock_quotation(name: str) -> None:
+		original = frappe.db.get_value("Quotation", name, "original_quotation") or name
+		frappe.db.get_value("Quotation", original, "name", for_update=True)
+
 	def set_indicator(self):
 		if self.docstatus == 1:
 			self.indicator_color = "blue"
@@ -142,7 +331,6 @@ class Quotation(SellingController):
 
 	def validate(self):
 		super().validate()
-		self.set_status()
 		self.validate_uom_is_integer("stock_uom", "stock_qty")
 		self.validate_uom_is_integer("uom", "qty")
 		self.validate_valid_till()
@@ -153,11 +341,14 @@ class Quotation(SellingController):
 		from erpnext.stock.doctype.packed_item.packed_item import make_packing_list
 
 		make_packing_list(self)
+		self.update_revision_fields()
+		self.set_status()
 
 	def after_insert(self):
 		self.carry_forward_communication()
 
 	def before_submit(self):
+		self.validate_revision_submission()
 		self.set_has_alternative_item()
 
 	def validate_valid_till(self):
@@ -268,6 +459,9 @@ class Quotation(SellingController):
 		self, lost_reasons_list: list, competitors: list, detailed_reason: str | None = None
 	):
 		self.check_permission("write")
+		self.lock_quotation(self.name)
+		if not frappe.db.get_value("Quotation", self.name, "is_latest_revision", for_update=True):
+			frappe.throw(_("Only the current quotation can be marked as Lost."))
 
 		if not (self.is_fully_ordered() or self.is_partially_ordered()):
 			get_lost_reasons = frappe.get_list("Quotation Lost Reason", fields=["name"])
@@ -302,18 +496,18 @@ class Quotation(SellingController):
 		frappe.get_cached_doc("Authorization Control").validate_approving_authority(
 			self.doctype, self.company, self.base_grand_total, self
 		)
+		self.sync_revision_status()
 
 		# update enquiry status
 		self.update_opportunity("Quotation")
 		self.update_lead()
 
 	def on_cancel(self):
-		if self.lost_reasons:
-			self.lost_reasons = []
 		super().on_cancel()
 
 		# update enquiry status
 		self.set_status(update=True)
+		self.sync_revision_status()
 		self.update_opportunity("Open")
 		self.update_lead()
 
@@ -357,6 +551,239 @@ class Quotation(SellingController):
 
 		return rows_with_alternatives
 
+	def initialize_revision(self) -> None:
+		self.is_latest_revision = int(not self.revised_from)
+		if self.amended_from:
+			source = frappe.get_doc("Quotation", self.amended_from)
+			source.check_permission("read")
+			for field in Quotation.revision_fields:
+				self.set(field, source.get(field))
+			self.is_latest_revision = int(not self.original_quotation)
+			return
+
+		if not self.revised_from:
+			self.original_quotation = None
+			self.quotation_version = 0
+			return
+
+		source = frappe.get_doc("Quotation", self.revised_from)
+		self.original_quotation = source.original_quotation or source.name
+
+		# Serialize the first allocation as well as later revisions of the same quotation.
+		self.lock_revision_family()
+		source = frappe.get_doc("Quotation", self.revised_from, for_update=True)
+		self.validate_revision_source(source)
+		self.validate_revision_party(source)
+		prefix = f"{self.original_quotation}-REV-"
+		self.quotation_version = cint(getseries(prefix, 1))
+		name = f"{prefix}{self.quotation_version}"
+		if len(name) > 140:
+			frappe.throw(_("Quotation name is too long to append a revision suffix."))
+		self.set_new_name(set_name=name)
+
+	def update_revision_fields(self) -> None:
+		previous = self.flags.pop("quotation_before_update", None)
+		if previous:
+			# Update Items persists children before saving the parent. Preserve the original
+			# snapshot for both the commercial-change count and the Version history.
+			self._doc_before_save = previous
+		else:
+			previous = self.get_doc_before_save()
+
+		if previous:
+			for field in Quotation.revision_fields:
+				if self.get(field) != previous.get(field):
+					frappe.throw(_("Quotation version references cannot be changed."))
+		elif self.amended_from:
+			previous = frappe.get_doc("Quotation", self.amended_from)
+
+		if self.revised_from:
+			self.validate_revision_party(frappe.get_cached_doc("Quotation", self.revised_from))
+
+		if self._action == "submit":
+			self.is_latest_revision = 1
+		elif self.is_new():
+			self.is_latest_revision = int(not self.original_quotation)
+		else:
+			self.is_latest_revision = cint(previous.is_latest_revision)
+		self.quote_revision_count = (
+			cint(previous.get("quote_revision_count")) + int(self.has_commercial_changes(previous))
+			if previous
+			else 0
+		)
+
+	def has_commercial_changes(self, previous: Document) -> bool:
+		return self.get_revision_values(previous) != self.get_revision_values(self)
+
+	def get_revision_values(self, doc: Document) -> tuple:
+		items = [self.get_revision_field_values(row, Quotation.revision_item_fields) for row in doc.items]
+		if not any(row.is_alternative for row in doc.items):
+			items = Counter(items)
+		taxes = [
+			(
+				*self.get_revision_field_values(row, Quotation.revision_tax_fields),
+				flt(row.tax_amount) if row.charge_type == "Actual" else None,
+			)
+			for row in doc.taxes
+		]
+		payments = [
+			self.get_revision_field_values(row, Quotation.revision_payment_fields)
+			for row in doc.payment_schedule
+		]
+		return (
+			self.get_revision_field_values(doc, Quotation.revision_commercial_fields),
+			items,
+			taxes,
+			payments,
+		)
+
+	@staticmethod
+	def get_revision_field_values(doc: Document, fieldnames: tuple[str, ...]) -> tuple:
+		values = []
+		for fieldname in fieldnames:
+			field = doc.meta.get_field(fieldname)
+			value = doc.get(fieldname)
+			if field and field.fieldtype in ("Float", "Currency", "Percent", "Int", "Check"):
+				value = flt(value)
+			else:
+				value = str(value or "")
+			values.append(value)
+		return tuple(values)
+
+	@staticmethod
+	def validate_revision_source(source: Document) -> None:
+		source.check_permission("read")
+		if source.docstatus != 1:
+			frappe.throw(_("Only submitted quotations can be revised."))
+		if not source.is_latest_revision or source.status not in ("Open", "Expired"):
+			frappe.throw(_("Only the current Open or Expired quotation can be revised."))
+		source.validate_revision_transactions()
+
+	def validate_revision_party(self, source: Document) -> None:
+		if any(self.get(field) != source.get(field) for field in ("company", "quotation_to", "party_name")):
+			frappe.throw(_("A quotation revision must use the same company and party as its source."))
+
+	def validate_revision_submission(self) -> None:
+		self.lock_revision_family()
+		if not self.original_quotation:
+			return
+
+		source = frappe.get_doc("Quotation", self.revised_from, for_update=True)
+		if source.docstatus != 1 or source.status == "Lost":
+			frappe.throw(_("The source quotation must remain submitted and must not be Lost."))
+		self.validate_revision_transactions()
+		current = self.get_current_revision()
+		if current and current.status == "Lost":
+			frappe.throw(_("The current quotation is Lost and cannot be replaced by a draft revision."))
+		if current and cint(current.quotation_version) >= cint(self.quotation_version):
+			frappe.throw(
+				_("Quotation {0} is already the current version. Create a revision from it instead.").format(
+					current.name
+				)
+			)
+
+	def validate_revision_cancellation(self) -> None:
+		self.lock_revision_family()
+		quotation = frappe.qb.DocType("Quotation")
+		drafts = (
+			frappe.qb.from_(quotation)
+			.select(quotation.name)
+			.where(
+				(quotation.docstatus == 0)
+				& ((quotation.original_quotation == self.name) | (quotation.revised_from == self.name))
+			)
+			.limit(1)
+			.for_update()
+			.run(pluck=True)
+		)
+		if drafts:
+			frappe.throw(
+				_("Delete draft revision {0} before cancelling quotation {1}.").format(drafts[0], self.name)
+			)
+
+	def sync_revision_status(self) -> None:
+		original = self.original_quotation or self.name
+		self.lock_revision_family()
+		members = self.get_revision_family()
+		current = next((row.name for row in members if row.docstatus == 1), None)
+		for row in members:
+			is_current = int(
+				row.name == current or (not current and row.name == original and row.docstatus == 0)
+			)
+			if cint(row.is_latest_revision) == is_current:
+				continue
+			quotation = self if row.name == self.name else frappe.get_doc("Quotation", row.name)
+			quotation.db_set("is_latest_revision", is_current)
+			quotation.set_status(update=True)
+
+	def validate_revision_transactions(self) -> None:
+		self.lock_revision_family()
+		names = [row.name for row in self.get_revision_family()]
+		# Older direct invoices without a quotation reference cannot be matched retrospectively.
+		for doctype, fieldname in (("Sales Order", "prevdoc_docname"), ("Sales Invoice", "quotation")):
+			item = frappe.qb.DocType(f"{doctype} Item")
+			if (
+				frappe.qb.from_(item)
+				.select(item.name)
+				.where((item.docstatus == 1) & item[fieldname].isin(names))
+				.limit(1)
+				.for_update()
+				.run()
+			):
+				frappe.throw(_("A quotation with a submitted {0} cannot be revised.").format(_(doctype)))
+
+	def lock_revision_family(self) -> None:
+		original = self.original_quotation or self.name
+		if original:
+			frappe.db.get_value("Quotation", original, "name", for_update=True)
+
+	def get_current_revision(self):
+		return next((row for row in self.get_revision_family() if row.docstatus == 1), None)
+
+	def get_revision_family(self):
+		original = self.original_quotation or self.name
+		quotation = frappe.qb.DocType("Quotation")
+		return (
+			frappe.qb.from_(quotation)
+			.select(
+				quotation.name,
+				quotation.docstatus,
+				quotation.status,
+				quotation.quotation_version,
+				quotation.is_latest_revision,
+			)
+			.where((quotation.name == original) | (quotation.original_quotation == original))
+			.orderby(quotation.quotation_version, quotation.creation, order=Order.desc)
+			.for_update()
+			.run(as_dict=True)
+		)
+
+	@staticmethod
+	def get_report_revision_condition(quotation, period_end_dates, date_field="transaction_date"):
+		"""Select the latest submitted version within each reporting period."""
+		period_end = Case()
+		for end_date in period_end_dates:
+			next_day = getdate(add_days(end_date, 1))
+			period_end = period_end.when(quotation[date_field] < next_day, next_day)
+
+		revision = frappe.qb.DocType("Quotation").as_("later_revision")
+		original = IfNull(NullIf(quotation.original_quotation, ""), quotation.name)
+		newer_version = (revision.quotation_version > quotation.quotation_version) | (
+			(revision.quotation_version == quotation.quotation_version)
+			& (revision.creation > quotation.creation)
+		)
+		later_revisions = (
+			frappe.qb.from_(revision)
+			.select(revision.name)
+			.where(
+				(revision.original_quotation == original)
+				& (revision.docstatus == 1)
+				& (revision[date_field] < period_end)
+				& newer_version
+			)
+		)
+		return ExistsCriterion(later_revisions).negate()
+
 
 def get_list_context(context=None):
 	from erpnext.controllers.website_list_for_contact import get_list_context
@@ -399,7 +826,7 @@ def set_expired_status():
 		.set(quotation.status, "Expired")
 		.where(
 			(quotation.docstatus == 1)
-			& (quotation.status.notin(["Expired", "Lost"]))
+			& (quotation.status.notin(["Expired", "Lost", "Superseded"]))
 			& (quotation.valid_till < nowdate())
 			& ExistsCriterion(so_against_quo).negate()
 		)

--- a/erpnext/selling/doctype/quotation/quotation_list.js
+++ b/erpnext/selling/doctype/quotation/quotation_list.js
@@ -36,6 +36,8 @@ frappe.listview_settings["Quotation"] = {
 			return [__("Lost"), "gray", "status,=,Lost"];
 		} else if (doc.status === "Expired") {
 			return [__("Expired"), "gray", "status,=,Expired"];
+		} else if (doc.status === "Superseded") {
+			return [__("Superseded"), "gray", "status,=,Superseded"];
 		}
 	},
 };

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -2,23 +2,39 @@
 # License: GNU General Public License v3. See license.txt
 
 import json
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+from unittest.mock import patch
 
 import frappe
+from frappe.share import add
 from frappe.tests import change_settings
 from frappe.utils import add_days, add_months, flt, getdate, nowdate
+from freezegun import freeze_time
 
+from erpnext.accounts.doctype.sales_invoice.mapper import make_sales_return
 from erpnext.controllers.accounts_controller import InvalidQtyError, update_child_qty_rate
-from erpnext.selling.doctype.quotation.mapper import make_sales_order
+from erpnext.crm.doctype.opportunity.mapper import make_quotation as make_opportunity_quotation
+from erpnext.crm.doctype.opportunity.test_opportunity import make_opportunity
+from erpnext.crm.report.campaign_efficiency.campaign_efficiency import get_lead_quotation_count
+from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
+from erpnext.selling.doctype.quotation.mapper import make_sales_invoice, make_sales_order
+from erpnext.selling.doctype.quotation.quotation import Quotation, set_expired_status
+from erpnext.selling.page.sales_funnel.sales_funnel import get_funnel_data
+from erpnext.selling.report.quotation_trends.quotation_trends import execute as quotation_trends
+from erpnext.selling.report.sales_analytics.sales_analytics import execute as sales_analytics
+from erpnext.selling.report.territory_wise_sales.territory_wise_sales import execute as territory_sales
+from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestQuotation(ERPNextTestSuite):
 	def setUp(self):
+		# Keep default dates scoped to each test, including frozen report dates.
+		self.enterContext(patch.object(frappe.local, "new_doc_templates", {}))
 		self.load_test_records("Quotation")
 
 	def test_update_child_quotation_add_item(self):
-		from erpnext.stock.doctype.item.test_item import make_item
-
 		item_1 = frappe.get_doc("Item", "_Test Item")
 		item_2 = make_item("_Test Item 1")
 
@@ -61,8 +77,6 @@ class TestQuotation(ERPNextTestSuite):
 		self.assertRaises(frappe.ValidationError, qo.save)
 
 	def test_update_child_rate_change(self):
-		from erpnext.stock.doctype.item.test_item import make_item
-
 		item_1 = frappe.get_doc("Item", "_Test Item")
 		item_2 = make_item("_Test Item 1")
 
@@ -157,8 +171,6 @@ class TestQuotation(ERPNextTestSuite):
 		self.assertEqual(len(qo.get("items")), 1)
 
 	def test_update_child_qty_with_uom_conversion_factor(self):
-		from erpnext.stock.doctype.item.test_item import make_item
-
 		item = make_item(uoms=[{"uom": "Box", "conversion_factor": 5}])
 		quotation = make_quotation(item_code=item.item_code, qty=6, uom="Box", do_not_submit=1)
 		quotation.submit()
@@ -297,7 +309,6 @@ class TestQuotation(ERPNextTestSuite):
 
 	def test_do_not_add_ordered_items_in_new_sales_order(self):
 		from erpnext.selling.doctype.quotation.mapper import make_sales_order
-		from erpnext.stock.doctype.item.test_item import make_item
 
 		item = make_item("_Test Item for Quotation for SO", {"is_stock_item": 1})
 
@@ -328,7 +339,6 @@ class TestQuotation(ERPNextTestSuite):
 		self.assertEqual(sales_order.items[0].qty, 5.0)
 
 	def test_gross_profit(self):
-		from erpnext.stock.doctype.item.test_item import make_item
 		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 		from erpnext.stock.get_item_details import insert_item_price
 
@@ -542,8 +552,6 @@ class TestQuotation(ERPNextTestSuite):
 		si.save()
 
 	def test_create_two_quotations(self):
-		from erpnext.stock.doctype.item.test_item import make_item
-
 		first_item = make_item("_Test Laptop", {"is_stock_item": 1})
 
 		second_item = make_item("_Test CPU", {"is_stock_item": 1})
@@ -575,8 +583,6 @@ class TestQuotation(ERPNextTestSuite):
 		sec_qo.submit()
 
 	def test_quotation_expiry(self):
-		from erpnext.selling.doctype.quotation.quotation import set_expired_status
-
 		quotation_item = [{"item_code": "_Test Item", "warehouse": "", "qty": 1, "rate": 500}]
 
 		yesterday = add_days(nowdate(), -1)
@@ -591,9 +597,7 @@ class TestQuotation(ERPNextTestSuite):
 		self.assertEqual(expired_quotation.status, "Expired")
 
 	def test_product_bundle_mapping_on_creating_so(self):
-		from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
 		from erpnext.selling.doctype.quotation.mapper import make_sales_order
-		from erpnext.stock.doctype.item.test_item import make_item
 
 		make_item("_Test Product Bundle", {"is_stock_item": 0})
 		make_item("_Test Bundle Item 1", {"is_stock_item": 1})
@@ -647,9 +651,6 @@ class TestQuotation(ERPNextTestSuite):
 		self.assertEqual(quotation_packed_items, so_packed_items)
 
 	def test_product_bundle_price_calculation_when_calculate_bundle_price_is_unchecked(self):
-		from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
-		from erpnext.stock.doctype.item.test_item import make_item
-
 		make_item("_Test Product Bundle", {"is_stock_item": 0})
 		bundle_item1 = make_item("_Test Bundle Item 1", {"is_stock_item": 1})
 		bundle_item2 = make_item("_Test Bundle Item 2", {"is_stock_item": 1})
@@ -666,9 +667,6 @@ class TestQuotation(ERPNextTestSuite):
 		self.assertEqual(quotation.items[0].amount, 200)
 
 	def test_product_bundle_price_calculation_when_calculate_bundle_price_is_checked(self):
-		from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
-		from erpnext.stock.doctype.item.test_item import make_item
-
 		make_item("_Test Product Bundle", {"is_stock_item": 0})
 		make_item("_Test Bundle Item 1", {"is_stock_item": 1})
 		make_item("_Test Bundle Item 2", {"is_stock_item": 1})
@@ -690,9 +688,6 @@ class TestQuotation(ERPNextTestSuite):
 	def test_product_bundle_price_calculation_for_multiple_product_bundles_when_calculate_bundle_price_is_checked(
 		self,
 	):
-		from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
-		from erpnext.stock.doctype.item.test_item import make_item
-
 		make_item("_Test Product Bundle 1", {"is_stock_item": 0})
 		make_item("_Test Product Bundle 2", {"is_stock_item": 0})
 		make_item("_Test Bundle Item 1", {"is_stock_item": 1})
@@ -738,9 +733,6 @@ class TestQuotation(ERPNextTestSuite):
 		enable_calculate_bundle_price(enable=0)
 
 	def test_packed_items_indices_are_reset_when_product_bundle_is_deleted_from_items_table(self):
-		from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
-		from erpnext.stock.doctype.item.test_item import make_item
-
 		make_item("_Test Product Bundle 1", {"is_stock_item": 0})
 		make_item("_Test Product Bundle 2", {"is_stock_item": 0})
 		make_item("_Test Product Bundle 3", {"is_stock_item": 0})
@@ -793,8 +785,6 @@ class TestQuotation(ERPNextTestSuite):
 		- One set of non-alternative & alternative items [first 3 rows]
 		- One simple stock item
 		"""
-		from erpnext.stock.doctype.item.test_item import make_item
-
 		item_list = []
 		stock_items = {
 			"_Test Simple Item 1": 100,
@@ -839,8 +829,6 @@ class TestQuotation(ERPNextTestSuite):
 		All having the same item code and unique item name/description due to
 		dynamic services
 		"""
-		from erpnext.stock.doctype.item.test_item import make_item
-
 		item_list = []
 		service_items = {
 			"Tiling with Standard Tiles": 100,
@@ -890,8 +878,6 @@ class TestQuotation(ERPNextTestSuite):
 
 	def test_amount_calculation_for_alternative_items(self):
 		"""Make sure that the amount is calculated correctly for alternative items when the qty is changed."""
-		from erpnext.stock.doctype.item.test_item import make_item
-
 		item_list = []
 		stock_items = {
 			"_Test Simple Item 1": 100,
@@ -920,7 +906,6 @@ class TestQuotation(ERPNextTestSuite):
 
 	def test_alternative_items_sales_order_mapping_with_stock_items(self):
 		from erpnext.selling.doctype.quotation.mapper import make_sales_order
-		from erpnext.stock.doctype.item.test_item import make_item
 
 		frappe.flags.args = frappe._dict()
 		item_list = []
@@ -959,8 +944,6 @@ class TestQuotation(ERPNextTestSuite):
 		self.assertEqual(quotation.status, "Ordered")
 
 	def test_uom_validation(self):
-		from erpnext.stock.doctype.item.test_item import make_item
-
 		item = "_Test Item FOR UOM Validation"
 		make_item(item, {"is_stock_item": 1})
 
@@ -974,8 +957,6 @@ class TestQuotation(ERPNextTestSuite):
 		{"add_taxes_from_item_tax_template": 1, "add_taxes_from_taxes_and_charges_template": 0},
 	)
 	def test_item_tax_template_for_quotation(self):
-		from erpnext.stock.doctype.item.test_item import make_item
-
 		if not frappe.db.exists("Account", {"account_name": "_Test Vat", "company": "_Test Company"}):
 			frappe.get_doc(
 				{
@@ -1040,7 +1021,6 @@ class TestQuotation(ERPNextTestSuite):
 	@ERPNextTestSuite.change_settings("Selling Settings", {"allow_zero_qty_in_quotation": 1})
 	def test_so_from_zero_qty_quotation(self):
 		from erpnext.selling.doctype.quotation.mapper import make_sales_order
-		from erpnext.stock.doctype.item.test_item import make_item
 
 		quotation = make_quotation(qty=0, do_not_save=1)
 		quotation.append("items", {"item_code": "_Test Item 2", "qty": 10, "rate": 100})
@@ -1072,7 +1052,6 @@ class TestQuotation(ERPNextTestSuite):
 	@ERPNextTestSuite.change_settings("Selling Settings", {"allow_multiple_items": 1})
 	def test_duplicate_items_in_quotation(self):
 		from erpnext.selling.doctype.quotation.mapper import make_sales_order
-		from erpnext.stock.doctype.item.test_item import make_item
 
 		# item code same but description different
 		quotation = make_quotation(qty=10, rate=100, do_not_submit=1)
@@ -1216,6 +1195,662 @@ class TestQuotation(ERPNextTestSuite):
 		self.assertEqual(sales_order.payment_schedule[1].due_date, add_days(sales_order.transaction_date, 10))
 		self.assertEqual(sales_order.payment_schedule[0].payment_amount, 5000)
 		self.assertEqual(sales_order.payment_schedule[1].payment_amount, 5000)
+
+	def test_create_revision_preserves_submitted_source(self):
+		source = make_quotation(do_not_submit=True)
+		self.assertRaises(frappe.ValidationError, source.make_revision)
+		source.submit()
+		draft = source.make_revision()
+		self.assertTrue(draft.is_new())
+		self.assertEqual(draft.docstatus, 0)
+		for child in draft.get_all_children():
+			self.assertFalse(child.parent)
+		draft.insert()
+		self.assertEqual(draft.name, f"{source.name}-REV-1")
+		self.assertEqual(draft.original_quotation, source.name)
+		self.assertEqual(draft.revised_from, source.name)
+		self.assertEqual(draft.quotation_version, 1)
+		self.assertEqual(draft.quote_revision_count, 0)
+		self.assertEqual(draft.items[0].qty, source.items[0].qty)
+		self.assertEqual(draft.items[0].rate, source.items[0].rate)
+		self.assertNotEqual(draft.items[0].name, source.items[0].name)
+		draft.items[0].qty += 1
+		draft.items[0].rate += 10
+		draft.save()
+		self.assertEqual(draft.quote_revision_count, 1)
+		source.reload()
+		self.assertEqual(source.docstatus, 1)
+		self.assertEqual(source.status, "Open")
+		self.assertEqual(source.quote_revision_count, 0)
+		self.assertNotEqual(source.items[0].qty, draft.items[0].qty)
+		self.assertNotEqual(source.items[0].rate, draft.items[0].rate)
+
+	def test_ordinary_duplicate_starts_new_family(self):
+		source = make_quotation()
+		version = source.make_revision().insert()
+		duplicate = frappe.copy_doc(version, ignore_no_copy=False).insert()
+		self.assertFalse(duplicate.original_quotation)
+		self.assertFalse(duplicate.revised_from)
+		self.assertEqual(duplicate.quotation_version, 0)
+		self.assertEqual(duplicate.quote_revision_count, 0)
+		self.assertNotIn("-REV-", duplicate.name)
+
+	def test_revision_protects_party_lineage_and_counters(self):
+		source = make_quotation()
+		version = source.make_revision().insert()
+		version.party_name = "_Test Customer 1"
+		self.assertRaises(frappe.ValidationError, version.save)
+		version.reload()
+		payload = version.as_dict()
+		payload.update(revision_fields=[], quotation_version=99)
+		self.assertRaises(frappe.ValidationError, frappe.get_doc(payload).save)
+		version.reload()
+		payload = version.as_dict()
+		payload.update(
+			quote_revision_count=99,
+			is_latest_revision=1,
+			revision_commercial_fields=[],
+			revision_item_fields=[],
+			revision_tax_fields=[],
+			revision_payment_fields=[],
+		)
+		version = frappe.get_doc(payload)
+		version.save()
+		self.assertEqual(version.quote_revision_count, 0)
+		self.assertFalse(version.is_latest_revision)
+		version.items[0].description = "Revised specification"
+		version.save().reload()
+		self.assertEqual(version.quote_revision_count, 1)
+		source.is_latest_revision = 0
+		source.save()
+		self.assertTrue(source.is_latest_revision)
+
+	def test_counter_tracks_commercial_changes(self):
+		for field, value in (
+			("qty", 12),
+			("rate", 125),
+			("discount_percentage", 5),
+			("discount_amount", 5),
+			("description", "Revised specification"),
+			("additional_discount_percentage", 5),
+		):
+			with self.subTest(field=field):
+				quotation = make_quotation(do_not_submit=True)
+				if field.startswith("discount_"):
+					quotation.items[0].price_list_rate = 100
+					quotation.items[0].rate = 95
+				target = quotation if field == "additional_discount_percentage" else quotation.items[0]
+				target.set(field, value)
+				quotation.save()
+				self.assertEqual(quotation.quote_revision_count, 1)
+				quotation.save()
+				self.assertEqual(quotation.quote_revision_count, 1)
+
+	def test_counter_ignores_noncommercial_changes_and_item_reordering(self):
+		quotation = make_quotation(
+			do_not_submit=True,
+			item_list=[
+				{"item_code": "_Test Item", "qty": 10, "rate": 100},
+				{"item_code": "_Test Item 2", "qty": 1, "rate": 50},
+			],
+		)
+		self.assertEqual(quotation.quote_revision_count, 0)
+		quotation.save()
+		self.assertEqual(quotation.quote_revision_count, 0)
+		quotation.letter_head = None
+		quotation.language = "en"
+		quotation.items.reverse()
+		for idx, item in enumerate(quotation.items, 1):
+			item.idx = idx
+		quotation.save()
+		self.assertEqual(quotation.quote_revision_count, 0)
+		quotation.submit().save()
+		self.assertEqual(quotation.quote_revision_count, 0)
+
+	def test_submitted_update_items_counts_once_and_retains_history(self):
+		quotation = make_quotation()
+		items = self.update_items_payload(quotation)
+		items[0].update(qty=12, rate=125, description="New specification")
+		with patch.object(frappe, "in_test", False):
+			update_child_qty_rate("Quotation", items, quotation.name)
+		quotation.reload()
+		self.assertEqual(quotation.quote_revision_count, 1)
+		versions = frappe.get_all(
+			"Version", filters={"ref_doctype": "Quotation", "docname": quotation.name}, pluck="data"
+		)
+		self.assertTrue(any(json.loads(data).get("row_changed") for data in versions))
+		update_child_qty_rate("Quotation", self.update_items_payload(quotation), quotation.name)
+		quotation.reload()
+		self.assertEqual(quotation.quote_revision_count, 1)
+
+	def test_submitted_item_addition_and_removal_are_counted(self):
+		quotation = make_quotation()
+		items = self.update_items_payload(quotation)
+		items.append({"item_code": "_Test Item 2", "qty": 2, "rate": 50})
+		update_child_qty_rate("Quotation", items, quotation.name)
+		quotation.reload()
+		self.assertEqual(quotation.quote_revision_count, 1)
+		update_child_qty_rate("Quotation", self.update_items_payload(quotation)[:1], quotation.name)
+		quotation.reload()
+		self.assertEqual(quotation.quote_revision_count, 2)
+
+	def test_revision_submission_and_cancellation_track_current_version(self):
+		source = make_quotation()
+		first = source.make_revision().insert()
+		self.assertTrue(source.reload().is_latest_revision)
+		self.assertFalse(first.is_latest_revision)
+		self.assertTrue(make_sales_order(source.name).items)
+		first.submit()
+		second = first.make_revision().insert()
+		self.assertEqual(second.name, f"{source.name}-REV-2")
+		self.assertEqual(second.original_quotation, source.name)
+		self.assertEqual(second.revised_from, first.name)
+		self.assertCountEqual(second.get_revisions(), [source.name, first.name, second.name])
+		second.submit()
+		for quotation in (source, first):
+			quotation.reload()
+			self.assertEqual(quotation.status, "Superseded")
+			self.assertFalse(quotation.is_latest_revision)
+			self.assertRaises(frappe.ValidationError, quotation.make_revision)
+		self.assertTrue(second.is_latest_revision)
+		self.assertEqual(second.status, "Open")
+		order = make_sales_order(second.name)
+		self.assertEqual(order.items[0].quotation_item, second.items[0].name)
+		reason = frappe.get_doc(
+			{
+				"doctype": "Quotation Lost Reason",
+				"order_lost_reason": f"_Test Revision Cancellation {frappe.generate_hash(length=8)}",
+			}
+		).insert()
+		second.declare_enquiry_lost([{"lost_reason": reason.name}], [])
+		self.assertTrue(second.reload().lost_reasons)
+		second.cancel().reload()
+		self.assertFalse(second.lost_reasons)
+		self.assertFalse(second.is_latest_revision)
+		self.assertEqual(second.status, "Cancelled")
+		self.assertTrue(first.reload().is_latest_revision)
+		self.assertEqual(first.status, "Open")
+
+	def test_cannot_cancel_source_with_a_draft_revision(self):
+		source = make_quotation()
+		revision = source.make_revision().insert()
+		with self.assertRaisesRegex(frappe.ValidationError, "Delete draft revision"):
+			source.reload().cancel()
+		revision.delete()
+		source.reload().cancel()
+		self.assertEqual(source.status, "Cancelled")
+		self.assertRaises(frappe.ValidationError, source.make_revision)
+
+	def test_cannot_submit_older_sibling_after_newer_version(self):
+		source = make_quotation()
+		first = source.make_revision().insert()
+		second = source.make_revision().insert().submit()
+		with self.assertRaisesRegex(frappe.ValidationError, "already the current version"):
+			first.submit()
+		self.assertTrue(second.reload().is_latest_revision)
+		self.assertEqual(first.reload().docstatus, 0)
+
+	def test_sibling_draft_cannot_replace_a_lost_current_revision(self):
+		source = make_quotation()
+		first = source.make_revision().insert()
+		second = source.make_revision().insert()
+		first.submit().declare_enquiry_lost([], [])
+		self.assertRaises(frappe.ValidationError, first.make_revision)
+		with self.assertRaisesRegex(frappe.ValidationError, "current quotation is Lost"):
+			second.submit()
+		self.assertTrue(first.reload().is_latest_revision)
+		self.assertEqual(first.status, "Lost")
+
+	def test_expired_revisions_renew_payment_dates(self):
+		source = make_quotation(transaction_date=add_days(nowdate(), -20), do_not_submit=True)
+		source.valid_till = add_days(nowdate(), -10)
+		schedule = source.payment_schedule[0]
+		schedule.due_date = add_days(nowdate(), -5)
+		schedule.discount_type = "Percentage"
+		schedule.discount = 2
+		schedule.discount_date = add_days(nowdate(), -10)
+		source.save().submit()
+		self.assertEqual(source.status, "Expired")
+		revision = source.make_revision().insert().submit()
+		self.assertEqual(revision.status, "Open")
+		self.assertEqual(getdate(revision.valid_till), getdate(add_days(nowdate(), 10)))
+		self.assertEqual(getdate(revision.payment_schedule[0].due_date), getdate(add_days(nowdate(), 15)))
+		self.assertEqual(
+			getdate(revision.payment_schedule[0].discount_date), getdate(add_days(nowdate(), 10))
+		)
+		set_expired_status()
+		self.assertEqual(source.reload().status, "Superseded")
+
+	def test_superseded_versions_reject_mapping_and_item_updates(self):
+		source = make_quotation()
+		source.make_revision().insert().submit()
+		self.assertRaises(frappe.ValidationError, make_sales_order, source.name)
+		self.assertRaises(frappe.ValidationError, make_sales_invoice, source.name)
+		items = self.update_items_payload(source)
+		items[0]["qty"] += 1
+		self.assertRaises(frappe.ValidationError, update_child_qty_rate, "Quotation", items, source.name)
+		with self.assertRaisesRegex(frappe.ValidationError, "Only the current quotation"):
+			source.declare_enquiry_lost([], [])
+		self.assertEqual(source.reload().status, "Superseded")
+
+	def test_revision_preserves_opportunity_item_references(self):
+		opportunity = make_opportunity(with_items=1)
+		source = make_opportunity_quotation(opportunity.name).insert().submit()
+		revision = source.make_revision().insert().submit()
+		self.assertEqual(revision.items[0].prevdoc_doctype, "Opportunity")
+		self.assertEqual(revision.items[0].prevdoc_docname, opportunity.name)
+		self.assertTrue(opportunity.reload().has_active_quotation())
+		with self.assertRaisesRegex(frappe.ValidationError, "active Quotation exists"):
+			opportunity.declare_enquiry_lost([], [])
+		self.make_order(revision, 1).submit()
+		self.assertTrue(opportunity.reload().has_ordered_quotation())
+
+	def test_saved_transactions_reject_superseded_quotations(self):
+		for doctype in ("Sales Order", "Sales Invoice"):
+			with self.subTest(doctype=doctype):
+				source = make_quotation()
+				transaction = self.make_quotation_transaction(source, doctype)
+				fieldname = "quotation" if doctype == "Sales Invoice" else "prevdoc_docname"
+				self.assertEqual(transaction.reload().items[0].get(fieldname), source.name)
+				source.make_revision().insert().submit()
+				with self.assertRaisesRegex(frappe.ValidationError, "superseded"):
+					transaction.save()
+				with self.assertRaisesRegex(frappe.ValidationError, "superseded"):
+					transaction.reload().submit()
+				self.assertEqual(transaction.reload().docstatus, 0)
+
+	def test_submitted_transactions_block_revision_until_cancelled(self):
+		for doctype in ("Sales Order", "Sales Invoice"):
+			with self.subTest(doctype=doctype):
+				source = make_quotation()
+				revision = source.make_revision().insert()
+				transaction = self.make_quotation_transaction(source, doctype).submit()
+				self.assertRaises(frappe.ValidationError, source.reload().make_revision)
+				with self.assertRaisesRegex(frappe.ValidationError, f"submitted {doctype}"):
+					revision.submit()
+				transaction.cancel()
+				revision.reload().submit()
+				self.assertTrue(revision.is_latest_revision)
+
+	def test_credit_note_accepts_historical_quotation(self):
+		source = make_quotation()
+		invoice = make_sales_invoice(source.name).insert().submit()
+		# Historical invoices must remain returnable after their offer is superseded.
+		source.db_set("is_latest_revision", 0)
+		source.db_set("status", "Superseded")
+		credit_note = make_sales_return(invoice.name)
+		self.assertEqual(credit_note.items[0].quotation, source.name)
+		credit_note.insert().submit()
+		self.assertEqual(credit_note.docstatus, 1)
+
+	def test_existing_quotation_can_be_revised(self):
+		# Existing quotations did not run the new revision initialization hook.
+		with patch.object(Quotation, "before_insert"):
+			source = make_quotation()
+		revision = source.make_revision().insert()
+		invoice = make_sales_invoice(source.name).insert().submit()
+		with self.assertRaisesRegex(frappe.ValidationError, "submitted Sales Invoice"):
+			source.make_revision()
+		with self.assertRaisesRegex(frappe.ValidationError, "submitted Sales Invoice"):
+			revision.submit()
+
+		invoice.cancel()
+		revision.reload().submit()
+		self.assertEqual(revision.original_quotation, source.name)
+		self.assertEqual(revision.quotation_version, 1)
+		self.assertTrue(revision.is_latest_revision)
+		self.assertEqual(source.reload().status, "Superseded")
+
+	def test_amended_revision_can_become_current(self):
+		source = make_quotation()
+		revision = source.make_revision().insert().submit()
+		revision.cancel()
+		amendment = frappe.copy_doc(revision, ignore_no_copy=False)
+		amendment.docstatus = 0
+		amendment.amended_from = revision.name
+		amendment.insert().submit()
+		self.assertTrue(amendment.is_latest_revision)
+		self.assertEqual(amendment.original_quotation, source.name)
+		self.assertEqual(amendment.quotation_version, 1)
+		self.assertEqual(source.reload().status, "Superseded")
+		self.assertEqual(amendment.make_revision().insert().quotation_version, 2)
+
+	def test_revision_name_length_limits(self):
+		valid_source = make_quotation(do_not_save=True)
+		valid_source.insert(set_name="Q" * 120).submit()
+		revision = valid_source.make_revision().insert()
+		self.assertEqual(revision.name, f"{valid_source.name}-REV-1")
+		source = make_quotation(do_not_save=True)
+		source.insert(set_name="Q" * 135).submit()
+		with self.assertRaisesRegex(frappe.ValidationError, "too long"):
+			source.make_revision().insert()
+		self.assertFalse(frappe.db.exists("Quotation", {"original_quotation": source.name}))
+
+	def test_read_only_sharing_does_not_grant_create_permission(self):
+		source = make_quotation()
+		user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": "quotation-readonly@example.test",
+				"first_name": "Quotation Test",
+				"send_welcome_email": 0,
+			}
+		).insert()
+		add("Quotation", source.name, user=user.name, read=1, notify=0)
+		with self.set_user(user.name):
+			self.assertTrue(frappe.has_permission("Quotation", "read", doc=source))
+			self.assertRaises(frappe.PermissionError, source.make_revision)
+
+	def test_concurrent_creation_allocates_distinct_numbers(self):
+		self.setup_revision_requests()
+		gate = Barrier(2)
+		futures = [self.pool.submit(self.request, self.create_revision, gate) for _ in range(2)]
+		names = [future.result(timeout=30) for future in futures]
+		self.assertCountEqual(names, [f"{self.source}-REV-1", f"{self.source}-REV-2"])
+
+	def test_order_and_revision_submission_cannot_both_succeed(self):
+		self.setup_revision_requests()
+		self.check_transaction_submission("Sales Order")
+
+	def test_invoice_and_revision_submission_cannot_both_succeed(self):
+		self.setup_revision_requests()
+		self.check_transaction_submission("Sales Invoice")
+
+	@freeze_time("2026-06-01 09:00:00.123456")
+	def test_funnel_counts_family_once_through_revision_and_cancellation(self):
+		before = self.funnel_count()
+		source = self.make_opportunity_quotation()
+		revision = source.make_revision().insert()
+		self.assertEqual(self.funnel_count() - before, 1)
+		revision.submit()
+		self.assertEqual(self.funnel_count() - before, 1)
+		revision.cancel()
+		self.assertEqual(self.funnel_count() - before, 1)
+
+	@freeze_time("2026-06-01 09:00:00.123456")
+	def test_campaign_counts_current_quotation_including_original_draft(self):
+		lead = frappe.get_doc({"doctype": "Lead", "first_name": "_Test Revision Campaign"}).insert()
+		source = make_quotation(do_not_save=True, transaction_date="2026-06-01")
+		source.quotation_to = "Lead"
+		source.party_name = lead.name
+		source.insert()
+		self.assertEqual(get_lead_quotation_count([lead.name]), 1)
+		source.submit()
+		revision = source.make_revision().insert()
+		self.assertEqual(get_lead_quotation_count([lead.name]), 1)
+		revision.submit()
+		self.assertEqual(get_lead_quotation_count([lead.name]), 1)
+		revision.cancel()
+		self.assertEqual(get_lead_quotation_count([lead.name]), 1)
+
+	@freeze_time("2026-06-01 09:00:00.123456")
+	def test_trends_count_current_version_and_restore_after_cancellation(self):
+		before = self.trends_amount()
+		source = make_quotation(qty=2, rate=100, transaction_date="2026-06-01")
+		revision = self.make_revision(source)
+		self.assertEqual(self.trends_amount() - before, revision.base_net_total)
+		revision.cancel()
+		self.assertEqual(self.trends_amount() - before, source.base_net_total)
+
+	@freeze_time("2026-06-01 09:00:00.123456")
+	def test_analytics_count_current_version_in_each_dimension(self):
+		source = make_quotation(qty=2, rate=100, transaction_date="2026-06-01")
+		dimensions = (
+			("Customer", source.party_name),
+			("Item", source.items[0].item_code),
+			("Customer Group", source.customer_group),
+			("Territory", source.territory),
+			("Item Group", source.items[0].item_group),
+			("Order Type", source.order_type),
+		)
+		before = {dimension: self.analytics_amount(*dimension) for dimension in dimensions}
+		revision = self.make_revision(source)
+		for dimension in dimensions:
+			with self.subTest(dimension=dimension):
+				self.assertEqual(
+					self.analytics_amount(*dimension) - before[dimension],
+					revision.base_net_total - source.base_net_total,
+				)
+
+	@freeze_time("2026-06-01 09:00:00.123456")
+	def test_reports_preserve_versions_in_closed_periods(self):
+		before_funnel = self.funnel_count()
+		source = self.make_opportunity_quotation()
+		first = self.make_revision(source)
+		dimensions = (
+			("Customer", source.party_name),
+			("Item", source.items[0].item_code),
+			("Customer Group", source.customer_group),
+			("Territory", source.territory),
+			("Item Group", source.items[0].item_group),
+			("Order Type", source.order_type),
+		)
+		before_analytics = {dimension: self.analytics_amount(*dimension) for dimension in dimensions}
+		before_months = self.analytics_amount("Customer", source.party_name, to_date="2026-07-31")
+		before_june = self.trends_amount(period="Monthly", column="Jun (Amt)")
+		before_july = self.trends_amount(period="Monthly", column="Jul (Amt)")
+		with freeze_time("2026-07-01 09:00:00.123456"):
+			later = self.make_revision(first)
+		self.assertEqual(self.funnel_count() - before_funnel, 1)
+		self.assertEqual(self.trends_amount(period="Monthly", column="Jun (Amt)"), before_june)
+		self.assertEqual(
+			self.trends_amount(period="Monthly", column="Jul (Amt)") - before_july, later.base_net_total
+		)
+		for dimension in dimensions:
+			with self.subTest(dimension=dimension):
+				self.assertEqual(self.analytics_amount(*dimension), before_analytics[dimension])
+		self.assertEqual(
+			self.analytics_amount("Customer", source.party_name, to_date="2026-07-31") - before_months,
+			later.base_net_total,
+		)
+		before_year = self.trends_amount()
+		with freeze_time("2027-01-01 09:00:00.123456"):
+			self.make_revision(later)
+		self.assertEqual(self.trends_amount(), before_year)
+
+	@freeze_time("2026-06-01 09:00:00.123456")
+	def test_territory_counts_current_offers_and_preserves_historical_orders(self):
+		before_orders = self.territory_amount("order_amount")
+		before_quotations = self.territory_amount("quotation_amount")
+		source = self.make_opportunity_quotation()
+		revision = self.make_revision(source)
+		self.assertEqual(
+			self.territory_amount("quotation_amount") - before_quotations, revision.base_grand_total
+		)
+		order = make_sales_order(revision.name)
+		order.transaction_date = revision.transaction_date
+		order.delivery_date = "2026-06-02"
+		order.insert().submit()
+		# Earlier versions allowed orders against several revisions of the same quotation.
+		revision.db_set("is_latest_revision", 0)
+		self.assertEqual(self.territory_amount("quotation_amount"), before_quotations)
+		self.assertEqual(self.territory_amount("order_amount") - before_orders, order.base_grand_total)
+
+	@staticmethod
+	def update_items_payload(quotation):
+		return [
+			{
+				"docname": row.name,
+				"item_code": row.item_code,
+				"qty": row.qty,
+				"rate": row.rate,
+				"description": row.description,
+				"uom": row.uom,
+				"conversion_factor": row.conversion_factor,
+			}
+			for row in quotation.items
+		]
+
+	@staticmethod
+	def make_order(source, quantity):
+		order = make_sales_order(source.name)
+		order.delivery_date = add_days(nowdate(), 5)
+		for item in order.items:
+			item.delivery_date = order.delivery_date
+			item.qty = quantity
+		return order.insert()
+
+	def setup_revision_requests(self):
+		self.site = frappe.local.site
+		self.sites_path = frappe.local.sites_path
+		self.pool = ThreadPoolExecutor(max_workers=2)
+		self.addCleanup(self.pool.shutdown)
+		self.source = self.pool.submit(self.request, self.create_source).result(timeout=30)
+		self.addCleanup(self.cleanup_source)
+
+	def check_transaction_submission(self, doctype):
+		revision = self.pool.submit(self.request, self.create_revision).result(timeout=30)
+		create_transaction = self.create_order if doctype == "Sales Order" else self.create_invoice
+		transaction = self.pool.submit(self.request, create_transaction).result(timeout=30)
+		gate = Barrier(2)
+		futures = [
+			self.pool.submit(self.request, self.submit_document, doctype, name, gate)
+			for doctype, name in (("Quotation", revision), (doctype, transaction))
+		]
+		results = [future.result(timeout=30) for future in futures]
+		self.assertCountEqual(results, ["submitted", "rejected"])
+
+	def request(self, action, *args):
+		frappe.init(site=self.site, sites_path=self.sites_path)
+		frappe.connect()
+		frappe.set_user("Administrator")
+		frappe.flags.mute_emails = True
+		try:
+			result = action(*args)
+			# Separate committed requests are required to exercise actual database locks.
+			frappe.db.commit()  # nosemgrep: frappe-manual-commit, Dont-commit
+			return result
+		except Exception:
+			frappe.db.rollback()
+			raise
+		finally:
+			frappe.destroy()
+
+	def create_source(self):
+		source = make_quotation(do_not_save=True)
+		source.insert(set_name=f"_Test Quotation {self._testMethodName}").submit()
+		return source.name
+
+	def create_revision(self, gate=None):
+		if gate:
+			gate.wait(timeout=15)
+		return frappe.get_doc("Quotation", self.source).make_revision().insert().name
+
+	def create_order(self):
+		return self.make_order(frappe.get_doc("Quotation", self.source), 10).name
+
+	def create_invoice(self):
+		return make_sales_invoice(self.source).insert().name
+
+	@staticmethod
+	def submit_document(doctype, name, gate):
+		doc = frappe.get_doc(doctype, name)
+		gate.wait(timeout=15)
+		try:
+			doc.submit()
+			return "submitted"
+		except frappe.ValidationError:
+			frappe.db.rollback()
+			return "rejected"
+
+	def cleanup_source(self):
+		frappe.db.rollback()
+		self.pool.submit(self.request, self.delete_source).result(timeout=30)
+
+	def delete_source(self):
+		for doctype, fieldname in (("Sales Invoice", "quotation"), ("Sales Order", "prevdoc_docname")):
+			for name in frappe.get_all(f"{doctype} Item", filters={fieldname: self.source}, pluck="parent"):
+				transaction = frappe.get_doc(doctype, name)
+				if transaction.docstatus == 1:
+					transaction.cancel()
+				transaction.delete()
+		for name in frappe.get_all(
+			"Quotation",
+			filters={"original_quotation": self.source},
+			pluck="name",
+			order_by="quotation_version desc",
+		):
+			revision = frappe.get_doc("Quotation", name)
+			if revision.docstatus == 1:
+				revision.cancel()
+			revision.delete()
+		source = frappe.get_doc("Quotation", self.source)
+		source.cancel()
+		source.delete()
+		frappe.db.delete("Series", {"name": f"{self.source}-REV-"})
+
+	@staticmethod
+	def make_revision(source):
+		revision = source.make_revision()
+		revision.items[0].qty = 3
+		revision.items[0].rate = 150
+		return revision.insert().submit()
+
+	@staticmethod
+	def funnel_count():
+		return next(
+			row["value"]
+			for row in get_funnel_data("2026-06-01", "2026-06-30", "_Test Company")
+			if row["title"] == "Quotations"
+		)
+
+	@staticmethod
+	def trends_amount(period="Yearly", column="Total(Amt)"):
+		columns, rows, *_ = quotation_trends(
+			frappe._dict(
+				company="_Test Company",
+				fiscal_year="_Test Fiscal Year 2026",
+				based_on="Item",
+				period=period,
+			)
+		)
+		labels = [column.split(":")[0] if isinstance(column, str) else column["label"] for column in columns]
+		return next((row[labels.index(column)] or 0 for row in rows if row[0] == "_Test Item"), 0)
+
+	@staticmethod
+	def analytics_amount(tree_type, entity, to_date="2026-06-30"):
+		_, rows, *_ = sales_analytics(
+			{
+				"doc_type": "Quotation",
+				"tree_type": tree_type,
+				"entity": [entity],
+				"value_quantity": "Value",
+				"range": "Monthly",
+				"company": "_Test Company",
+				"from_date": "2026-06-01",
+				"to_date": to_date,
+				"curves": "all",
+			}
+		)
+		return next((row["total"] for row in rows if row["entity"] == entity), 0)
+
+	@staticmethod
+	def territory_amount(field):
+		_, rows = territory_sales(frappe._dict(company="_Test Company"))
+		return next(row[field] for row in rows if row["territory"] == "_Test Territory")
+
+	@staticmethod
+	def make_opportunity_quotation():
+		opportunity = frappe.get_doc(
+			{
+				"doctype": "Opportunity",
+				"opportunity_from": "Customer",
+				"party_name": "_Test Customer",
+				"territory": "_Test Territory",
+				"company": "_Test Company",
+				"currency": "INR",
+				"opportunity_amount": 5000,
+				"transaction_date": "2026-06-01",
+			}
+		).insert()
+		source = make_quotation(qty=2, rate=100, transaction_date="2026-06-01", do_not_save=True)
+		source.opportunity = opportunity.name
+		return source.insert().submit()
+
+	def make_quotation_transaction(self, source, doctype):
+		if doctype == "Sales Order":
+			return self.make_order(source, 4)
+		return make_sales_invoice(source.name).insert()
 
 
 def enable_calculate_bundle_price(enable=1):

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1257,7 +1257,8 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						get_query_filters: {
 							company: me.frm.doc.company,
 							docstatus: 1,
-							status: ["not in", ["Lost", "Ordered"]],
+							is_latest_revision: 1,
+							status: ["not in", ["Lost", "Ordered", "Superseded"]],
 						},
 						allow_child_item_selection: true,
 						child_fieldname: "items",

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -8,6 +8,7 @@ from typing import Literal
 import frappe
 import frappe.utils
 from frappe import _, qb
+from frappe.model.base_document import get_controller
 from frappe.model.document import Document
 from frappe.query_builder import Case
 from frappe.query_builder.functions import Abs, Sum
@@ -199,6 +200,10 @@ class SalesOrder(SellingController):
 		utm_medium: DF.Link | None
 		utm_source: DF.Link | None
 	# end: auto-generated types
+
+	def save(self, *args, **kwargs):
+		get_controller("Quotation").lock_quotation_references(self)
+		return super().save(*args, **kwargs)
 
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
@@ -476,6 +481,7 @@ class SalesOrder(SellingController):
 				)
 
 	def validate_with_previous_doc(self):
+		get_controller("Quotation").validate_quotation_references(self)
 		super().validate_with_previous_doc(
 			{
 				"Quotation": {"ref_dn_field": "prevdoc_docname", "compare_fields": [["company", "="]]},

--- a/erpnext/selling/page/sales_funnel/sales_funnel.py
+++ b/erpnext/selling/page/sales_funnel/sales_funnel.py
@@ -5,6 +5,7 @@ from itertools import groupby
 
 import frappe
 from frappe import _
+from frappe.model.base_document import get_controller
 from frappe.query_builder.functions import Count, Date
 from frappe.utils import flt
 
@@ -51,6 +52,7 @@ def get_funnel_data(from_date: str, to_date: str, company: str):
 		.select(Count("*"))
 		.where(
 			(quotation.docstatus == 1)
+			& get_controller("Quotation").get_report_revision_condition(quotation, [to_date], "creation")
 			& Date(quotation.creation).between(from_date, to_date)
 			& ((quotation.opportunity != "") | (quotation.quotation_to == "Lead"))
 			& (quotation.company == company)

--- a/erpnext/selling/report/lost_quotations/lost_quotations.py
+++ b/erpnext/selling/report/lost_quotations/lost_quotations.py
@@ -68,6 +68,7 @@ def get_data(company: str, from_date: str, to_date: str, group_by: Literal["Lost
 
 	lost_quotation_condition = (
 		(q.status == "Lost")
+		& (q.is_latest_revision == 1)
 		& (q.docstatus == DocStatus.submitted())
 		& (q.transaction_date >= from_date)
 		& (q.transaction_date <= to_date)

--- a/erpnext/selling/report/sales_analytics/sales_analytics.py
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.py
@@ -4,6 +4,7 @@
 
 import frappe
 from frappe import _, scrub
+from frappe.model.base_document import get_controller
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import IfNull
 from frappe.utils import add_days, add_to_date, flt, getdate
@@ -193,15 +194,26 @@ class Analytics:
 			self.get_sales_transactions_based_on_project()
 			self.get_rows()
 
+	def get_transaction_filters(self):
+		filters = {
+			"docstatus": 1,
+			"company": ["in", self.filters.company],
+			self.date_field: ("between", [self.filters.from_date, self.filters.to_date]),
+		}
+		if self.filters.doc_type == "Quotation":
+			return [
+				filters,
+				get_controller("Quotation").get_report_revision_condition(
+					DocType("Quotation"), self.periodic_daterange
+				),
+			]
+		return filters
+
 	def _get_permitted_parent_names(self):
 		return frappe.qb.get_query(
 			table=self.filters.doc_type,
 			fields=["name"],
-			filters={
-				"docstatus": 1,
-				"company": ["in", self.filters.company],
-				self.date_field: ("between", [self.filters.from_date, self.filters.to_date]),
-			},
+			filters=self.get_transaction_filters(),
 			ignore_permissions=False,
 		).run(pluck="name")
 
@@ -256,11 +268,7 @@ class Analytics:
 				entity_name = "party_name as entity_name"
 				value_field = "base_paid_amount as value_field"
 
-		filters = {
-			"docstatus": 1,
-			"company": ["in", self.filters.company],
-			self.date_field: ("between", [self.filters.from_date, self.filters.to_date]),
-		}
+		filters = self.get_transaction_filters()
 
 		if self.filters.doc_type in ["Sales Invoice", "Purchase Invoice", "Payment Entry"]:
 			filters.update({"is_opening": "No"})
@@ -323,11 +331,7 @@ class Analytics:
 		else:
 			entity_field = "territory as entity"
 
-		filters = {
-			"docstatus": 1,
-			"company": ["in", self.filters.company],
-			self.date_field: ("between", [self.filters.from_date, self.filters.to_date]),
-		}
+		filters = self.get_transaction_filters()
 
 		if self.filters.doc_type in ["Sales Invoice", "Purchase Invoice", "Payment Entry"]:
 			filters.update({"is_opening": "No"})

--- a/erpnext/selling/report/territory_wise_sales/territory_wise_sales.py
+++ b/erpnext/selling/report/territory_wise_sales/territory_wise_sales.py
@@ -94,7 +94,7 @@ def get_data(filters=None):
 		territory_data = {
 			"territory": territory.name,
 			"opportunity_amount": _get_total(territory_opportunities, "opportunity_amount"),
-			"quotation_amount": _get_total(territory_quotations),
+			"quotation_amount": _get_total([q for q in territory_quotations if q.is_latest_revision]),
 			"order_amount": _get_total(territory_orders),
 			"billing_amount": _get_total(territory_invoices),
 		}
@@ -128,7 +128,7 @@ def get_quotations(opportunities):
 
 	return frappe.get_all(
 		"Quotation",
-		fields=["name", "base_grand_total", "opportunity"],
+		fields=["name", "base_grand_total", "opportunity", "is_latest_revision"],
 		filters={"docstatus": 1, "opportunity": ["in", opportunity_names]},
 	)
 


### PR DESCRIPTION
### Issue

Sales teams need to preserve quotation offers during negotiation and track commercial changes within each offer.

Closes #52963 ,  #57319

**After:**

[Screencast from 2026-09-10 17-48-57.webm](https://github.com/user-attachments/assets/f4f2ed50-b84b-4c7a-987a-fb861974b21a)


### Fixes

- Add Create → Revision and View → Revisions, with Original Quotation, Revised From, and Quotation Version fields. Revisions use sequential names under the original quotation, including when revising an existing revision.
- Add Quote Revision Count for saves that change tracked commercial details, including supported Update Items operations. Preserve change history and exclude initial saves, unchanged saves, and ordinary item reordering.
- Add Current Version and Superseded status. Keep the submitted source current while its revision is a draft, switch the current version on submission, and restore the previous submitted version when the current revision is cancelled.
- Validate revision lineage, party, company, and transaction references. Prevent older drafts from replacing newer submitted revisions and prevent save payloads from overriding revision protection or change-counting rules.
- Reject superseded quotations when creating or saving Sales Orders and directly mapped Sales Invoices. Block revisions while the quotation family has submitted orders or directly linked invoices, and coordinate concurrent submissions through a shared lock.
- Preserve Opportunity references, payment schedules, and credit-note quotation references. Shift validity, payment due dates, and discount dates relative to the new quotation date.
- Update quotation selection and status filters. Count current versions in Quotation Trends, Sales Analytics, Territory Wise Sales, Lost Quotations, Sales Funnel, and Campaign Efficiency, while retaining historical order totals.
- Handle long quotation names and concurrent revision-number allocation.


### Covered DocTypes

The feature covers Quotation revisions and their related records:

| DocType | Coverage |
| --- | --- |
| Quotation | Revision creation, version numbers, commercial revision counts, current-version tracking, statuses, and cancellation handling. |
| Quotation Item | Track commercial item changes, preserve Opportunity references, and support eligible Update Items operations. |
| Sales Order and Sales Order Item | Validate source quotation references, reject superseded offers, and block revisions when submitted orders exist. |
| Sales Invoice and Sales Invoice Item | Store references for directly mapped quotations, validate the current version, block revisions with submitted invoices, and preserve references on credit notes. |
| Opportunity | Preserve quotation links and exclude superseded offers from active-quotation checks. |
| Lead | Exclude superseded offers when checking whether a lead has an active quotation. |
| Payment Schedule | Copy quotation payment schedules, adjust due and discount dates, and count tracked payment-term changes. |
| Sales Taxes and Charges | Include tracked quotation tax changes in the commercial revision count. |
| Version | Record quotation change history through the existing document-version mechanism. |

### Actual behaviour

- A separate quotation offer requires cancellation and amendment, or duplication with an unrelated quotation number.
- Commercial edits do not automatically maintain a Quote Revision Count.
- Related offers have no shared current-version tracking, so choosing the latest offer and excluding older copies from report totals requires manual handling.

### Expected behaviour

- Users can create linked quotation revisions while preserving earlier offers.
- Each revision has a version number, and commercial changes are counted automatically.
- Only eligible quotations can be revised, and new transactions use the current version.
- Cancelling the current revision restores the previous valid version.
- Revision history, related records, payment terms, and report totals remain consistent.

No-docs