### PR TITLE
feat: add close and re-open actions to blanket orders

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -813,6 +813,7 @@ def get_blanket_orders(doctype: str, txt: str, searchfield: str, start: int, pag
 			& (bo.blanket_order_type == filters.get("blanket_order_type"))
 			& (bo.company == filters.get("company"))
 			& (bo.docstatus == 1)
+			& (IfNull(bo.status, "") != "Closed")
 		)
 	)
 

--- a/erpnext/manufacturing/doctype/blanket_order/blanket_order.js
+++ b/erpnext/manufacturing/doctype/blanket_order/blanket_order.js
@@ -26,7 +26,28 @@ frappe.ui.form.on("Blanket Order", {
 	refresh: function (frm) {
 		erpnext.hide_company(frm);
 		blanket_order_pricing.update_labels(frm);
-		if (frm.doc.customer && frm.doc.docstatus === 1 && frm.doc.to_date > frappe.datetime.get_today()) {
+		if (frm.doc.docstatus !== 1) {
+			return;
+		}
+
+		const is_closed = frm.doc.status === "Closed";
+		if (frm.has_perm("write")) {
+			frm.add_custom_button(
+				is_closed ? __("Re-open") : __("Close"),
+				() => {
+					frm.call("update_status", { status: is_closed ? "Open" : "Closed" }).then(() => {
+						frm.reload_doc();
+					});
+				},
+				__("Status")
+			);
+		}
+
+		if (is_closed) {
+			return;
+		}
+
+		if (frm.doc.customer && frm.doc.to_date > frappe.datetime.get_today()) {
 			frm.add_custom_button(
 				__("Sales Order"),
 				function () {
@@ -56,7 +77,7 @@ frappe.ui.form.on("Blanket Order", {
 			);
 		}
 
-		if (frm.doc.supplier && frm.doc.docstatus === 1) {
+		if (frm.doc.supplier) {
 			frm.add_custom_button(
 				__("Purchase Order"),
 				function () {

--- a/erpnext/manufacturing/doctype/blanket_order/blanket_order.json
+++ b/erpnext/manufacturing/doctype/blanket_order/blanket_order.json
@@ -18,6 +18,7 @@
   "from_date",
   "to_date",
   "company",
+  "status",
   "currency_and_price_list",
   "currency",
   "conversion_rate",
@@ -34,6 +35,17 @@
   "terms"
  ],
  "fields": [
+  {
+   "allow_on_submit": 1,
+   "default": "Open",
+   "depends_on": "eval:doc.docstatus === 1",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "no_copy": 1,
+   "options": "Open\nClosed",
+   "read_only": 1
+  },
   {
    "fieldname": "naming_series",
    "fieldtype": "Select",
@@ -215,7 +227,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-27 10:55:37.000000",
+ "modified": "2026-09-12 18:00:00.000000",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Blanket Order",
@@ -266,6 +278,11 @@
  "search_fields": "blanket_order_type, to_date",
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": [],
+ "states": [
+  {
+   "color": "Green",
+   "title": "Closed"
+  }
+ ],
  "track_changes": 1
 }

--- a/erpnext/manufacturing/doctype/blanket_order/blanket_order.py
+++ b/erpnext/manufacturing/doctype/blanket_order/blanket_order.py
@@ -42,6 +42,7 @@ class BlanketOrder(Document):
 		plc_conversion_rate: DF.Float
 		price_list_currency: DF.Link | None
 		selling_price_list: DF.Link | None
+		status: DF.Literal["Open", "Closed"]
 		supplier: DF.Link | None
 		supplier_name: DF.Data | None
 		tc_name: DF.Link | None
@@ -55,11 +56,33 @@ class BlanketOrder(Document):
 		blanket_order_pricing.set_price_list(self)
 
 	def validate(self):
+		if self.docstatus == 0 or self.is_new():
+			self.status = "Open"
 		self.validate_dates()
 		self.validate_duplicate_items()
 		self.validate_item_qty()
 		self.set_party_item_code()
 		self.set_base_rates()
+
+	@frappe.whitelist(methods=["POST"])
+	def update_status(self, status: str):
+		if self.is_new():
+			frappe.throw(_("Only submitted Blanket Orders can be closed or re-opened."))
+		if status not in ("Open", "Closed"):
+			frappe.throw(_("Status must be Open or Closed."))
+
+		# Ordered quantities can change without updating the parent's modified timestamp.
+		self.flags.for_update = True
+		self.reload()
+		self.check_permission("write")
+		if self.docstatus != 1:
+			frappe.throw(_("Only submitted Blanket Orders can be closed or re-opened."))
+
+		self.db_set("status", status, notify=True)
+
+	def validate_open(self):
+		if self.status == "Closed":
+			frappe.throw(_("Blanket Order {0} is closed.").format(frappe.bold(self.name)))
 
 	def set_currency(self):
 		if self.currency:
@@ -189,6 +212,7 @@ def make_order(source_name: str):
 	doctype = frappe.flags.args.doctype
 
 	def update_doc(source_doc, target_doc, source_parent):
+		source_doc.validate_open()
 		if doctype == "Quotation":
 			target_doc.quotation_to = "Customer"
 			target_doc.party_name = source_doc.customer
@@ -210,6 +234,7 @@ def make_order(source_name: str):
 			"Blanket Order": {
 				"doctype": doctype,
 				"field_no_map": ["naming_series"],
+				"validation": {"docstatus": ["=", 1]},
 				"postprocess": update_doc,
 			},
 			"Blanket Order Item": {
@@ -231,35 +256,42 @@ def make_order(source_name: str):
 
 
 def validate_against_blanket_order(order_doc):
-	if order_doc.doctype in ("Sales Order", "Purchase Order"):
-		order_data = {}
+	if order_doc.doctype not in ("Sales Order", "Purchase Order", "Quotation"):
+		return
 
-		for item in order_doc.get("items"):
-			if item.against_blanket_order and item.blanket_order:
-				if item.blanket_order in order_data:
-					if item.item_code in order_data[item.blanket_order]:
-						order_data[item.blanket_order][item.item_code] += item.qty
-					else:
-						order_data[item.blanket_order][item.item_code] = item.qty
-				else:
-					order_data[item.blanket_order] = {item.item_code: item.qty}
+	order_data = {}
+	for item in order_doc.get("items"):
+		if item.get("blanket_order"):
+			item_data = order_data.setdefault(item.blanket_order, {})
+			if item.against_blanket_order:
+				item_data[item.item_code] = item_data.get(item.item_code, 0) + item.qty
 
-		if order_data:
-			allowance = flt(
-				frappe.db.get_single_value(
-					"Selling Settings" if order_doc.doctype == "Sales Order" else "Buying Settings",
-					"blanket_order_allowance",
-				)
+	if not order_data:
+		return
+
+	allowance = 0
+	if order_doc.doctype != "Quotation":
+		allowance = flt(
+			frappe.db.get_single_value(
+				"Selling Settings" if order_doc.doctype == "Sales Order" else "Buying Settings",
+				"blanket_order_allowance",
 			)
-			for bo_name, item_data in order_data.items():
-				bo_doc = frappe.get_doc("Blanket Order", bo_name)
-				for item in bo_doc.get("items"):
-					if item.item_code in item_data:
-						remaining_qty = item.qty - item.ordered_qty
-						allowed_qty = remaining_qty + (remaining_qty * (allowance / 100))
-						if item.qty and allowed_qty < item_data[item.item_code]:
-							frappe.throw(
-								_(
-									"Item {0} cannot be ordered more than {1} against Blanket Order {2}."
-								).format(item.item_code, allowed_qty, bo_name)
-							)
+		)
+
+	for bo_name in sorted(order_data):
+		bo_doc = frappe.get_doc("Blanket Order", bo_name, for_update=True)
+		bo_doc.validate_open()
+		if order_doc.doctype == "Quotation":
+			continue
+
+		item_data = order_data[bo_name]
+		for item in bo_doc.get("items"):
+			if item.item_code in item_data:
+				remaining_qty = item.qty - item.ordered_qty
+				allowed_qty = remaining_qty + (remaining_qty * (allowance / 100))
+				if item.qty and allowed_qty < item_data[item.item_code]:
+					frappe.throw(
+						_("Item {0} cannot be ordered more than {1} against Blanket Order {2}.").format(
+							item.item_code, allowed_qty, bo_name
+						)
+					)

--- a/erpnext/manufacturing/doctype/blanket_order/test_blanket_order.py
+++ b/erpnext/manufacturing/doctype/blanket_order/test_blanket_order.py
@@ -19,6 +19,81 @@ class TestBlanketOrder(ERPNextTestSuite):
 	def setUp(self):
 		frappe.flags.args = frappe._dict()
 
+	def test_blanket_order_status(self):
+		bo, price_list = make_priced_blanket_order()
+		bo.insert().submit()
+		price_list = frappe.get_doc("Price List", price_list)
+		price_list.db_set("enabled", 0)
+		self.assertEqual(bo.status, "Open")
+		for status in ("Closed", "Open", "Closed"):
+			with self.set_user("Guest"), self.assertRaises(frappe.PermissionError):
+				bo.update_status(status)
+			bo.update_status(status)
+			self.assertEqual(bo.reload().status, status)
+
+		bo.db_set("selling_price_list", "_Test Missing Price List")
+		for status in ("Open", "Closed"):
+			bo.update_status(status)
+			self.assertEqual(bo.reload().status, status)
+		bo.db_set("selling_price_list", price_list.name)
+		price_list.db_set("enabled", 1)
+		bo.to_date = add_months(bo.to_date, 1)
+		bo.save()
+		self.assertEqual(bo.reload().status, "Closed")
+		with self.assertRaises(frappe.ValidationError):
+			bo.update_status("Invalid")
+
+		draft = frappe.copy_doc(bo)
+		draft.docstatus = 0
+		with self.assertRaises(frappe.ValidationError):
+			draft.update_status("Closed")
+		draft.insert()
+		self.assertEqual(draft.status, "Open")
+		with self.assertRaises(frappe.ValidationError):
+			draft.update_status("Closed")
+		bo.cancel()
+		with self.assertRaises(frappe.ValidationError):
+			bo.update_status("Open")
+		self.assertEqual(bo.reload().docstatus, 2)
+		amended = frappe.copy_doc(bo)
+		amended.docstatus = 0
+		amended.amended_from = bo.name
+		amended.insert().submit()
+		self.assertEqual(amended.status, "Open")
+
+	def test_closed_blanket_order_transactions(self):
+		for doctype in ("Sales Order", "Purchase Order", "Quotation"):
+			with self.subTest(doctype=doctype):
+				bo = make_blanket_order(
+					blanket_order_type="Purchasing" if doctype == "Purchase Order" else "Selling"
+				)
+				frappe.flags.args.doctype = doctype
+				order = make_order(bo.name)
+				self.assertEqual(order.status, "Draft")
+				order.items[0].qty = 10
+				if doctype != "Quotation":
+					order.set("delivery_date" if doctype == "Sales Order" else "schedule_date", today())
+				order.insert()
+				bo.update_status("Closed")
+
+				with self.assertRaisesRegex(frappe.ValidationError, "is closed"):
+					make_order(bo.name)
+				with self.assertRaisesRegex(frappe.ValidationError, "is closed"):
+					order.submit()
+				order.reload()
+				order.items[0].against_blanket_order = 0
+				with self.assertRaisesRegex(frappe.ValidationError, "is closed"):
+					order.save()
+
+				bo.update_status("Open")
+				order.reload().submit()
+				# Closing from a stale form must preserve quantities updated by the submitted order.
+				bo.update_status("Closed")
+				self.assertEqual(bo.items[0].ordered_qty, 0 if doctype == "Quotation" else 10)
+				order.cancel()
+				self.assertEqual(bo.reload().status, "Closed")
+				self.assertEqual(bo.items[0].ordered_qty, 0)
+
 	def test_sales_order_creation(self):
 		bo = make_blanket_order(blanket_order_type="Selling")
 
@@ -383,6 +458,7 @@ class TestBlanketOrder(ERPNextTestSuite):
 		transaction_currency = "USD" if company_currency != "USD" else "EUR"
 		blanket_order = make_blanket_order(
 			blanket_order_type="Selling",
+			item_code=make_item().name,
 			currency=transaction_currency,
 			conversion_rate=80,
 		)
@@ -412,6 +488,23 @@ class TestBlanketOrder(ERPNextTestSuite):
 			}
 		)
 		self.assertFalse(details)
+
+		filters["currency"] = transaction_currency
+		context = {
+			"company": blanket_order.company,
+			"currency": transaction_currency,
+			"customer": blanket_order.customer,
+			"doctype": "Sales Order",
+			"item_code": blanket_order.items[0].item_code,
+			"transaction_date": today(),
+		}
+		for status in (None, "", "Closed", "Open"):
+			blanket_order.db_set("status", status)
+			matches = get_blanket_orders("Blanket Order", "", "name", 0, 20, filters)
+			self.assertEqual(blanket_order.name in [row[0] for row in matches], status != "Closed")
+			for name in (None, blanket_order.name):
+				context["blanket_order"] = name
+				self.assertEqual(bool(get_blanket_order_details(context)), status != "Closed")
 
 
 def make_blanket_order(**args):

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -9,6 +9,7 @@ from frappe.utils import getdate, nowdate
 from pypika.terms import ExistsCriterion
 
 from erpnext.controllers.selling_controller import SellingController
+from erpnext.manufacturing.doctype.blanket_order.blanket_order import validate_against_blanket_order
 
 from .mapper import (
 	get_ordered_items,
@@ -146,6 +147,7 @@ class Quotation(SellingController):
 		self.validate_uom_is_integer("stock_uom", "stock_qty")
 		self.validate_uom_is_integer("uom", "qty")
 		self.validate_valid_till()
+		validate_against_blanket_order(self)
 		self.set_customer_name()
 		if self.items:
 			self.with_items = 1

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1886,6 +1886,7 @@ def get_blanket_order_details(ctx: ItemDetailsCtx):
 				(bo.company == ctx.company)
 				& (bo_item.item_code == ctx.item_code)
 				& (bo.docstatus == 1)
+				& (IfNull(bo.status, "") != "Closed")
 				& (bo.name == bo_item.parent)
 			)
 		)


### PR DESCRIPTION
### Issue

Fixes #57332

Blanket Orders cannot be manually closed, so users can continue creating transactions against agreements they no longer want to use.


### Actual behaviour

There is no Close action. The Create buttons and Blanket Order lookups remain available.

### Expected behaviour

Submitted Blanket Orders have Status → Close and Re-open actions for users with write permission. Closing hides Create and blocks mapping, saving or submitting linked drafts, and selection through lookups. Reopening restores availability. Existing ordered quantities and order cancellation continue to work.

### After

[Screencast from 2026-09-12 22-55-41.webm](https://github.com/user-attachments/assets/a373f1bb-f7de-4e71-b859-bbf5b0e9abf9)

No-docs
