### PR TITLE
fix(support): stop the SLA link filter patches from aborting migrate on PostgreSQL

### DIFF
--- a/erpnext/patches/v15_0/backfill_sla_link_filters_on_custom_field.py
+++ b/erpnext/patches/v15_0/backfill_sla_link_filters_on_custom_field.py
@@ -8,10 +8,12 @@ def execute():
 			"fieldname": "service_level_agreement",
 			"fieldtype": "Link",
 			"options": "Service Level Agreement",
-			"link_filters": ("is", "not set"),
 		},
-		fields=["name", "dt"],
+		fields=["name", "dt", "link_filters"],
 	):
+		if custom_field.link_filters:
+			continue
+
 		link_filters = frappe.as_json(
 			[["Service Level Agreement", "document_type", "=", custom_field.dt]], indent=None
 		)

--- a/erpnext/patches/v15_0/backfill_sla_link_filters_on_docfield.py
+++ b/erpnext/patches/v15_0/backfill_sla_link_filters_on_docfield.py
@@ -9,10 +9,12 @@ def execute():
 			"fieldname": "service_level_agreement",
 			"fieldtype": "Link",
 			"options": "Service Level Agreement",
-			"link_filters": ("is", "not set"),
 		},
-		fields=["name", "parent"],
+		fields=["name", "parent", "link_filters"],
 	):
+		if docfield.link_filters:
+			continue
+
 		link_filters = frappe.as_json(
 			[["Service Level Agreement", "document_type", "=", docfield.parent]], indent=None
 		)


### PR DESCRIPTION
`bench migrate` cannot get past these two patches on PostgreSQL. Both select rows whose `link_filters` is not set:

```python
"link_filters": ("is", "not set"),
```

The framework renders that as `("link_filters" IS NULL OR "link_filters"='')`, and `link_filters` is a JSON column, so PostgreSQL rejects the comparison:

```
psycopg2.errors.UndefinedFunction: operator does not exist: json = unknown
LINE 1: ...ent' AND ("link_filters" IS NULL OR "link_filters"='') ORDER...
HINT:  No operator matches the given name and argument types.
```

Migrate stops at `run_schema_updates`, so any PostgreSQL site that has not yet run these two patches from #56954 cannot upgrade. `--skip-failing` gets past it, but records both patches as executed, so `link_filters` is then never backfilled on that site.

Read `link_filters` alongside the other fields and skip rows that already have a value. That removes the comparison entirely, so it is correct on both engines, and the filtered set is tiny either way.

Verified on a restored PostgreSQL site: before the change migrate aborts on the first patch; after it both run and backfill the rows.