### PR TITLE
test: remove seven tests that cannot fail

### DIFF
--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -1041,40 +1041,6 @@ class TestPaymentRequestV2Gateway(ERPNextTestSuite):
 		mock_payments.utils = mock_utils
 		return {"payments": mock_payments, "payments.utils": mock_utils}, mock_utils
 
-	def test_is_v2_gateway_returns_false_for_none(self):
-		"""_is_v2_gateway returns False for None input."""
-		from erpnext.accounts.doctype.payment_request.payment_request import _is_v2_gateway
-
-		# Mock returns True, but is_v2_gateway(None) in payments.utils returns False
-		modules, mock_utils = self._mock_payments_modules(False)
-
-		with patch.dict(sys.modules, modules):
-			result = _is_v2_gateway(None)
-			self.assertFalse(result)
-			mock_utils.is_v2_gateway.assert_called_once_with(None)
-
-	def test_is_v2_gateway_returns_false_for_empty_string(self):
-		"""_is_v2_gateway returns False for empty string input."""
-		from erpnext.accounts.doctype.payment_request.payment_request import _is_v2_gateway
-
-		modules, mock_utils = self._mock_payments_modules(False)
-
-		with patch.dict(sys.modules, modules):
-			result = _is_v2_gateway("")
-			self.assertFalse(result)
-			mock_utils.is_v2_gateway.assert_called_once_with("")
-
-	def test_is_v2_gateway_returns_false_for_nonexistent_gateway(self):
-		"""_is_v2_gateway returns False for nonexistent gateway."""
-		from erpnext.accounts.doctype.payment_request.payment_request import _is_v2_gateway
-
-		modules, mock_utils = self._mock_payments_modules(False)
-
-		with patch.dict(sys.modules, modules):
-			result = _is_v2_gateway("NonExistentGateway12345")
-			self.assertFalse(result)
-			mock_utils.is_v2_gateway.assert_called_once_with("NonExistentGateway12345")
-
 	def test_is_v2_gateway_delegates_to_payments_util(self):
 		"""_is_v2_gateway delegates to payments.utils.is_v2_gateway."""
 		from erpnext.accounts.doctype.payment_request.payment_request import _is_v2_gateway

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -4444,11 +4444,6 @@ class TestStockEntryCoverage(ERPNextTestSuite):
 
 	# ── validate_source_stock_entry ────────────────────────────────────────────
 
-	def test_validate_source_stock_entry_skips_when_no_source(self):
-		se = frappe.new_doc("Stock Entry")
-		se.source_stock_entry = None
-		se.validate_source_stock_entry()  # must not raise
-
 	def test_validate_source_stock_entry_throws_on_work_order_mismatch(self):
 		source_se = make_stock_entry(
 			item_code="_Test Item",
@@ -4480,11 +4475,6 @@ class TestStockEntryCoverage(ERPNextTestSuite):
 
 	# ── validate_job_card_fg_item ──────────────────────────────────────────────
 
-	def test_validate_job_card_fg_item_skips_when_no_job_card(self):
-		se = frappe.new_doc("Stock Entry")
-		se.job_card = None
-		se.validate_job_card_fg_item()  # must not raise
-
 	def test_validate_job_card_fg_item_throws_when_fg_item_mismatches(self):
 		wrong_fg = make_item("_JC Wrong FG Item", {"is_stock_item": 1}).name
 
@@ -4502,17 +4492,6 @@ class TestStockEntryCoverage(ERPNextTestSuite):
 		self.assertRaises(frappe.ValidationError, se.validate_job_card_fg_item)
 
 	# ── validate_job_card_item ─────────────────────────────────────────────────
-
-	def test_validate_job_card_item_skips_when_no_job_card(self):
-		se = frappe.new_doc("Stock Entry")
-		se.job_card = None
-		se.validate_job_card_item()  # must not raise
-
-	def test_validate_job_card_item_skips_for_manufacture_purpose(self):
-		se = frappe.new_doc("Stock Entry")
-		se.job_card = "SOME-JC-001"
-		se.purpose = "Manufacture"
-		se.validate_job_card_item()  # must not raise even with a job card set
 
 	@ERPNextTestSuite.change_settings("Manufacturing Settings", {"job_card_excess_transfer": 0})
 	def test_validate_job_card_item_throws_when_job_card_item_ref_missing(self):


### PR DESCRIPTION
Seven tests that pass when the code they are named after is deleted.

### `test_stock_entry.py` — four tests

Each covers an early-return guard in a validator. I deleted each guard and re-ran the test that claims to protect it, plus `test_material_receipt_gl_entry`, `test_material_issue_gl_entry` and `test_material_transfer_gl_entry`:

| Guard deleted from | Its own test | The three integration tests |
|---|---|---|
| `validate_source_stock_entry` | passed | passed |
| `validate_job_card_fg_item` | passed | passed |
| `validate_job_card_item` | passed (both) | **failed** |

Two of the three guards are not trivial — remove `validate_job_card_item`'s and ordinary material issues stop submitting. But the tests named after it do not notice: they build a Stock Entry with no item rows, so the loop that throws never runs. The integration tests catch it instead.

`validate_job_card_fg_item`'s guard is unreachable from production. `validate()` only calls that method inside the `else:` of `if not self.job_card`.

### `test_payment_request.py` — three tests

They mock `payments.utils.is_v2_gateway` to return `False`, then assert the result is `False`, for three inputs (`None`, `""`, `"NonExistentGateway12345"`) that take an identical code path. The mock decides the outcome, so the assertion holds regardless of what ERPNext does. The three tests covering the real branches — delegation, a `False` delegate, and the exception fallback — are kept.

Nothing is lost: no guard here loses its only protection, because none of these tests was providing any.