### PR TITLE
fix(asset): recompute reference doc reqd on asset type change

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -571,6 +571,7 @@ frappe.ui.form.on("Asset", {
 				frm.set_df_property("net_purchase_amount", "read_only", 0);
 			}
 		}
+		frm.trigger("toggle_reference_doc");
 	},
 
 	create_asset_maintenance: function (frm) {


### PR DESCRIPTION
### Problem

On an Asset, selecting an asset type (e.g. "Existing Asset") did not clear the mandatory flags on `purchase_receipt` / `purchase_invoice`. The first save threw a mandatory error; the second save went through (the fields are hidden by `depends_on`, so the second mandatory check skips them).

### Cause

The refactor that replaced the asset-type checkboxes with a select box (`87a7bc6f49`) merged the `is_existing_asset` and `is_composite_asset` handlers into one `asset_type` handler, but dropped the `frm.trigger("toggle_reference_doc")` the old `is_composite_asset` handler had. `toggle_reference_doc` is what recomputes the reqd/read-only state of the reference fields.

### Fix

Call `toggle_reference_doc` at the end of the `asset_type` handler, matching `develop`.