### PR TITLE
fix: self-referential Link fields show the wrong linked record's title

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -1233,6 +1233,10 @@ frappe.form.link_formatters["Project"] = function (value, doc, df) {
  * @returns {string} - The link value with the added title.
  */
 function add_link_title(value, doc, df, title_field) {
+	// self-link to another row (e.g. Employee.reports_to): doc[title_field] is this row's title, not the target's
+	if (df.options && df.options === df.parent && value !== doc.name) {
+		return value;
+	}
 	if (value && doc[title_field]) {
 		if (doc[title_field] !== value && doc[df.fieldname] === value) {
 			return value + ": " + doc[title_field];


### PR DESCRIPTION
## Problem
- Any self-referential Link field (target doctype == parent doctype, e.g. `Employee.reports_to`) showed the **wrong** decorated title in report views.
- Example: Employee `HR-EMP-00001` reporting to `HR-EMP-00010` rendered as `HR-EMP-00010: <HR-EMP-00001's own name>` instead of the manager's name.
<img width="2566" height="902" alt="image" src="https://github.com/user-attachments/assets/b4acba89-edfc-4e8d-9a23-867d1512a1c5" />

**Root Cause**
- `add_link_title()` decorates a Link value with `doc[title_field]`, assuming that field always describes the *linked* row.
- For a self-referential link, `doc[title_field]` is the *current* row's own title, the row data has no way to carry the target's title.

### Fix
- When the link's target doctype equals its parent doctype (self-referential) and the value doesn't point at the row itself, skip the decoration and return the plain id.
- Matches existing behavior for any other Link whose title isn't present in the row.
<img width="2566" height="882" alt="image" src="https://github.com/user-attachments/assets/553f5a42-e91a-424f-9d0e-8538baaacc3f" />



> [!NOTE]
> Getting the manager's *actual* title still requires a lookup, not something the row data offers, enabling "**Show Title in Link Fields**" on the doctype already does this via an async fetch. This PR only removes the incorrect guess.

`no-docs`