### PR TITLE
fix: prevent disabled items from being used in BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -902,6 +902,19 @@ class BOM(WebsiteGenerator):
 				)
 			)
 
+		bom_items = {self.item, *items}
+		bom_items.update(d.item_code for d in self.get("secondary_items"))
+		bom_items.update(d.finished_good for d in self.get("operations") if d.finished_good)
+
+		if disabled_items := frappe.db.get_all(
+			"Item", filters={"item_code": ("in", list(bom_items)), "disabled": 1}, pluck="name"
+		):
+			frappe.throw(
+				_("Disabled Item {0} cannot be used in BOMs.").format(
+					", ".join(get_link_to_form("Item", item) for item in disabled_items)
+				)
+			)
+
 	def check_recursion(self):
 		"""Check whether recursion occurs in any bom"""
 		bom_list = self.traverse_tree()


### PR DESCRIPTION
### Issue

A BOM can still contain a disabled Item if the row arrives via copy / amend (e.g. creating a new version from a cancelled BOM), and such a BOM can be saved and submitted. The Item link search filters out disabled items, so the same Item cannot be selected manually — the validation is inconsistent.

Fixes #58985

### Steps to reproduce

1. Create and submit a BOM with an Item as a raw-material component.
2. Disable that Item in the Item master.
3. Cancel the BOM and create a new version from it.
4. The copied row still holds the disabled Item, and the BOM saves and submits.
5. Remove the row and search the Item in the link field — it no longer appears.

**After:**

[after bom.webm](https://github.com/user-attachments/assets/687eafb4-abeb-45f8-864e-c0e9ae95915a)


### Actual behaviour

A BOM containing a disabled Item can be saved and submitted when the row is copied/amended, while the same Item cannot be picked through link search.

### Expected behaviour

BOM validation should reject disabled items consistently, regardless of how the row was added — the same way fixed-asset items are already rejected in validate_materials.

**Backport needed for v15 and v16**