### PR TITLE
fix(selling): list billable sales orders oldest first

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1035,7 +1035,7 @@ def get_potentially_billable_sales_orders(
 
 	query = frappe.qb.get_query(
 		so,
-		fields=[so.name, so.customer, so.transaction_date],
+		fields=[so.name, so.customer, so.transaction_date, so.creation],
 		filters=filters,
 		or_filters=or_filters,
 		ignore_permissions=False,
@@ -1048,7 +1048,8 @@ def get_potentially_billable_sales_orders(
 		.on(item.name == so_item.item_code)
 		.where(get_potentially_billable_item_criterion(so, so_item, item))
 		.distinct()
-		.orderby(so.transaction_date, order=Order.desc)
+		.orderby(so.transaction_date, order=Order.asc)
+		.orderby(so.creation, order=Order.asc)
 		.limit(cint(page_len))
 		.offset(cint(start))
 		.run(as_dict=True)


### PR DESCRIPTION
Closes #59003 (ordering half). Replaces #59009, which could not be reopened after a force-push orphaned its head commit.

The Sales Invoice "Get Items From > Sales Order" picker used to come back ordered by name ascending: `frappe.desk.search.search_widget` re-sorts every page in Python with `relevance_sorter`, and with an empty search term that key is the name alone. #58751 pointed the picker at `get_potentially_billable_sales_orders`, which moves the flow onto the custom-query branch — that branch skips the re-sort, so the query's own `ORDER BY transaction_date DESC` reached the user. Orders sharing a transaction date had no tiebreak either, so their relative order fell out of the `DISTINCT` dedup.

The picker order is also the order rows land in the invoice: `map_docs` iterates `source_names`, and `MultiSelectDialog` builds that list from the rendered rows.

Now ordered by transaction date ascending, oldest first, with `creation` as the tiebreak. Note this is not a straight revert to the old order: a backdated order now sorts by its order date rather than by when it was entered.

Two things worth flagging for review:

- PostgreSQL rejects an `ORDER BY` expression a `SELECT DISTINCT` does not select (`for SELECT DISTINCT, ORDER BY expressions must appear in select list`), so `creation` joins the selected fields. MariaDB accepts it either way.
- Selecting an extra field changes nothing in the dialog: `MultiSelectDialog.get_datatable_columns()` builds the columns from `name` plus the setters, not from the query.

The slowness reported in #59003 is untouched; I could not trace it to a regression in this window.

Needs a backport to version-16-hotfix; v16.34.2 ships the regression.