### PR TITLE
fix(stock): keep entered rate when batch bundle has no rate

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -1653,14 +1653,22 @@ erpnext.stock.select_batch_and_serial_no = (frm, item) => {
 
 			new erpnext.SerialBatchPackageSelector(frm, item, (r) => {
 				if (r) {
-					frappe.model.set_value(item.doctype, item.name, {
+					let update_values = {
 						serial_and_batch_bundle: r.name,
 						use_serial_batch_fields: 0,
-						basic_rate: r.avg_rate,
 						qty:
 							Math.abs(r.total_qty) /
 							flt(item.conversion_factor || 1, precision("conversion_factor", item)),
-					});
+					};
+
+					let is_rate_derived_from_bundle =
+						item.type_of_transaction === "Outward" || flt(r.avg_rate) !== 0;
+
+					if (is_rate_derived_from_bundle) {
+						update_values.basic_rate = r.avg_rate;
+					}
+
+					frappe.model.set_value(item.doctype, item.name, update_values);
 				}
 			});
 		}

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/mihirkandoi/pilot/benches/postgres/apps/erpnext/node_modules


### PR DESCRIPTION
Found while reviewing #58994.

### Issue

`erpnext.stock.select_batch_and_serial_no` copies the bundle's `avg_rate` into `basic_rate` unconditionally. An inward bundle has no rate of its own unless the user enters one in the dialog, so `avg_rate` is `0` and the rate the user typed is lost. The server then re-derives it from the batch's existing valuation.

### Steps to reproduce

1. Batch-tracked item with batchwise valuation.
2. Receive 10 units at ₹10 into batch A.
3. New Material Receipt for 5 units at ₹12; turn off `Use Serial No / Batch Fields` and pick batch A through the Serial and Batch selector.
4. Save.

**Actual:** rate ₹10, amount ₹50 — the receipt is booked at the batch's existing valuation instead of the entered cost.
**Expected:** rate ₹12, amount ₹60.

### Fix

Copy the bundle rate only when it means something: outward rows, where the rate comes from valuation anyway, or a bundle that carries a rate. Verified end to end — rate ₹12, SLE `incoming_rate` 12, `stock_value_difference` 60, and the bundle entries pick up 12 on submit, so the ledger matches the form.

Purchase Receipt is unaffected: `buying.js` never copies `avg_rate` into the row rate. `sales_common.js` does, but only for outward rows, where it is correct.

No test — the behaviour lives in the selector callback and there is no JS test harness for it in this repo.
