### PR TITLE
test(accounts): expect a naming rule counter per resolved prefix

### DIFF
--- a/erpnext/controllers/tests/test_accounts_controller.py
+++ b/erpnext/controllers/tests/test_accounts_controller.py
@@ -2410,4 +2410,10 @@ class TestAccountsController(ERPNextTestSuite):
 		si.set_posting_time = 1
 		si.posting_date = "2026-01-01"
 		si.save()
+		self.assertEqual(si.name, "SI-01-2026-00001")
+
+		si = create_sales_invoice(do_not_save=True)
+		si.set_posting_time = 1
+		si.posting_date = "2026-01-15"
+		si.save()
 		self.assertEqual(si.name, "SI-01-2026-00002")


### PR DESCRIPTION
Unblocks `develop`. Every erpnext PR is failing `test_document_naming_rule_based_on_posting_date` since frappe/frappe#42690 merged this morning.

### Why it broke

That PR moved Document Naming Rule counters off a single field on the rule and onto a counter per resolved prefix in `tabSeries`, so a prefix carrying `.MM.` / `.YYYY.` restarts when the period changes. That was the point of it — frappe/frappe#35587.

This test asserted the old behaviour:

```python
si.posting_date = "2025-12-31"  ->  SI-12-2025-00001
si.posting_date = "2026-01-01"  ->  SI-01-2026-00002   # counter carried across the year
```

The second invoice now gets `SI-01-2026-00001`.

### Change

Expect `00001` for the new year, and add a third invoice on `2026-01-15` so the test pins both halves of the behaviour: a new period restarts, the period in hand advances.

The test's own subject is unchanged — it still checks that `use_posting_datetime_for_naming_documents` drives the date parts from `posting_date` rather than today. The counter value was incidental to that and is now meaningful.

Verified locally against frappe at the merged commit.