### PR TITLE
fix(ui): do not decorate self-referential links with the row's own title

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -1233,7 +1233,8 @@ frappe.form.link_formatters["Project"] = function (value, doc, df) {
  * @returns {string} - The link value with the added title.
  */
 function add_link_title(value, doc, df, title_field) {
-	if (value && doc[title_field]) {
+	const title_belongs_to_value = df.options !== df.parent || value === doc.name;
+	if (value && title_belongs_to_value && doc[title_field]) {
 		if (doc[title_field] !== value && doc[df.fieldname] === value) {
 			return value + ": " + doc[title_field];
 		} else if (doc.doctype == df.parent) {


### PR DESCRIPTION
`add_link_title()` appends `doc[title_field]` to a Link value, but that title describes `doc.name`. When the link points at the same doctype (`Employee.reports_to`, `Item.variant_of`), the row carries no title for the target, so report and list views render the manager as `HR-EMP-00010: <this row's employee name>`.

Skip the decoration for such fields unless the value is the row itself, which keeps the ID column titled.

Frappe already guards this in `frappe.form.formatters.Link` ("don't apply formatters in case of composite"), but report view builds the row object it passes from column cells alone, so `doc.doctype` is undefined there and the guard never fires.

Alternative to #59006 (same bug, reported by @iamkhanraheel) — folded into the existing condition instead of an early return. Close whichever you prefer.

`no-docs`
