### PR TITLE
fix(assets): round booked depreciation months for period-aligned assets

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -3726,7 +3726,7 @@ class TestSalesInvoice(ERPNextTestSuite):
 		)
 		asset.load_from_db()
 
-		expected_values = [["2020-12-31", 30000, 30000], ["2021-12-31", 30041.15, 60041.15]]
+		expected_values = [["2020-12-31", 30000, 30000], ["2021-12-31", 30000, 60000]]
 
 		for i, schedule in enumerate(get_depr_schedule(asset.name, "Active")):
 			self.assertEqual(getdate(expected_values[i][0]), schedule.schedule_date)

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -249,7 +249,7 @@ class TestAsset(AssetSetup):
 			asset.precision("net_purchase_amount"),
 		)
 
-		second_asset_depr_schedule.depreciation_amount = 9006.17
+		second_asset_depr_schedule.depreciation_amount = 9000.0
 		second_asset_depr_schedule.asset_doc = asset
 		second_asset_depr_schedule.get_finance_book_row()
 		second_asset_depr_schedule.fetch_asset_details()

--- a/erpnext/assets/doctype/asset_depreciation_schedule/deppreciation_schedule_controller.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/deppreciation_schedule_controller.py
@@ -242,11 +242,17 @@ class DepreciationScheduleController(StraightLineMethod, WDVMethod):
 			computed_available_for_use_date = add_days(
 				add_months(self.fb_row.depreciation_start_date, -1 * asset_used_for_months), 1
 			)
-			if getdate(computed_available_for_use_date) < getdate(self.asset_doc.available_for_use_date):
+			asset_available_mid_period = getdate(computed_available_for_use_date) < getdate(
+				self.asset_doc.available_for_use_date
+			)
+			if asset_available_mid_period:
 				computed_available_for_use_date = self.asset_doc.available_for_use_date
 			depr_booked_for_months = (date_diff(last_depr_date, computed_available_for_use_date) + 1) / (
 				365 / 12
 			)
+			if not asset_available_mid_period:
+				frequency = cint(self.fb_row.frequency_of_depreciation)
+				depr_booked_for_months = round(depr_booked_for_months / frequency) * frequency
 		return depr_booked_for_months
 
 	def get_total_pending_days_or_years(self):

--- a/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
@@ -188,6 +188,24 @@ class TestAssetDepreciationSchedule(ERPNextTestSuite):
 		]
 		self.assertEqual(schedules, expected_schedules)
 
+	def test_schedule_slm_for_period_aligned_existing_asset(self):
+		asset = create_asset(
+			calculate_depreciation=1,
+			depreciation_method="Straight Line",
+			available_for_use_date="2023-01-31",
+			asset_type="Existing Asset",
+			opening_number_of_booked_depreciations=1,
+			opening_accumulated_depreciation=1000,
+			depreciation_start_date="2023-03-31",
+			total_number_of_depreciations=12,
+			frequency_of_depreciation=1,
+			net_purchase_amount=12000,
+		)
+
+		amounts = [d.depreciation_amount for d in get_depr_schedule(asset.name, "Draft")]
+
+		self.assertEqual(amounts, [1000.0] * 11)
+
 	# Enable Checkbox to Calculate depreciation using total days in depreciation period
 	def test_daily_prorata_based_depr_after_enabling_configuration(self):
 		frappe.db.set_single_value("Accounts Settings", "calculate_depr_using_total_days", 1)


### PR DESCRIPTION
Booked months were derived from days via a `365/12` approximation, so a whole booked month became a fraction and skewed straight-line amounts. Round it to a whole number unless the asset is genuinely pro-rata.

Fixes #48117
Fixes #50701