### PR TITLE
fix(stock): calculate batch bundle valuation per unit

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
@@ -1176,6 +1176,67 @@ class TestSerialandBatchBundle(ERPNextTestSuite):
 		self.assertEqual(bundle_doc.docstatus, 0)
 		self.assertRaises(frappe.ValidationError, bundle_doc.submit)
 
+	@ERPNextTestSuite.change_settings("Stock Settings", {"do_not_use_batchwise_valuation": 0})
+	def test_amended_material_receipt_rate_after_batch_selection(self):
+		warehouse = "_Test Warehouse - _TC"
+		for valuation_method in ("FIFO", "Moving Average"):
+			with self.subTest(valuation_method=valuation_method):
+				item = make_item(
+					properties={
+						"is_stock_item": 1,
+						"has_batch_no": 1,
+						"stock_uom": "Nos",
+						"valuation_method": valuation_method,
+					}
+				)
+				batches = [
+					frappe.get_doc(
+						{"doctype": "Batch", "item": item.name, "batch_id": f"{item.name}-{index}"}
+					)
+					.insert()
+					.name
+					for index in range(2)
+				]
+				for index, (batch, qty) in enumerate(((batches[0], 10), (batches[1], 10), (batches[0], 5))):
+					receipt = make_stock_entry(
+						item_code=item.name,
+						company="_Test Company",
+						to_warehouse=warehouse,
+						qty=qty,
+						rate=10,
+						batch_no=batch,
+						posting_date=add_days(today(), index - 2),
+						posting_time="10:00:00",
+					)
+
+				receipt.cancel()
+				amended = frappe.copy_doc(receipt, ignore_no_copy=False)
+				amended.amended_from = receipt.name
+				amended.docstatus = 0
+				row = amended.items[0]
+				row.batch_no = None
+				row.serial_and_batch_bundle = None
+				row.use_serial_batch_fields = 0
+
+				# The selector returns an unpriced bundle and copies its rate to the receipt row.
+				bundle = add_serial_batch_ledgers(
+					[{"batch_no": batches[1], "qty": 5}],
+					row.as_dict(),
+					amended.as_dict(),
+					warehouse,
+				)
+				row.serial_and_batch_bundle = bundle.name
+				row.basic_rate = bundle.avg_rate
+				amended.insert()
+				self.assertEqual(row.basic_rate, 10)
+				self.assertEqual(row.basic_amount, 50)
+
+				amended.submit()
+				ledger = frappe.get_doc("Stock Ledger Entry", {"voucher_no": amended.name, "is_cancelled": 0})
+				self.assertEqual(ledger.incoming_rate, 10)
+				self.assertEqual(ledger.stock_value_difference, 50)
+				self.assertEqual(ledger.stock_value, 250)
+
 	def test_reference_voucher_on_cancel(self):
 		"""
 		When a source document is cancelled, the reference voucher field

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -2195,16 +2195,20 @@ def get_valuation_rate(
 
 	# Get moving average rate of a specific batch number
 	if warehouse and serial_and_batch_bundle:
+		bundle = frappe.get_value(
+			"Serial and Batch Bundle",
+			serial_and_batch_bundle,
+			["total_qty", "posting_datetime"],
+			as_dict=True,
+		)
 		batch_obj = BatchNoValuation(
 			sle=frappe._dict(
 				{
 					"item_code": item_code,
 					"warehouse": warehouse,
-					"actual_qty": -1,
+					"actual_qty": -abs(flt(bundle.total_qty)),
 					"serial_and_batch_bundle": serial_and_batch_bundle,
-					"posting_datetime": frappe.get_value(
-						"Serial and Batch Bundle", serial_and_batch_bundle, "posting_datetime"
-					),
+					"posting_datetime": bundle.posting_datetime,
 				}
 			)
 		)


### PR DESCRIPTION
  ### Issue

  Fixes #58960

  Changing the batch through the Serial and Batch selector on an amended Material Receipt can inflate the unit rate. The valuation calculation divides the
  bundle value by one instead of the bundle’s actual quantity.

  ### Steps to reproduce

  1. Create a stock item with batch tracking and batch-wise valuation enabled.
  2. Create batches A and B.
  3. Submit three Material Receipts into the same warehouse:
     - Batch A: 10 units at ₹10.
     - Batch B: 10 units at ₹10.
     - Batch A: 5 units at ₹10.
  4. Cancel and amend the third receipt.
  5. Use the Serial and Batch selector to change the batch to B, keeping quantity at 5.
  6. Save and submit the amended receipt.

**Before:**


[Screencast from 2026-09-11 11-44-34.webm](https://github.com/user-attachments/assets/7b375242-58fe-4f02-9927-3c6cf2fc2b0d)


**After:**

[Screencast from 2026-09-11 11-47-59.webm](https://github.com/user-attachments/assets/36696138-3b54-4893-800a-04f244b2d65b)


  ### Actual behaviour

  The unit rate becomes ₹50, making the amended receipt’s value ₹250.

  ### Expected behaviour

  The unit rate remains ₹10 and the receipt value remains ₹50.

  Calculate the unit rate using the bundle’s actual quantity. The amendment regression test passes with FIFO and Moving Average valuation.

  ### Backport needed  for v15 and v16